### PR TITLE
Fix Flat Array Parsing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 
 ### Changed
 - Fix AnnData text decoding.
+- Refactor AnnData flat array decoding and resolve bug.
 
 ## [1.1.3](https://www.npmjs.com/package/vitessce/v/1.1.3) - 2021-01-07
 


### PR DESCRIPTION
There are a [few](https://github.com/vitessce/vitessce/blob/0abec9d46f5bed14f31325c308ad7adbfb0adf00/src/loaders/anndata-loaders/MatrixZarrLoader.js#L108-L116) different [spots](https://github.com/vitessce/vitessce/blob/0abec9d46f5bed14f31325c308ad7adbfb0adf00/src/loaders/anndata-loaders/BaseAnnDataLoader.js#L70-L82) where our AnnData loaders load a flattened array by fetching a key directly, but could be more robust to error if they kept trying to fetch the data until they couldn't find any.  Thus this PR refactors these lines of code to be reusable:

https://github.com/vitessce/vitessce/blob/0abec9d46f5bed14f31325c308ad7adbfb0adf00/src/loaders/anndata-loaders/BaseAnnDataLoader.js#L132-L154

The `getFlatArrDecompressed` method is now used wherever a flat array is needed directly from the store.

[Here](http://localhost:3000/?url=data:,{%22version%22:%20%221.0.0%22,%22name%22:%20%22Krasnow%20Lab%22,%22description%22:%20%22Human%20Lung%20Cell%20Atlas%20Smart-seq2%22,%22datasets%22:%20[{%22uid%22:%20%22A%22,%22name%22:%20%22Lung%22,%22files%22:%20[{%22type%22:%20%22cells%22,%22fileType%22:%20%22anndata-cells.zarr%22,%22url%22:%20%22https://storage.googleapis.com/vitessce-demo-data/cxg_examples/cxg-smart-seq2.zarr/%22,%22options%22:%20{%22mappings%22:%20{%22tSNE%22:%20{%22key%22:%20%22obsm/X_tSNE%22,%22dims%22:%20[0,1]}},%22factors%22:%20[%22obs/cell_type%22,%22obs/ethnicity%22]}},{%22type%22:%20%22cell-sets%22,%22fileType%22:%20%22anndata-cell-sets.zarr%22,%22url%22:%20%22https://storage.googleapis.com/vitessce-demo-data/cxg_examples/cxg-smart-seq2.zarr/%22,%22options%22:%20[{%22groupName%22:%20%22Cell%20Type%22,%22setName%22:%20%22obs/cell_type%22},{%22groupName%22:%20%22Ethnicity%22,%22setName%22:%20%22obs/ethnicity%22}]},{%22type%22:%20%22expression-matrix%22,%22fileType%22:%20%22anndata-expression-matrix.zarr%22,%22url%22:%20%22https://storage.googleapis.com/vitessce-demo-data/cxg_examples/cxg-smart-seq2.zarr/%22,%22options%22:%20{%22matrix%22:%20%22obsm/X_hvg%22,%22geneFilter%22:%20%22var/highly_variable%22}}]}],%22coordinationSpace%22:%20{%22dataset%22:%20{%22A%22:%20%22A%22},%22embeddingType%22:%20{%22A%22:%20%22tSNE%22}},%22layout%22:%20[{%22component%22:%20%22scatterplot%22,%22coordinationScopes%22:%20{%22dataset%22:%20%22A%22,%22embeddingType%22:%20%22A%22},%22x%22:%200,%22y%22:%200,%22w%22:%206,%22h%22:%206},{%22component%22:%20%22cellSets%22,%22coordinationScopes%22:%20{%22dataset%22:%20%22A%22},%22x%22:%206,%22y%22:%200,%22w%22:%206,%22h%22:%206},{%22component%22:%20%22genes%22,%22coordinationScopes%22:%20{%22dataset%22:%20%22A%22},%22x%22:%206,%22y%22:%206,%22w%22:%206,%22h%22:%206},{%22component%22:%20%22heatmap%22,%22coordinationScopes%22:%20{%22dataset%22:%20%22A%22},%22x%22:%200,%22y%22:%206,%22w%22:%206,%22h%22:%206}],%22initStrategy%22:%20%22auto%22}) is a local URL and [here](http://vitessce.io/?url=data:,{%22version%22:%20%221.0.0%22,%22name%22:%20%22Krasnow%20Lab%22,%22description%22:%20%22Human%20Lung%20Cell%20Atlas%20Smart-seq2%22,%22datasets%22:%20[{%22uid%22:%20%22A%22,%22name%22:%20%22Lung%22,%22files%22:%20[{%22type%22:%20%22cells%22,%22fileType%22:%20%22anndata-cells.zarr%22,%22url%22:%20%22https://storage.googleapis.com/vitessce-demo-data/cxg_examples/cxg-smart-seq2.zarr/%22,%22options%22:%20{%22mappings%22:%20{%22tSNE%22:%20{%22key%22:%20%22obsm/X_tSNE%22,%22dims%22:%20[0,1]}},%22factors%22:%20[%22obs/cell_type%22,%22obs/ethnicity%22]}},{%22type%22:%20%22cell-sets%22,%22fileType%22:%20%22anndata-cell-sets.zarr%22,%22url%22:%20%22https://storage.googleapis.com/vitessce-demo-data/cxg_examples/cxg-smart-seq2.zarr/%22,%22options%22:%20[{%22groupName%22:%20%22Cell%20Type%22,%22setName%22:%20%22obs/cell_type%22},{%22groupName%22:%20%22Ethnicity%22,%22setName%22:%20%22obs/ethnicity%22}]},{%22type%22:%20%22expression-matrix%22,%22fileType%22:%20%22anndata-expression-matrix.zarr%22,%22url%22:%20%22https://storage.googleapis.com/vitessce-demo-data/cxg_examples/cxg-smart-seq2.zarr/%22,%22options%22:%20{%22matrix%22:%20%22obsm/X_hvg%22,%22geneFilter%22:%20%22var/highly_variable%22}}]}],%22coordinationSpace%22:%20{%22dataset%22:%20{%22A%22:%20%22A%22},%22embeddingType%22:%20{%22A%22:%20%22tSNE%22}},%22layout%22:%20[{%22component%22:%20%22scatterplot%22,%22coordinationScopes%22:%20{%22dataset%22:%20%22A%22,%22embeddingType%22:%20%22A%22},%22x%22:%200,%22y%22:%200,%22w%22:%206,%22h%22:%206},{%22component%22:%20%22cellSets%22,%22coordinationScopes%22:%20{%22dataset%22:%20%22A%22},%22x%22:%206,%22y%22:%200,%22w%22:%206,%22h%22:%206},{%22component%22:%20%22genes%22,%22coordinationScopes%22:%20{%22dataset%22:%20%22A%22},%22x%22:%206,%22y%22:%206,%22w%22:%206,%22h%22:%206},{%22component%22:%20%22heatmap%22,%22coordinationScopes%22:%20{%22dataset%22:%20%22A%22},%22x%22:%200,%22y%22:%206,%22w%22:%206,%22h%22:%206}],%22initStrategy%22:%20%22auto%22}) is the vitessce.io to compare (only 511 genes load because we only previously fetched the 0th item in the store, whereas now we make use of the `while` loop)