### PR TITLE
Fix Categories Parsing in AnnData and Factors Display

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 ### Changed
 - Fix AnnData text decoding.
 - Refactor AnnData flat array decoding and resolve bug.
+- Fix non-string cell id parsing in AnnData.
 
 ## [1.1.3](https://www.npmjs.com/package/vitessce/v/1.1.3) - 2021-01-07
 

--- a/src/loaders/anndata-loaders/BaseAnnDataLoader.js
+++ b/src/loaders/anndata-loaders/BaseAnnDataLoader.js
@@ -70,7 +70,10 @@ export default class BaseAnnDataLoader extends AbstractLoader {
         const { categories } = await this.getJson(
           `${setName}/.zattrs`,
         );
-        const categoriesValues = await this.getFlatTextArr(`/obs/${categories}`);
+        let categoriesValues;
+        if (categories) {
+          categoriesValues = await this.getFlatTextArr(`/obs/${categories}`);
+        }
         const cellSetsArr = await openArray({
           store,
           path: setName,
@@ -79,7 +82,7 @@ export default class BaseAnnDataLoader extends AbstractLoader {
         const cellSetsValues = await cellSetsArr.get();
         const { data } = cellSetsValues;
         const mappedCellSetValues = new Array(...data).map(
-          i => categoriesValues[i],
+          i => (!categoriesValues ? i : categoriesValues[i]),
         );
         return mappedCellSetValues;
       }),

--- a/src/loaders/anndata-loaders/CellsZarrLoader.js
+++ b/src/loaders/anndata-loaders/CellsZarrLoader.js
@@ -110,7 +110,7 @@ export default class CellsZarrLoader extends BaseAnnDataLoader {
         const factorsObj = {};
         factors.forEach(
           // eslint-disable-next-line no-return-assign
-          (factor, j) => (factorsObj[this.options.factors[j].split('.').slice(-1)] = factor[i]),
+          (factor, j) => (factorsObj[this.options.factors[j].split('/').slice(-1)] = factor[i]),
         );
         cells[name].factors = factorsObj;
       }


### PR DESCRIPTION
If an AnnData store cell set ID's are not strings, there is no categorical value to be used.  Also I fixed a small bug in the factors display from when I was using dots and not slashes.  To test out here is an AnnData store and a [link](http://localhost:3000/?url=data:,{%22version%22:%20%221.0.0%22,%22name%22:%20%223ac0768d61c6c84f0ec59d766e123e05%22,%22datasets%22:%20[{%22uid%22:%20%2240334a99-2be7-4904-bc75-102609fe53e9%22,%22name%22:%20%2240334a99-2be7-4904-bc75-102609fe53e9%22,%22files%22:%20[{%22type%22:%20%22cells%22,%22fileType%22:%20%22anndata-cells.zarr%22,%22url%22:%20%22http://127.0.0.1:8081/R001_X005_Y003-anndata.zarr/%22,%22options%22:%20{%22poly%22:%20%22obsm/poly%22,%22xy%22:%20%22obsm/xy%22,%22factors%22:%20[%22obs/K-Means%20[Mean]%20Expression%22,%22obs/K-Means%20[Covariance]%20Expression%22,%22obs/K-Means%20[Total]%20Expression%22,%22obs/K-Means%20[Mean-All-SubRegions]%20Expression%22,%22obs/K-Means%20[Shape-Vectors]%22]}},{%22type%22:%20%22cell-sets%22,%22fileType%22:%20%22anndata-cell-sets.zarr%22,%22url%22:%20%22http://127.0.0.1:8081/R001_X005_Y003-anndata.zarr/%22,%22options%22:%20[{%22groupName%22:%20%22K-Means%20[Mean]%20Expression%22,%22setName%22:%20%22obs/K-Means%20[Mean]%20Expression%22},{%22groupName%22:%20%22K-Means%20[Covariance]%20Expression%22,%22setName%22:%20%22obs/K-Means%20[Covariance]%20Expression%22},{%22groupName%22:%20%22K-Means%20[Total]%20Expression%22,%22setName%22:%20%22obs/K-Means%20[Total]%20Expression%22},{%22groupName%22:%20%22K-Means%20[Mean-All-SubRegions]%20Expression%22,%22setName%22:%20%22obs/K-Means%20[Mean-All-SubRegions]%20Expression%22},{%22groupName%22:%20%22K-Means%20[Shape-Vectors]%22,%22setName%22:%20%22obs/K-Means%20[Shape-Vectors]%22}]},{%22type%22:%20%22expression-matrix%22,%22fileType%22:%20%22anndata-expression-matrix.zarr%22,%22url%22:%20%22http://127.0.0.1:8081/R001_X005_Y003-anndata.zarr/%22,%22options%22:%20{%22matrix%22:%20%22X%22}}]}],%22initStrategy%22:%20%22auto%22,%22coordinationSpace%22:%20{%22spatialZoom%22:%20{%22A%22:%20-3},%22spatialTargetX%22:%20{%22A%22:%20500},%22spatialTargetY%22:%20{%22A%22:%20500}},%22layout%22:%20[{%22component%22:%20%22cellSets%22,%22h%22:%203,%22w%22:%203,%22x%22:%209,%22y%22:%200,%22coordinationScopes%22:%20{}},{%22component%22:%20%22genes%22,%22props%22:%20{%22variablesLabelOverride%22:%20%22antigen%22},%22h%22:%203,%22w%22:%203,%22x%22:%209,%22y%22:%203,%22coordinationScopes%22:%20{}},{%22component%22:%20%22spatial%22,%22h%22:%203,%22w%22:%209,%22x%22:%200,%22y%22:%200,%22coordinationScopes%22:%20{%22spatialZoom%22:%20%22A%22,%22spatialTargetX%22:%20%22A%22,%22spatialTargetY%22:%20%22A%22}},{%22component%22:%20%22heatmap%22,%22props%22:%20{%22transpose%22:%20true,%22variablesLabelOverride%22:%20%22antigen%22},%22h%22:%203,%22w%22:%209,%22x%22:%200,%22y%22:%203,%22coordinationScopes%22:%20{}}]}) for the AnnData store being served out of `http://127.0.0.1:8081/R001_X005_Y003-anndata.zarr/`
[R001_X005_Y003-anndata.zarr.zip](https://github.com/vitessce/vitessce/files/5891469/R001_X005_Y003-anndata.zarr.zip)
