### PR TITLE
Fix AnnData Text Decoding.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ### Added
 
 ### Changed
+- Fix AnnData text decoding.
 
 ## [1.1.3](https://www.npmjs.com/package/vitessce/v/1.1.3) - 2021-01-07
 

--- a/src/loaders/anndata-loaders/BaseAnnDataLoader.js
+++ b/src/loaders/anndata-loaders/BaseAnnDataLoader.js
@@ -41,7 +41,8 @@ export default class BaseAnnDataLoader extends AbstractLoader {
   decodeTextArray(buffer) {
     return (
       new TextDecoder()
-        // Not clear to me why, but the first four bytes are meaningless, random, and error-prone.
+        // Remove header: https://github.com/zarr-developers/numcodecs/blob/2c1aff98e965c3c4747d9881d8b8d4aad91adb3a/numcodecs/vlen.pyx#L34
+        // Should we validate? Seems unnecessary, but maybe?
         .decode(buffer.slice(4))
         // https://stackoverflow.com/questions/11159118/incorrect-string-value-xef-xbf-xbd-for-column
         // for information on the right hand side of the | in the regex.

--- a/src/loaders/anndata-loaders/BaseAnnDataLoader.js
+++ b/src/loaders/anndata-loaders/BaseAnnDataLoader.js
@@ -41,7 +41,8 @@ export default class BaseAnnDataLoader extends AbstractLoader {
   decodeTextArray(buffer) {
     return (
       new TextDecoder()
-        .decode(buffer)
+        // Not clear to me why, but the first four bytes are meaningless, random, and error-prone.
+        .decode(buffer.slice(4))
         // https://stackoverflow.com/questions/11159118/incorrect-string-value-xef-xbf-xbd-for-column
         // for information on the right hand side of the | in the regex.
         // eslint-disable-next-line no-control-regex
@@ -147,9 +148,7 @@ export default class BaseAnnDataLoader extends AbstractLoader {
             throw err;
           }
         }
-        const text = this.decodeTextArray(data)
-          .filter(i => !Number(i))
-          .filter(i => i.length > 2);
+        const text = this.decodeTextArray(data);
         return text;
       }));
     return this.cellNames;


### PR DESCRIPTION
I seem to have tracked down the issue with string decoding mentioned in #807.  I have noticed there is a "header" in both JSON and VLenUtf8 `numcodecs` compressors for strings.  For example, with JSON, this is the output in the file where the first four bytes (i.e the number 6) correspond to the chunk size, which is the number of string elements in this array (each one separated by `3,0,0,0`):
```
[6,0,0,0,3,0,0,0,102,111,111,3,0,0,0,98,97,114,3,0,0,0,122,97,112,4,0,0,0,106,97,122,122,3,0,0,0,102,111,111,3,0,0,0,98,97,114,"|u1",[47]]
```
from this python:
```python
import zarr
import numcodecs
compressor = numcodecs.JSON()
z = zarr.open_array('~/test_str.zarr', chunks=(6,), shape=(20,), compressor=compressor, dtype=str, fill_value='foo', mode='w')
z[:] = ['foo', 'bar', 'zap', 'jazz', 'foo', 'bar', 'zap', 'jazz', 'foo', 'bar', 'zap', 'jazz', 'foo', 'bar', 'zap', 'jazz', 'foo', 'bar', 'zap', 'jazz']
```

Here is a (truncated) real output from VLenUtf8 where the first four bytes again indicate the number of elements (in this case 700 = ((2 ** 0) * 188) + ((2 ** 8) * 2) cells from the `pbmc` reduced example [here](https://github.com/vitessce/vitessce/pull/807)):
```
[188, 2, 0, 0, 16, 0, 0, 0, 65, 65, ...]
```
Hopefully this puts this issue to rest and fixes the loom example which https://github.com/vitessce/vitessce-python/pull/39 broke when it was converted to AnnData.