### PR TITLE
Deploy workflow should succeed despite no change to package version

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -8,6 +8,8 @@ on:
 jobs:
   deploy:
     runs-on: ubuntu-18.04
+    env:
+      NODE_OPTIONS: '--max_old_space_size=4096'
     steps:
       - uses: actions/checkout@v2
       - name: Setup Node 14
@@ -19,10 +21,8 @@ jobs:
         run: npm ci
       - name: Run tests
         run: ./test.sh
-        env:
-          NODE_OPTIONS: '--max_old_space_size=4096'
       - name: Deploy to NPM
+        continue-on-error: true
         run: npm publish
         env:
-          NODE_OPTIONS: '--max_old_space_size=4096'
           NODE_AUTH_TOKEN: ${{ secrets.NPM_AUTH_TOKEN }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@
 - Upgrade Viv to 0.8.0 and deck.gl to 8.4.0-alpha.2
 - Added GitHub Actions workflow to replace the Travis CI workflow.
 - Fix `test.sh` branch variable again.
-- Fix deploy step.
+- Fix deploy step again.
 
 ## [1.1.1](https://www.npmjs.com/package/vitessce/v/1.1.1) - 2020-12-27
 


### PR DESCRIPTION
The deployment workflow failed because NPM (correctly) rejected a new package with the same version as an existing published package. We can add the `continue-on-error` tag to the NPM publish step so that this workflow succeeds regardless.

Also, I learned last night while reading the actions documentation that `env` can be specified at the _job_ level as well as the _step_ level. Here I just used that to remove the small code duplication