### PR TITLE
Use camelCase rather than snake_case in schema

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@
 - Added GitHub Actions workflow to replace the Travis CI workflow.
 - Fix `test.sh` branch variable again.
 - Fix deploy step again.
+- Changed to using camelCase in the cell-sets-tabular schema.
+- Fixed CSV and JSON file import / export bugs in the cell set manager component.
 
 ## [1.1.1](https://www.npmjs.com/package/vitessce/v/1.1.1) - 2020-12-27
 

--- a/src/components/sets/CellSetsManagerSubscriber.js
+++ b/src/components/sets/CellSetsManagerSubscriber.js
@@ -607,7 +607,7 @@ export default function CellSetsManagerSubscriber(props) {
   function onExportLevelZeroNodeJSON(nodePath) {
     const {
       treeToExport, nodeName,
-    } = treeExportLevelZeroNode(mergedCellSets, nodePath, SETS_DATATYPE_CELL);
+    } = treeExportLevelZeroNode(mergedCellSets, nodePath, SETS_DATATYPE_CELL, cellSetColor);
     downloadForUser(
       handleExportJSON(treeToExport),
       `${nodeName}_${packageJson.name}-${SETS_DATATYPE_CELL}-hierarchy.${FILE_EXTENSION_JSON}`,
@@ -618,7 +618,7 @@ export default function CellSetsManagerSubscriber(props) {
   function onExportLevelZeroNodeTabular(nodePath) {
     const {
       treeToExport, nodeName,
-    } = treeExportLevelZeroNode(mergedCellSets, nodePath, SETS_DATATYPE_CELL);
+    } = treeExportLevelZeroNode(mergedCellSets, nodePath, SETS_DATATYPE_CELL, cellSetColor);
     downloadForUser(
       handleExportTabular(treeToExport),
       `${nodeName}_${packageJson.name}-${SETS_DATATYPE_CELL}-hierarchy.${FILE_EXTENSION_TABULAR}`,

--- a/src/components/sets/io.test.js
+++ b/src/components/sets/io.test.js
@@ -70,20 +70,20 @@ const treeV013WithPredictionScoresAsJson = JSON.stringify(treeV013WithPrediction
 const expectedExportedJson = `data:application/json;charset=utf-8,${encodeURIComponent(treeV013AsJson)}`;
 const expectedExportedJsonWithPredictionScores = `data:application/json;charset=utf-8,${encodeURIComponent(treeV013WithPredictionScoresAsJson)}`;
 
-const treeV012AsCsv = `"group_name","set_name","set_color","cell_id"
+const treeV012AsCsv = `"groupName","setName","setColor","obsId"
 "Clustering Algorithm","Cluster A","#ff0000","cell_243"
 "Clustering Algorithm","Cluster A","#ff0000","cell_271"
 "Clustering Algorithm","Cluster A","#ff0000","cell_247"
 "Clustering Algorithm","Cluster A","#ff0000","cell_248"`;
 
-const treeV013AsCsv = `"group_name","set_name","set_color","cell_id","prediction_score"
+const treeV013AsCsv = `"groupName","setName","setColor","obsId","predictionScore"
 "Clustering Algorithm","Cluster A","#ff0000","cell_243","NA"
 "Clustering Algorithm","Cluster A","#ff0000","cell_271","NA"
 "Clustering Algorithm","Cluster A","#ff0000","cell_247","NA"
 "Clustering Algorithm","Cluster A","#ff0000","cell_248","NA"`;
 const expectedExportedTabular = `data:text/csv;charset=utf-8,${encodeURIComponent(treeV013AsCsv)}`;
 
-const treeV013WithPredictionScoresAsCsv = `"group_name","set_name","set_color","cell_id","prediction_score"
+const treeV013WithPredictionScoresAsCsv = `"groupName","setName","setColor","obsId","predictionScore"
 "Clustering Algorithm","Cluster A","#ff0000","cell_243",0.5
 "Clustering Algorithm","Cluster A","#ff0000","cell_271",0.6
 "Clustering Algorithm","Cluster A","#ff0000","cell_247",0.12345

--- a/src/loaders/anndata-loaders/CellSetsZarrLoader.js
+++ b/src/loaders/anndata-loaders/CellSetsZarrLoader.js
@@ -15,14 +15,14 @@ export default class CellSetsZarrLoader extends BaseAnnDataLoader {
   load() {
     const { options } = this;
     // eslint-disable-next-line camelcase
-    const cellSetZarrLocation = options.map(({ set_name }) => set_name);
+    const cellSetZarrLocation = options.map(({ setName }) => setName);
     return Promise
       .all([this.loadCellNames(), this.loadCellSetIds(cellSetZarrLocation)])
       .then((data) => {
         const [cellNames, cellSets] = data;
         const cellSetsTree = treeInitialize(SETS_DATATYPE_CELL);
         cellSets.forEach((cellSetIds, j) => {
-          const name = options[j].group_name;
+          const name = options[j].groupName;
           let levelZeroNode = {
             name,
             children: [],

--- a/src/schemas/cell-sets-tabular.schema.json
+++ b/src/schemas/cell-sets-tabular.schema.json
@@ -14,13 +14,13 @@
     "items": {
         "type": "object",
         "additionalProperties": false,
-        "required": ["group_name", "set_name", "cell_id"],
+        "required": ["groupName", "setName", "obsId"],
         "properties": {
-            "group_name": { "type": "string" },
-            "set_name": { "type": "string" },
-            "set_color": { "$ref": "#/definitions/colorArray" },
-            "cell_id": { "type": "string" },
-            "prediction_score": {
+            "groupName": { "type": "string" },
+            "setName": { "type": "string" },
+            "setColor": { "$ref": "#/definitions/colorArray" },
+            "obsId": { "type": "string" },
+            "predictionScore": {
                 "oneOf": [
                     {
                         "type": "number",

--- a/src/schemas/config.schema.json
+++ b/src/schemas/config.schema.json
@@ -79,13 +79,13 @@
       "items": {
         "type": "object",
         "additionalProperties": false,
-        "required": ["group_name", "set_name"],
+        "required": ["groupName", "setName"],
         "properties": {
-          "group_name": {
+          "groupName": {
             "type": "string",
             "description": "The display name for the set, like 'Cell Type' or 'Louvain.'"
           },
-          "set_name": {
+          "setName": {
             "type": "string",
             "description": "The location in the AnnData store for the set, like 'obs/louvain' or 'obs/celltype.'"
           }

--- a/src/schemas/fixtures/cell-sets-tabular.good.json
+++ b/src/schemas/fixtures/cell-sets-tabular.good.json
@@ -1,26 +1,26 @@
 [
     {
-        "group_name": "Clustering Algorithm",
-        "set_name": "Cluster A",
-        "set_color": [255, 0, 0],
-        "cell_id": "cell_243"
+        "groupName": "Clustering Algorithm",
+        "setName": "Cluster A",
+        "setColor": [255, 0, 0],
+        "obsId": "cell_243"
     },
     {
-        "group_name": "Clustering Algorithm",
-        "set_name": "Cluster A",
-        "set_color": [255, 0, 0],
-        "cell_id": "cell_271"
+        "groupName": "Clustering Algorithm",
+        "setName": "Cluster A",
+        "setColor": [255, 0, 0],
+        "obsId": "cell_271"
     },
     {
-        "group_name": "Clustering Algorithm",
-        "set_name": "Cluster A",
-        "set_color": [255, 0, 0],
-        "cell_id": "cell_247"
+        "groupName": "Clustering Algorithm",
+        "setName": "Cluster A",
+        "setColor": [255, 0, 0],
+        "obsId": "cell_247"
     },
     {
-        "group_name": "Clustering Algorithm",
-        "set_name": "Cluster A",
-        "set_color": [255, 0, 0],
-        "cell_id": "cell_248"
+        "groupName": "Clustering Algorithm",
+        "setName": "Cluster A",
+        "setColor": [255, 0, 0],
+        "obsId": "cell_248"
     }
 ]


### PR DESCRIPTION
It was bugging me that the cell-sets-tabular schema uses snake_case. I wanted to fix this now while I don't think anyone is relying on this feature yet ( / before it is documented). In this PR I changed it to use camelCase, and also updated the AnnData loader.

I also fixed some CSV/JSON file import/export bugs - there were issues due to changes to the way that set colors are handled now that we use `additionalCellSets`