### PR TITLE
Upgrade Viv to 0.8.1 and deck.gl to 8.4.0-alpha.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ### Added
 
 ### Changed
+- Upgrade Viv to 0.8.1 and deck.gl to 8.4.0-alpha.4
 
 ## [1.1.2](https://www.npmjs.com/package/vitessce/v/1.1.2) - 2020-12-31
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1478,37 +1478,59 @@
       }
     },
     "@deck.gl/aggregation-layers": {
-      "version": "8.4.0-alpha.2",
-      "resolved": "https://registry.npmjs.org/@deck.gl/aggregation-layers/-/aggregation-layers-8.4.0-alpha.2.tgz",
-      "integrity": "sha512-zcxvhi7P9PJ0RPo16zDkEyWJqeDwRiDvnDIVQxwubhBeB2AFvv5OBzaz56xDXh9bSqL6QsYbLIVxuVtWbOF0bQ==",
+      "version": "8.4.0-alpha.4",
+      "resolved": "https://registry.npmjs.org/@deck.gl/aggregation-layers/-/aggregation-layers-8.4.0-alpha.4.tgz",
+      "integrity": "sha512-wcwQZVMC1VGj/XQu61thlH4RM6DPltTwcr6+meicehBxnG5AHHxWxm/LoK3IHgYF9gm2+1iE9ggrwzDOv0hnPQ==",
       "requires": {
         "@luma.gl/shadertools": "^8.3.1",
-        "@math.gl/web-mercator": "^3.3.0",
+        "@math.gl/web-mercator": "^3.3.2",
         "d3-hexbin": "^0.2.1"
+      },
+      "dependencies": {
+        "@math.gl/web-mercator": {
+          "version": "3.3.2",
+          "resolved": "https://registry.npmjs.org/@math.gl/web-mercator/-/web-mercator-3.3.2.tgz",
+          "integrity": "sha512-84NNnwP97Xwm1ynZzat1BuEU2uLyIw0gzG5uvGMrAzezny2P38+E2cUK8t9eptKa8gjk2MaC7hhcO0saFCZTHw==",
+          "requires": {
+            "@babel/runtime": "^7.0.0",
+            "gl-matrix": "^3.0.0"
+          }
+        }
       }
     },
     "@deck.gl/carto": {
-      "version": "8.4.0-alpha.2",
-      "resolved": "https://registry.npmjs.org/@deck.gl/carto/-/carto-8.4.0-alpha.2.tgz",
-      "integrity": "sha512-54ldcxI+72cnIb7RUp6I/oW2kTamKtY3HBKA+v9gNgamUmTNT9ROWipXccl6xpe42+nhbALBk8X48w84mNvWcA==",
+      "version": "8.4.0-alpha.4",
+      "resolved": "https://registry.npmjs.org/@deck.gl/carto/-/carto-8.4.0-alpha.4.tgz",
+      "integrity": "sha512-rK4tw1fLV4K292KNArx9AkDfagzr0+L0VJSCnylFru/3MPS7vJCSBSrd/0t/EaQOTku8gmG9tJROIoyp9P0GNQ==",
       "requires": {
         "@loaders.gl/loader-utils": "^2.3.0",
         "@loaders.gl/mvt": "^2.3.0",
         "@loaders.gl/tiles": "^2.3.0",
-        "@math.gl/web-mercator": "^3.3.0"
+        "@math.gl/web-mercator": "^3.3.2"
+      },
+      "dependencies": {
+        "@math.gl/web-mercator": {
+          "version": "3.3.2",
+          "resolved": "https://registry.npmjs.org/@math.gl/web-mercator/-/web-mercator-3.3.2.tgz",
+          "integrity": "sha512-84NNnwP97Xwm1ynZzat1BuEU2uLyIw0gzG5uvGMrAzezny2P38+E2cUK8t9eptKa8gjk2MaC7hhcO0saFCZTHw==",
+          "requires": {
+            "@babel/runtime": "^7.0.0",
+            "gl-matrix": "^3.0.0"
+          }
+        }
       }
     },
     "@deck.gl/core": {
-      "version": "8.4.0-alpha.2",
-      "resolved": "https://registry.npmjs.org/@deck.gl/core/-/core-8.4.0-alpha.2.tgz",
-      "integrity": "sha512-WoIPL+Q/mWVym/AeB8EUiV/khdofo/KVB5vD0gqbuQJeiqRxG/gm26hq+jEXKpUqJ90jy4du7vXiEOdMc/jZXQ==",
+      "version": "8.4.0-alpha.4",
+      "resolved": "https://registry.npmjs.org/@deck.gl/core/-/core-8.4.0-alpha.4.tgz",
+      "integrity": "sha512-BVKP+oS2VshdRwcWL4UEKHzRxXePDS9uSw5c5z2yaQpe5fRWcDiGkiVwUUWZCe1W/igXZ6zgGJMZ5YfWv9hHdw==",
       "requires": {
         "@loaders.gl/core": "^2.3.0",
         "@loaders.gl/images": "^2.3.0",
         "@luma.gl/core": "^8.3.1",
-        "@math.gl/web-mercator": "^3.3.0",
+        "@math.gl/web-mercator": "^3.3.2",
         "gl-matrix": "^3.0.0",
-        "math.gl": "^3.3.0",
+        "math.gl": "^3.3.2",
         "mjolnir.js": "^2.3.0",
         "probe.gl": "^3.2.1"
       },
@@ -1517,6 +1539,15 @@
           "version": "3.3.2",
           "resolved": "https://registry.npmjs.org/@math.gl/core/-/core-3.3.2.tgz",
           "integrity": "sha512-W0QoVrdjiLs52ivtozrHbCitqWGNsWi4TwdfBckhOaeB5cE/R/pyOXfvLmdwGj2b1TLSg8SwgZLlmkWG776GKw==",
+          "requires": {
+            "@babel/runtime": "^7.0.0",
+            "gl-matrix": "^3.0.0"
+          }
+        },
+        "@math.gl/web-mercator": {
+          "version": "3.3.2",
+          "resolved": "https://registry.npmjs.org/@math.gl/web-mercator/-/web-mercator-3.3.2.tgz",
+          "integrity": "sha512-84NNnwP97Xwm1ynZzat1BuEU2uLyIw0gzG5uvGMrAzezny2P38+E2cUK8t9eptKa8gjk2MaC7hhcO0saFCZTHw==",
           "requires": {
             "@babel/runtime": "^7.0.0",
             "gl-matrix": "^3.0.0"
@@ -1533,9 +1564,9 @@
       }
     },
     "@deck.gl/extensions": {
-      "version": "8.4.0-alpha.2",
-      "resolved": "https://registry.npmjs.org/@deck.gl/extensions/-/extensions-8.4.0-alpha.2.tgz",
-      "integrity": "sha512-svBD3SOKE2pxpEYBaWBm9OGCX8OZpMiVjD5kWvh6qKi8ZoyEOPHOCoFb+hqFl8n4WdA0CTXinYvp3fvVYHCQ4Q==",
+      "version": "8.4.0-alpha.4",
+      "resolved": "https://registry.npmjs.org/@deck.gl/extensions/-/extensions-8.4.0-alpha.4.tgz",
+      "integrity": "sha512-JGbH6Wy3FoXkD+OkhhRfNCbf5rQsMrzKTDjykqKa0nstzCm/CHldG0oevvup3HlmXIeiIjGov488k/jitSBXVg==",
       "requires": {
         "@luma.gl/shadertools": "^8.3.1"
       }
@@ -1596,34 +1627,34 @@
       }
     },
     "@deck.gl/google-maps": {
-      "version": "8.4.0-alpha.2",
-      "resolved": "https://registry.npmjs.org/@deck.gl/google-maps/-/google-maps-8.4.0-alpha.2.tgz",
-      "integrity": "sha512-TJRFvzhguVDjoCzFXgXZzLitRqQ9SJjC77EDbIs4eLmFVxGVBNRfmzo+Ar+Qi42i0GnLQlfHDOqy5+I0zmtUlA=="
+      "version": "8.4.0-alpha.4",
+      "resolved": "https://registry.npmjs.org/@deck.gl/google-maps/-/google-maps-8.4.0-alpha.4.tgz",
+      "integrity": "sha512-oDUbwOJVlimUWfYpcSOjUf901269I5HB4UZmO/4hhGD5+Bc9d+G/lfq93Jf/kQG7iyOBUwYU1c1lChVH6tgOBQ=="
     },
     "@deck.gl/json": {
-      "version": "8.4.0-alpha.2",
-      "resolved": "https://registry.npmjs.org/@deck.gl/json/-/json-8.4.0-alpha.2.tgz",
-      "integrity": "sha512-hqvSlpUx+vw/944gbRpiYAKg+/sw4ACejY2prjlPQbZo78MFbRRRDcFj7Iy1R3wIhG6W2W83lMeIQN1ErQ5ofg==",
+      "version": "8.4.0-alpha.4",
+      "resolved": "https://registry.npmjs.org/@deck.gl/json/-/json-8.4.0-alpha.4.tgz",
+      "integrity": "sha512-RbHoFel47Ogg3JK3kSCYVeKq+wr6XmPSqvhMToEMGUHfLdHq199+fyr4g5FhBREQFEnEwJHZEvY+Q9yENKSnXg==",
       "requires": {
         "d3-dsv": "^1.0.8",
         "expression-eval": "^2.0.0"
       }
     },
     "@deck.gl/layers": {
-      "version": "8.4.0-alpha.2",
-      "resolved": "https://registry.npmjs.org/@deck.gl/layers/-/layers-8.4.0-alpha.2.tgz",
-      "integrity": "sha512-llCOxOWqVZOgDJVZbdxh8BOr9ZA6lMUsiAEhsGrh6thunFYs9HcYLqlPRvgwVDHcexWc6ewthZXbO3aI7sHOJw==",
+      "version": "8.4.0-alpha.4",
+      "resolved": "https://registry.npmjs.org/@deck.gl/layers/-/layers-8.4.0-alpha.4.tgz",
+      "integrity": "sha512-k29vMmAS5XnJbPSt7KnBhN2EZ2hFgOxeo0CQE0LD9G3NEgEdB9B9OS9jI0APZO4ePig8TkkVFBtkPWRGGxAlIA==",
       "requires": {
         "@loaders.gl/images": "^2.3.0",
         "@mapbox/tiny-sdf": "^1.1.0",
-        "@math.gl/polygon": "^3.3.0",
+        "@math.gl/polygon": "^3.3.2",
         "earcut": "^2.0.6"
       }
     },
     "@deck.gl/mapbox": {
-      "version": "8.4.0-alpha.2",
-      "resolved": "https://registry.npmjs.org/@deck.gl/mapbox/-/mapbox-8.4.0-alpha.2.tgz",
-      "integrity": "sha512-swEzWPrN7JPqr7xE7W8VoRGhQP57Nz4pxMS+7gbkiiTH+FsaZXP9G6pRE3maav12wYsZ5eqglX4nWzTOucddog=="
+      "version": "8.4.0-alpha.4",
+      "resolved": "https://registry.npmjs.org/@deck.gl/mapbox/-/mapbox-8.4.0-alpha.4.tgz",
+      "integrity": "sha512-K00RIkHV+S3USjc9JkoJbrJYd9PalPWlyPjYUo0B6/GrOyO2Dlz4mJ+rpYxM0qogqPhj3VuKzRGvLORsaAT42A=="
     },
     "@deck.gl/mesh-layers": {
       "version": "8.4.0-alpha.4",
@@ -1687,15 +1718,15 @@
       }
     },
     "@hms-dbmi/viv": {
-      "version": "0.8.0",
-      "resolved": "https://registry.npmjs.org/@hms-dbmi/viv/-/viv-0.8.0.tgz",
-      "integrity": "sha512-FEHEtnqJa9enWKrDoKa7OCG+7xzukU6z/aFn4fSybupUgPMlgNeavqOQdMJFgyHG6MXcyxB8ECB4MHlMdCrHBQ==",
+      "version": "0.8.1",
+      "resolved": "https://registry.npmjs.org/@hms-dbmi/viv/-/viv-0.8.1.tgz",
+      "integrity": "sha512-WmrWHtqYllD/kxzqp5IIV01EfdSfaEYo7wz5KqkgKZCQWM4LamEiMB+lQ89PvSX1t+xIp+T77jNnfk0W2hGU/A==",
       "requires": {
-        "@deck.gl/core": "^8.4.0-alpha.2",
-        "@deck.gl/geo-layers": "^8.4.0-alpha.2",
-        "@deck.gl/layers": "^8.4.0-alpha.2",
-        "@deck.gl/mesh-layers": "^8.4.0-alpha.2",
-        "@deck.gl/react": "^8.4.0-alpha.2",
+        "@deck.gl/core": "^8.4.0-alpha.3",
+        "@deck.gl/geo-layers": "^8.4.0-alpha.3",
+        "@deck.gl/layers": "^8.4.0-alpha.3",
+        "@deck.gl/mesh-layers": "^8.4.0-alpha.3",
+        "@deck.gl/react": "^8.4.0-alpha.3",
         "@luma.gl/constants": "^8.3.1",
         "@luma.gl/core": "^8.3.1",
         "@luma.gl/shadertools": "^8.3.1",
@@ -1706,10 +1737,45 @@
         "zarr": "^0.3.0"
       },
       "dependencies": {
+        "@deck.gl/core": {
+          "version": "8.4.0-alpha.4",
+          "resolved": "https://registry.npmjs.org/@deck.gl/core/-/core-8.4.0-alpha.4.tgz",
+          "integrity": "sha512-BVKP+oS2VshdRwcWL4UEKHzRxXePDS9uSw5c5z2yaQpe5fRWcDiGkiVwUUWZCe1W/igXZ6zgGJMZ5YfWv9hHdw==",
+          "requires": {
+            "@loaders.gl/core": "^2.3.0",
+            "@loaders.gl/images": "^2.3.0",
+            "@luma.gl/core": "^8.3.1",
+            "@math.gl/web-mercator": "^3.3.2",
+            "gl-matrix": "^3.0.0",
+            "math.gl": "^3.3.2",
+            "mjolnir.js": "^2.3.0",
+            "probe.gl": "^3.2.1"
+          }
+        },
+        "@deck.gl/layers": {
+          "version": "8.4.0-alpha.4",
+          "resolved": "https://registry.npmjs.org/@deck.gl/layers/-/layers-8.4.0-alpha.4.tgz",
+          "integrity": "sha512-k29vMmAS5XnJbPSt7KnBhN2EZ2hFgOxeo0CQE0LD9G3NEgEdB9B9OS9jI0APZO4ePig8TkkVFBtkPWRGGxAlIA==",
+          "requires": {
+            "@loaders.gl/images": "^2.3.0",
+            "@mapbox/tiny-sdf": "^1.1.0",
+            "@math.gl/polygon": "^3.3.2",
+            "earcut": "^2.0.6"
+          }
+        },
         "@math.gl/core": {
           "version": "3.3.2",
           "resolved": "https://registry.npmjs.org/@math.gl/core/-/core-3.3.2.tgz",
           "integrity": "sha512-W0QoVrdjiLs52ivtozrHbCitqWGNsWi4TwdfBckhOaeB5cE/R/pyOXfvLmdwGj2b1TLSg8SwgZLlmkWG776GKw==",
+          "requires": {
+            "@babel/runtime": "^7.0.0",
+            "gl-matrix": "^3.0.0"
+          }
+        },
+        "@math.gl/web-mercator": {
+          "version": "3.3.2",
+          "resolved": "https://registry.npmjs.org/@math.gl/web-mercator/-/web-mercator-3.3.2.tgz",
+          "integrity": "sha512-84NNnwP97Xwm1ynZzat1BuEU2uLyIw0gzG5uvGMrAzezny2P38+E2cUK8t9eptKa8gjk2MaC7hhcO0saFCZTHw==",
           "requires": {
             "@babel/runtime": "^7.0.0",
             "gl-matrix": "^3.0.0"
@@ -8359,74 +8425,21 @@
       "integrity": "sha1-9lNNFRSCabIDUue+4m9QH5oZEpA="
     },
     "deck.gl": {
-      "version": "8.4.0-alpha.2",
-      "resolved": "https://registry.npmjs.org/deck.gl/-/deck.gl-8.4.0-alpha.2.tgz",
-      "integrity": "sha512-k0sw3Tul0HbBMLTm2Pv5u+2NIHGs9RB7Gu9kKtX50V68IpvmeMmdnPX1uinhmrUwIhw6iFyPYvjAKMS5Jbld4A==",
+      "version": "8.4.0-alpha.4",
+      "resolved": "https://registry.npmjs.org/deck.gl/-/deck.gl-8.4.0-alpha.4.tgz",
+      "integrity": "sha512-v5niQIOT1+9aNJWCzPB2FKL+4pa2VB4lx9BG37jJsBTS1bM3HuqMIB+dQ0V+5LopXy3vYqcrnwwxRZU3M1PtAA==",
       "requires": {
-        "@deck.gl/aggregation-layers": "8.4.0-alpha.2",
-        "@deck.gl/carto": "8.4.0-alpha.2",
-        "@deck.gl/core": "8.4.0-alpha.2",
-        "@deck.gl/extensions": "8.4.0-alpha.2",
-        "@deck.gl/geo-layers": "8.4.0-alpha.2",
-        "@deck.gl/google-maps": "8.4.0-alpha.2",
-        "@deck.gl/json": "8.4.0-alpha.2",
-        "@deck.gl/layers": "8.4.0-alpha.2",
-        "@deck.gl/mapbox": "8.4.0-alpha.2",
-        "@deck.gl/mesh-layers": "8.4.0-alpha.2",
-        "@deck.gl/react": "8.4.0-alpha.2"
-      },
-      "dependencies": {
-        "@deck.gl/geo-layers": {
-          "version": "8.4.0-alpha.2",
-          "resolved": "https://registry.npmjs.org/@deck.gl/geo-layers/-/geo-layers-8.4.0-alpha.2.tgz",
-          "integrity": "sha512-qNvcQ8s6fmJmp65gYiqu/TcMDMw2ZZVIXxbEFlMapuk86J2LA09XB7yBy192ryj1oXxKkgsrf8NtA2i1C0Z/JA==",
-          "requires": {
-            "@loaders.gl/3d-tiles": "^2.3.0",
-            "@loaders.gl/loader-utils": "^2.3.0",
-            "@loaders.gl/mvt": "^2.3.0",
-            "@loaders.gl/terrain": "^2.3.0",
-            "@loaders.gl/tiles": "^2.3.0",
-            "@math.gl/culling": "^3.3.0",
-            "@math.gl/web-mercator": "^3.3.0",
-            "h3-js": "^3.6.0",
-            "long": "^3.2.0",
-            "math.gl": "^3.3.0"
-          }
-        },
-        "@deck.gl/mesh-layers": {
-          "version": "8.4.0-alpha.2",
-          "resolved": "https://registry.npmjs.org/@deck.gl/mesh-layers/-/mesh-layers-8.4.0-alpha.2.tgz",
-          "integrity": "sha512-8dNJfAOxTwZxgATmv/8g5ETkm/Mx2BnbYXiINmYr8znQeQYgW/meg7ab2hFD6smzXa8mLXBfCW9DHnDrxd+oRw==",
-          "requires": {
-            "@luma.gl/experimental": "^8.3.1",
-            "@luma.gl/shadertools": "^8.3.1"
-          }
-        },
-        "@deck.gl/react": {
-          "version": "8.4.0-alpha.2",
-          "resolved": "https://registry.npmjs.org/@deck.gl/react/-/react-8.4.0-alpha.2.tgz",
-          "integrity": "sha512-NGhuC8BArdWuZOcMRMB5zw9mQtMoO7DDYKqPqfvgtERZFFX7sXzWZ+5g35UJaAMUiooEuqI1SPDKnVCX41+nlA==",
-          "requires": {
-            "prop-types": "^15.6.0"
-          }
-        },
-        "@math.gl/core": {
-          "version": "3.3.2",
-          "resolved": "https://registry.npmjs.org/@math.gl/core/-/core-3.3.2.tgz",
-          "integrity": "sha512-W0QoVrdjiLs52ivtozrHbCitqWGNsWi4TwdfBckhOaeB5cE/R/pyOXfvLmdwGj2b1TLSg8SwgZLlmkWG776GKw==",
-          "requires": {
-            "@babel/runtime": "^7.0.0",
-            "gl-matrix": "^3.0.0"
-          }
-        },
-        "math.gl": {
-          "version": "3.3.2",
-          "resolved": "https://registry.npmjs.org/math.gl/-/math.gl-3.3.2.tgz",
-          "integrity": "sha512-33CWhbeiQxl+lzpnKdKijH9mPdZRQUP9TlBILNh6xhnJdMD9D+Kle6Xhfb8dMllE1UUQcPZlQ8/Sd1qSVtNsKQ==",
-          "requires": {
-            "@math.gl/core": "3.3.2"
-          }
-        }
+        "@deck.gl/aggregation-layers": "8.4.0-alpha.4",
+        "@deck.gl/carto": "8.4.0-alpha.4",
+        "@deck.gl/core": "8.4.0-alpha.4",
+        "@deck.gl/extensions": "8.4.0-alpha.4",
+        "@deck.gl/geo-layers": "8.4.0-alpha.4",
+        "@deck.gl/google-maps": "8.4.0-alpha.4",
+        "@deck.gl/json": "8.4.0-alpha.4",
+        "@deck.gl/layers": "8.4.0-alpha.4",
+        "@deck.gl/mapbox": "8.4.0-alpha.4",
+        "@deck.gl/mesh-layers": "8.4.0-alpha.4",
+        "@deck.gl/react": "8.4.0-alpha.4"
       }
     },
     "decode-uri-component": {
@@ -11249,9 +11262,9 @@
       "integrity": "sha1-PYpcZog6FqMMqGQ+hR8Zuqd5eRc="
     },
     "fast-xml-parser": {
-      "version": "3.17.5",
-      "resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-3.17.5.tgz",
-      "integrity": "sha512-lEvThd1Xq+CCylf1n+05bUZCDZjTufaaaqpxM3JZ+4iDqtlG+d/oKgtMmg9GEMOuzBgUoalIzFOaClht9YiGJQ=="
+      "version": "3.17.6",
+      "resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-3.17.6.tgz",
+      "integrity": "sha512-40WHI/5d2MOzf1sD2bSaTXlPn1lueJLAX6j1xH5dSAr6tNeut8B9ktEL6sjAK9yVON4uNj9//axOdBJUuruCzw=="
     },
     "faye-websocket": {
       "version": "0.11.3",

--- a/package.json
+++ b/package.json
@@ -20,9 +20,9 @@
     "react-dom": "^16.8.6"
   },
   "dependencies": {
-    "@deck.gl/core": "8.4.0-alpha.2",
-    "@deck.gl/layers": "8.4.0-alpha.2",
-    "@hms-dbmi/viv": "^0.8.0",
+    "@deck.gl/core": "8.4.0-alpha.4",
+    "@deck.gl/layers": "8.4.0-alpha.4",
+    "@hms-dbmi/viv": "^0.8.1",
     "@loaders.gl/3d-tiles": "^2.3.0",
     "@loaders.gl/core": "^2.3.0",
     "@loaders.gl/images": "^2.3.0",
@@ -48,7 +48,7 @@
     "d3-force": "^2.1.1",
     "d3-quadtree": "^1.0.7",
     "d3-scale-chromatic": "^1.3.3",
-    "deck.gl": "8.4.0-alpha.2",
+    "deck.gl": "8.4.0-alpha.4",
     "dynamic-import-polyfill": "^0.1.1",
     "glslify": "^7.0.0",
     "higlass": "1.11.4",

--- a/src/layers/HeatmapBitmapLayer.js
+++ b/src/layers/HeatmapBitmapLayer.js
@@ -35,6 +35,11 @@ export default class HeatmapBitmapLayer extends BitmapLayer {
     return shaders;
   }
 
+  updateState(args) {
+    super.updateState(args);
+    this.loadTexture(this.props.image);
+  }
+
   /**
    * Need to override to provide custom shaders.
    */

--- a/src/layers/PixelatedBitmapLayer.js
+++ b/src/layers/PixelatedBitmapLayer.js
@@ -1,10 +1,11 @@
 import { BitmapLayer } from '@deck.gl/layers';
-import { Texture2D } from '@luma.gl/core';
+import { CompositeLayer } from '@deck.gl/core';
 import { PIXELATED_TEXTURE_PARAMETERS } from './heatmap-constants';
 
 
 // These are the same defaultProps as for BitmapLayer.
 const defaultProps = {
+  ...BitmapLayer.defaultProps,
   image: { type: 'object', value: null, async: true },
   bounds: { type: 'array', value: [1, 0, 0, 1], compare: true },
   desaturate: {
@@ -14,35 +15,14 @@ const defaultProps = {
   tintColor: { type: 'color', value: [255, 255, 255] },
 };
 
-/**
- * The BitmapLayer with overridden DEFAULT_TEXTURE_PARAMETERS
- */
-export default class PixelatedBitmapLayer extends BitmapLayer {
-  /**
-   * Need to override to provide the custom DEFAULT_TEXTURE_PARAMETERS
-   * object.
-   * Simplified by removing video-related code.
-   * Reference: https://github.com/visgl/deck.gl/blob/0afd4e99a6199aeec979989e0c361c97e6c17a16/modules/layers/src/bitmap-layer/bitmap-layer.js#L218
-   * @param {Uint8Array} image
-   */
-  loadTexture(image) {
-    const { gl } = this.context;
-
-    if (this.state.bitmapTexture) {
-      this.state.bitmapTexture.delete();
-    }
-
-    if (image instanceof Texture2D) {
-      this.setState({ bitmapTexture: image });
-    } else if (image) {
-      // Browser object: Image, ImageData, HTMLCanvasElement, ImageBitmap
-      this.setState({
-        bitmapTexture: new Texture2D(gl, {
-          data: image,
-          parameters: PIXELATED_TEXTURE_PARAMETERS,
-        }),
-      });
-    }
+export default class PixelatedBitmapLayer extends CompositeLayer {
+  renderLayers() {
+    const { image } = this.props;
+    return new BitmapLayer(this.props, {
+      id: `${this.props.id}-wrapped`,
+      image,
+      textureParameters: PIXELATED_TEXTURE_PARAMETERS,
+    });
   }
 }
 


### PR DESCRIPTION
Because of https://github.com/visgl/deck.gl/pull/5197 we have to change the way we interact with `BitmapLayer` - the upgrade to 0.8.1 in Viv also gives interleaved-rgb support.