### PR TITLE
Fix deploy bug

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -24,4 +24,5 @@ jobs:
       - name: Deploy to NPM
         run: npm publish
         env:
+          NODE_OPTIONS: '--max_old_space_size=4096'
           NODE_AUTH_TOKEN: ${{ secrets.NPM_AUTH_TOKEN }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Changed
 - Added GitHub Actions workflow to replace the Travis CI workflow.
 - Fix `test.sh` branch variable again.
+- Fix deploy step.
 
 ## [1.1.1](https://www.npmjs.com/package/vitessce/v/1.1.1) - 2020-12-27
 


### PR DESCRIPTION
Forgot that this environment variable needs to be set for each step that runs `build` and the `prepublish` step includes the build