### PR TITLE
View config dataset descriptions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## In Progress
 
 ### Added
+- Added an optional `description` field to the dataset definition config object. Updated the `<Description/>` component to prefer this value over the top-level description value, if available.
 
 ### Changed
 

--- a/src/api/VitessceConfig.js
+++ b/src/api/VitessceConfig.js
@@ -36,11 +36,13 @@ export class VitessceConfigDataset {
    * Construct a new dataset definition instance.
    * @param {string} uid The unique ID for the dataset.
    * @param {string} name The name of the dataset.
+   * @param {string} description A description for the dataset.
    */
-  constructor(uid, name) {
+  constructor(uid, name, description) {
     this.dataset = {
       uid,
       name,
+      description,
       files: [],
     };
   }
@@ -204,7 +206,7 @@ export class VitessceConfig {
    * @param {string} name A name for the config. Optional.
    * @param {string} description A description for the config. Optional.
    */
-  constructor(name = '', description = '') {
+  constructor(name = undefined, description = undefined) {
     this.config = {
       version: '1.0.0',
       name,
@@ -219,14 +221,16 @@ export class VitessceConfig {
   /**
    * Add a new dataset to the config.
    * @param {string} name A name for the dataset. Optional.
+   * @param {string} description A description for the dataset. Optional.
    * @param {string} uid Override the automatically-generated dataset ID. Optional.
    * Intended for internal usage by the VitessceConfig.fromJSON code.
    * @returns {VitessceConfigDataset} A new dataset instance.
    */
-  addDataset(name = '', uid = null) {
+  addDataset(name = undefined, description = undefined, options = undefined) {
+    const { uid } = options || {};
     const prevDatasetUids = this.config.datasets.map(d => d.dataset.uid);
     const nextUid = (uid || getNextScope(prevDatasetUids));
-    const newDataset = new VitessceConfigDataset(nextUid, name);
+    const newDataset = new VitessceConfigDataset(nextUid, name, description);
     this.config.datasets.push(newDataset);
     const [newScope] = this.addCoordination(COORDINATION_TYPES.DATASET);
     newScope.setValue(nextUid);
@@ -396,7 +400,7 @@ export class VitessceConfig {
     const { name, description } = config;
     const vc = new VitessceConfig(name, description);
     config.datasets.forEach((d) => {
-      const newDataset = vc.addDataset(d.name, d.uid);
+      const newDataset = vc.addDataset(d.name, d.description, { uid: d.uid });
       d.files.forEach((f) => {
         newDataset.addFile(
           f.url,

--- a/src/api/VitessceConfig.js
+++ b/src/api/VitessceConfig.js
@@ -222,7 +222,8 @@ export class VitessceConfig {
    * Add a new dataset to the config.
    * @param {string} name A name for the dataset. Optional.
    * @param {string} description A description for the dataset. Optional.
-   * @param {string} uid Override the automatically-generated dataset ID. Optional.
+   * @param {object} options Extra parameters to be used internally. Optional.
+   * @param {string} options.uid Override the automatically-generated dataset ID.
    * Intended for internal usage by the VitessceConfig.fromJSON code.
    * @returns {VitessceConfigDataset} A new dataset instance.
    */

--- a/src/api/VitessceConfig.test.js
+++ b/src/api/VitessceConfig.test.js
@@ -15,7 +15,6 @@ describe('src/api/VitessceConfig.js', () => {
       expect(configJSON).toEqual({
         coordinationSpace: {},
         datasets: [],
-        description: '',
         initStrategy: 'auto',
         layout: [],
         name: 'My config',
@@ -38,7 +37,6 @@ describe('src/api/VitessceConfig.js', () => {
           uid: 'A',
           files: [],
         }],
-        description: '',
         initStrategy: 'auto',
         layout: [],
         name: 'My config',
@@ -46,8 +44,8 @@ describe('src/api/VitessceConfig.js', () => {
       });
     });
     it('can add a file to a dataset', () => {
-      const config = new VitessceConfig('My config');
-      config.addDataset('My dataset').addFile(
+      const config = new VitessceConfig('My config', 'My config description');
+      config.addDataset('My dataset', 'My dataset description').addFile(
         'http://example.com/cells.json',
         'cells',
         'cells.json',
@@ -62,6 +60,7 @@ describe('src/api/VitessceConfig.js', () => {
         },
         datasets: [{
           name: 'My dataset',
+          description: 'My dataset description',
           uid: 'A',
           files: [{
             url: 'http://example.com/cells.json',
@@ -69,7 +68,7 @@ describe('src/api/VitessceConfig.js', () => {
             fileType: 'cells.json',
           }],
         }],
-        description: '',
+        description: 'My config description',
         initStrategy: 'auto',
         layout: [],
         name: 'My config',
@@ -98,7 +97,6 @@ describe('src/api/VitessceConfig.js', () => {
           uid: 'A',
           files: [],
         }],
-        description: '',
         initStrategy: 'auto',
         layout: [
           {
@@ -171,7 +169,6 @@ describe('src/api/VitessceConfig.js', () => {
           uid: 'A',
           files: [],
         }],
-        description: '',
         initStrategy: 'auto',
         layout: [
           {
@@ -258,7 +255,6 @@ describe('src/api/VitessceConfig.js', () => {
           uid: 'A',
           files: [],
         }],
-        description: '',
         initStrategy: 'auto',
         layout: [
           {
@@ -319,7 +315,6 @@ describe('src/api/VitessceConfig.js', () => {
           uid: 'A',
           files: [],
         }],
-        description: '',
         initStrategy: 'auto',
         layout: [
           {
@@ -387,7 +382,6 @@ describe('src/api/VitessceConfig.js', () => {
           uid: 'A',
           files: [],
         }],
-        description: '',
         initStrategy: 'auto',
         layout: [
           {

--- a/src/app/VitessceGrid.js
+++ b/src/app/VitessceGrid.js
@@ -53,7 +53,7 @@ export default function VitessceGrid(props) {
   useEffect(() => {
     if (config) {
       setViewConfig(config);
-      const loaders = createLoaders(config.datasets);
+      const loaders = createLoaders(config.datasets, config.description);
       setLoaders(loaders);
     } else {
       // No config found, so clear the loaders.

--- a/src/app/api.js
+++ b/src/app/api.js
@@ -156,6 +156,7 @@ export const configs = {
       {
         uid: 'linnarsson-2018',
         name: 'Linnarsson 2018',
+        description: `Linnarsson: ${linnarssonDescription}`,
         files: linnarssonBase.layers.map(file => ({
           type: file.type.toLowerCase(),
           fileType: file.fileType,
@@ -185,9 +186,6 @@ export const configs = {
     },
     layout: [
       { component: 'description',
-        props: {
-          description: `Linnarsson: ${linnarssonDescription}`,
-        },
         x: 0, y: 0, w: 2, h: 1 },
       { component: 'layerController',
         x: 0, y: 1, w: 2, h: 4,
@@ -418,9 +416,6 @@ export const configs = {
     },
     layout: [
       { component: 'description',
-        props: {
-          description: driesDescription,
-        },
         x: 9, y: 0, w: 3, h: 2 },
       { component: 'status',
         x: 9, y: 2, w: 3, h: 2 },

--- a/src/app/vitessce-grid-utils.js
+++ b/src/app/vitessce-grid-utils.js
@@ -87,14 +87,17 @@ export function useRowHeight(config, initialRowHeight, height, margin, padding) 
 /**
  * Create a mapping from dataset ID to loader objects by data type.
  * @param {object[]} datasets The datasets array from the view config.
+ * @param {string} configDescription The top-level description in the
+ * view config.
  * @returns {object} Mapping from dataset ID to data type to loader
  * instance.
  */
-export function createLoaders(datasets) {
+export function createLoaders(datasets, configDescription) {
   const result = {};
   datasets.forEach((dataset) => {
     const datasetLoaders = {
       name: dataset.name,
+      description: dataset.description || configDescription,
       loaders: {},
     };
     dataset.files.forEach((file) => {

--- a/src/components/data-hooks.js
+++ b/src/components/data-hooks.js
@@ -20,6 +20,34 @@ function warn(error, setWarning) {
 }
 
 /**
+ * Get the dataset description string.
+ * @param {object} loaders The object mapping
+ * datasets and data types to loader instances.
+ * @param {string} dataset The key for a dataset,
+ * used to identify which loader to use.
+ * @returns {array} [description] where
+ * description is a string.
+ */
+export function useDescription(loaders, dataset) {
+  const [description, setDescription] = useState();
+
+  useEffect(() => {
+    if (!loaders[dataset]) {
+      return;
+    }
+
+    if (loaders[dataset].description) {
+      setDescription(loaders[dataset].description);
+    } else {
+      setDescription(null);
+    }
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [loaders, dataset]);
+
+  return [description];
+}
+
+/**
  * Get data from a cells data type loader,
  * updating "ready" and URL state appropriately.
  * Throw warnings if the data is marked as required.

--- a/src/components/description/DescriptionSubscriber.js
+++ b/src/components/description/DescriptionSubscriber.js
@@ -1,6 +1,6 @@
 import React, { useEffect, useMemo } from 'react';
 import { useReady } from '../hooks';
-import { useRasterData } from '../data-hooks';
+import { useDescription, useRasterData } from '../data-hooks';
 import { useCoordination, useLoaders } from '../../app/state/hooks';
 import { COMPONENT_COORDINATION_TYPES } from '../../app/state/coordination';
 import TitleInfo from '../TitleInfo';
@@ -11,7 +11,7 @@ const DESCRIPTION_DATA_TYPES = ['raster'];
 export default function DescriptionSubscriber(props) {
   const {
     coordinationScopes,
-    description,
+    description: descriptionOverride,
     removeGridComponent,
     theme,
   } = props;
@@ -35,6 +35,7 @@ export default function DescriptionSubscriber(props) {
   }, [loaders, dataset]);
 
   // Get data from loaders using the data hooks.
+  const [description] = useDescription(loaders, dataset);
   const [raster, imageLayerLoaders, imageLayerMeta] = useRasterData(
     loaders, dataset, setItemIsReady, () => {}, false,
   );
@@ -65,7 +66,7 @@ export default function DescriptionSubscriber(props) {
       isReady={isReady}
     >
       <Description
-        description={description}
+        description={descriptionOverride || description}
         metadata={metadata}
       />
     </TitleInfo>

--- a/src/schemas/config.schema.json
+++ b/src/schemas/config.schema.json
@@ -347,6 +347,7 @@
         "properties": {
           "uid": { "type": "string" },
           "name": { "type": "string" },
+          "description": { "type": "string" },
           "files": {
             "type": "array",
             "items": {


### PR DESCRIPTION
Fixes #813 

This adds an optional `description` property to dataset definitions in view configs. Also, I added a `useDescription` hook which the `<Description/>` component can use to get this value based on its dataset assignment from the coordination space.