### PR TITLE
Physical Size-based Scaling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 - Refactor AnnData flat array decoding and resolve bug.
 - Upgrade viv to 0.8.3
 - Fix non-string cell id parsing in AnnData.
+- Add automatic physical size scaling for multi-modal imaging if sizes are found.
 
 ## [1.1.3](https://www.npmjs.com/package/vitessce/v/1.1.3) - 2021-01-07
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -6710,6 +6710,11 @@
       "integrity": "sha1-3dgA2gxmEnOTzKWVDqloo6rxJTs=",
       "dev": true
     },
+    "complex.js": {
+      "version": "2.0.11",
+      "resolved": "https://registry.npmjs.org/complex.js/-/complex.js-2.0.11.tgz",
+      "integrity": "sha512-6IArJLApNtdg1P1dFtn3dnyzoZBEF0MwMnrfF1exSBRpZYoy4yieMkpZhQDC0uwctw48vii0CFVyHfpgZ/DfGw=="
+    },
     "component-bind": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/component-bind/-/component-bind-1.0.0.tgz",
@@ -8509,6 +8514,11 @@
       "resolved": "https://registry.npmjs.org/decamelize/-/decamelize-1.2.0.tgz",
       "integrity": "sha1-9lNNFRSCabIDUue+4m9QH5oZEpA="
     },
+    "decimal.js": {
+      "version": "10.2.1",
+      "resolved": "https://registry.npmjs.org/decimal.js/-/decimal.js-10.2.1.tgz",
+      "integrity": "sha512-KaL7+6Fw6i5A2XSnsbhm/6B+NuEA7TZ4vqxnd5tXz9sbKtrN9Srj8ab4vKVdK8YAqZO9P1kg45Y6YLoduPf+kw=="
+    },
     "deck.gl": {
       "version": "8.4.0-alpha.4",
       "resolved": "https://registry.npmjs.org/deck.gl/-/deck.gl-8.4.0-alpha.4.tgz",
@@ -9457,6 +9467,11 @@
       "resolved": "https://registry.npmjs.org/escape-html/-/escape-html-1.0.3.tgz",
       "integrity": "sha1-Aljq5NPQwJdN4cFpGI7wBR0dGYg=",
       "dev": true
+    },
+    "escape-latex": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/escape-latex/-/escape-latex-1.2.0.tgz",
+      "integrity": "sha512-nV5aVWW1K0wEiUIEdZ4erkGGH8mDxGyxSeqPzRNtWP7ataw+/olFObw7hujFWlVjNsaDFw5VZ5NzVSIqRgfTiw=="
     },
     "escape-string-regexp": {
       "version": "1.0.5",
@@ -11604,6 +11619,11 @@
       "integrity": "sha1-mMI9qxF1ZXuMBXPozszZGw/xjIQ=",
       "dev": true
     },
+    "fraction.js": {
+      "version": "4.0.13",
+      "resolved": "https://registry.npmjs.org/fraction.js/-/fraction.js-4.0.13.tgz",
+      "integrity": "sha512-E1fz2Xs9ltlUp+qbiyx9wmt2n9dRzPsS11Jtdb8D2o+cC7wr9xkkKsVKJuBX0ST+LVS+LhLO+SbLJNtfWcJvXA=="
+    },
     "fragment-cache": {
       "version": "0.2.1",
       "resolved": "https://registry.npmjs.org/fragment-cache/-/fragment-cache-0.2.1.tgz",
@@ -13369,6 +13389,11 @@
       "integrity": "sha1-R+Y/evVa+m+S4VAOaQ64uFKcCZo=",
       "dev": true
     },
+    "javascript-natural-sort": {
+      "version": "0.7.1",
+      "resolved": "https://registry.npmjs.org/javascript-natural-sort/-/javascript-natural-sort-0.7.1.tgz",
+      "integrity": "sha1-+eIwPUUH9tdDVac2ZNFED7Wg71k="
+    },
     "js-base64": {
       "version": "2.6.4",
       "resolved": "https://registry.npmjs.org/js-base64/-/js-base64-2.6.4.tgz",
@@ -14568,6 +14593,21 @@
       "integrity": "sha512-3OYCtzTOW1wkZufjsxk8g1D77+z+x7QehOZcMFPGgw1QjVEFNcyy3ql6hdrZpUlkyE3pX4lYak7WOIE+n0obYg==",
       "requires": {
         "@math.gl/core": "3.1.3"
+      }
+    },
+    "mathjs": {
+      "version": "9.2.0",
+      "resolved": "https://registry.npmjs.org/mathjs/-/mathjs-9.2.0.tgz",
+      "integrity": "sha512-R2fQxaOmyifxgP4+c59dnfLwpKI1KYHdnT5lLwDuHIZvgyGb71M8ay6kTJTEv9rG04pduqvX4tbBUoG5ypTF8A==",
+      "requires": {
+        "complex.js": "^2.0.11",
+        "decimal.js": "^10.2.1",
+        "escape-latex": "^1.2.0",
+        "fraction.js": "^4.0.13",
+        "javascript-natural-sort": "^0.7.1",
+        "seedrandom": "^3.0.5",
+        "tiny-emitter": "^2.1.0",
+        "typed-function": "^2.0.0"
       }
     },
     "md5.js": {
@@ -23887,6 +23927,11 @@
         "source-map": "^0.4.2"
       }
     },
+    "seedrandom": {
+      "version": "3.0.5",
+      "resolved": "https://registry.npmjs.org/seedrandom/-/seedrandom-3.0.5.tgz",
+      "integrity": "sha512-8OwmbklUNzwezjGInmZ+2clQmExQPvomqjL7LFqOYqtmuxRgQYqOD3mHaU+MvZn5FLUeVxVfQjwLZW/n/JFuqg=="
+    },
     "select": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/select/-/select-1.1.2.tgz",
@@ -25629,8 +25674,7 @@
     "tiny-emitter": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/tiny-emitter/-/tiny-emitter-2.1.0.tgz",
-      "integrity": "sha512-NB6Dk1A9xgQPMoGqC5CVXn123gWyte215ONT5Pp5a0yt4nlEoO1ZWeCwpncaekPHXO60i47ihFnZPiRPjRMq4Q==",
-      "optional": true
+      "integrity": "sha512-NB6Dk1A9xgQPMoGqC5CVXn123gWyte215ONT5Pp5a0yt4nlEoO1ZWeCwpncaekPHXO60i47ihFnZPiRPjRMq4Q=="
     },
     "tiny-warning": {
       "version": "1.0.3",
@@ -25871,6 +25915,11 @@
         "media-typer": "0.3.0",
         "mime-types": "~2.1.24"
       }
+    },
+    "typed-function": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/typed-function/-/typed-function-2.0.0.tgz",
+      "integrity": "sha512-Hhy1Iwo/e4AtLZNK10ewVVcP2UEs408DS35ubP825w/YgSBK1KVLwALvvIG4yX75QJrxjCpcWkzkVRB0BwwYlA=="
     },
     "typedarray": {
       "version": "0.0.6",

--- a/package.json
+++ b/package.json
@@ -59,6 +59,7 @@
     "lodash": "^4.17.15",
     "lz-string": "^1.4.4",
     "math.gl": "^3.1.3",
+    "mathjs": "^9.2.0",
     "nebula.gl": "^0.21.1",
     "prop-types": "^15.7.2",
     "rc-tooltip": "^4.0.3",

--- a/src/components/data-hooks.js
+++ b/src/components/data-hooks.js
@@ -389,7 +389,8 @@ export function useRasterData(loaders, dataset, setItemIsReady, addUrl, isRequir
         const {
           layers: rasterLayers,
           renderLayers:
-          rasterRenderLayers, usePhysicalSizeScaling,
+          rasterRenderLayers,
+          usePhysicalSizeScaling,
         } = data;
         initializeRasterLayersAndChannels(rasterLayers, rasterRenderLayers, usePhysicalSizeScaling)
           .then(([autoImageLayers, nextImageLoaders, nextImageMeta]) => {

--- a/src/components/data-hooks.js
+++ b/src/components/data-hooks.js
@@ -386,8 +386,12 @@ export function useRasterData(loaders, dataset, setItemIsReady, addUrl, isRequir
           addUrl(url, name);
         });
 
-        const { layers: rasterLayers, renderLayers: rasterRenderLayers } = data;
-        initializeRasterLayersAndChannels(rasterLayers, rasterRenderLayers)
+        const {
+          layers: rasterLayers,
+          renderLayers:
+          rasterRenderLayers, usePhysicalSizeScaling,
+        } = data;
+        initializeRasterLayersAndChannels(rasterLayers, rasterRenderLayers, usePhysicalSizeScaling)
           .then(([autoImageLayers, nextImageLoaders, nextImageMeta]) => {
             setImageLayerLoaders(nextImageLoaders);
             setImageLayerMeta(nextImageMeta);

--- a/src/loaders/RasterJsonLoader.js
+++ b/src/loaders/RasterJsonLoader.js
@@ -61,7 +61,7 @@ export default class RasterLoader extends JsonLoader {
       return Promise.reject(payload);
     }
     const { data: raster } = payload;
-    const { images, renderLayers } = raster;
+    const { images, renderLayers, usePhysicalSizeScaling = false } = raster;
 
     // Get image name and URL tuples.
     const urls = images
@@ -76,6 +76,9 @@ export default class RasterLoader extends JsonLoader {
         return loader;
       },
     }));
-    return Promise.resolve({ data: { layers: imagesWithLoaderCreators, renderLayers }, urls });
+    return Promise.resolve({
+      data: { layers: imagesWithLoaderCreators, renderLayers, usePhysicalSizeScaling },
+      urls,
+    });
   }
 }

--- a/src/schemas/raster.schema.json
+++ b/src/schemas/raster.schema.json
@@ -108,6 +108,7 @@
   "required": ["schemaVersion", "images"],
   "properties": {
     "schemaVersion": { "type": "string" },
+    "usePhysicalSizeScaling": { "type": "boolean", "description": "Default is false: passing true in will infer scaling from the reported physcial size" },
     "renderLayers": { "type": "array", "items": { "type": "string" } },
     "images": {
       "type": "array",


### PR DESCRIPTION
Begins to address #848.  The physical size scaling will be automatically detected and implemented if `usePhysicalSizeScaling` is provided and `true` in the `raster.json` - otherwise it will not be used.  With this default behavior, I think we should be able to maintain backwards compatibility.  What I mean by this is that going forward, we may want to decompose incoming transformations into scale, rotate, and translate and inject physical size scaling into those matrices.  Thus, with the `usePhysicalSizeScaling` as a parameter that needs be specifically passed in and `true` (without being required), people using transformation matrices but not `usePhysicalSizeScaling` won't automatically at some point in the future (if we implement it) have their matrices altered because we want to do this sort of decomposition+injection of physical size scaling.

To test this out, [here on localhost:3000](http://localhost:3000/?url=data:,{%22version%22:%20%221.0.0%22,%22name%22:%20%22Spraggins%20Multi-Modal%22,%22description%22:%20%22PAS%20+%20IMS%20+%20AF%20From%20https://portal.hubmapconsortium.org/browse/collection/6a6efd0c1a2681dc7d2faab8e4ab0bca%22,%22datasets%22:%20[{%22uid%22:%20%22A%22,%22name%22:%20%22Spraggins%22,%22files%22:%20[{%22type%22:%20%22raster%22,%22fileType%22:%20%22raster.json%22,%22options%22:%20{%22schemaVersion%22:%20%220.0.2%22,%22usePhysicalSizeScaling%22:%20true,%22images%22:%20[{%22name%22:%20%22PAS%22,%22type%22:%20%22ome-tiff%22,%22url%22:%20%22https://assets.hubmapconsortium.org/f4188a148e4c759092d19369d310883b/ometiff-pyramids/processedMicroscopy/VAN0006-LK-2-85-PAS_images/VAN0006-LK-2-85-PAS_registered.ome.tif?token=%22},{%22name%22:%20%22AF%22,%22type%22:%20%22ome-tiff%22,%22url%22:%20%22https://assets.hubmapconsortium.org/2130d5f91ce61d7157a42c0497b06de8/ometiff-pyramids/processedMicroscopy/VAN0006-LK-2-85-AF_preIMS_images/VAN0006-LK-2-85-AF_preIMS_registered.ome.tif?token=%22},{%22name%22:%20%22IMS%22,%22type%22:%20%22ome-tiff%22,%22url%22:%20%22https://assets.hubmapconsortium.org/be503a021ed910c0918842e318e6efa2/ometiff-pyramids/ometiffs/VAN0006-LK-2-85-IMS_PosMode_multilayer.ome.tif?token=%22}],%22renderLayers%22:%20[%22PAS%22,%22AF%22,%22IMS%22]}}]}],%22coordinationSpace%22:%20{%22dataset%22:%20{%22A%22:%20%22A%22},%22spatialZoom%22:%20{%22A%22:%20-6},%22spatialTargetX%22:%20{%22A%22:%2020000},%22spatialTargetY%22:%20{%22A%22:%2020000},%22spatialRotation%22:%20{%22A%22:%200},%22spatialTargetZ%22:%20{%22A%22:%200},%22cellFilter%22:%20{%22A%22:%20null},%22cellHighlight%22:%20{%22A%22:%20null},%22cellSetSelection%22:%20{%22A%22:%20null},%22cellSetHighlight%22:%20{%22A%22:%20null},%22cellSetColor%22:%20{%22A%22:%20null},%22geneHighlight%22:%20{%22A%22:%20null},%22geneSelection%22:%20{%22A%22:%20null},%22geneExpressionColormap%22:%20{%22A%22:%20%22plasma%22},%22geneExpressionColormapRange%22:%20{%22A%22:%20[0,1]},%22cellColorEncoding%22:%20{%22A%22:%20%22cellSetSelection%22},%22spatialLayers%22:%20{%22A%22:%20null},%22additionalCellSets%22:%20{%22A%22:%20null},%22moleculeHighlight%22:%20{%22A%22:%20null}},%22layout%22:%20[{%22component%22:%20%22spatial%22,%22coordinationScopes%22:%20{%22dataset%22:%20%22A%22,%22spatialZoom%22:%20%22A%22,%22spatialTargetX%22:%20%22A%22,%22spatialTargetY%22:%20%22A%22,%22spatialRotation%22:%20%22A%22,%22spatialTargetZ%22:%20%22A%22,%22cellFilter%22:%20%22A%22,%22cellHighlight%22:%20%22A%22,%22cellSetSelection%22:%20%22A%22,%22cellSetHighlight%22:%20%22A%22,%22cellSetColor%22:%20%22A%22,%22geneHighlight%22:%20%22A%22,%22geneSelection%22:%20%22A%22,%22geneExpressionColormap%22:%20%22A%22,%22geneExpressionColormapRange%22:%20%22A%22,%22cellColorEncoding%22:%20%22A%22,%22spatialLayers%22:%20%22A%22,%22additionalCellSets%22:%20%22A%22,%22moleculeHighlight%22:%20%22A%22},%22x%22:%200,%22y%22:%200,%22w%22:%209,%22h%22:%2012},{%22component%22:%20%22layerController%22,%22coordinationScopes%22:%20{%22dataset%22:%20%22A%22,%22spatialLayers%22:%20%22A%22},%22x%22:%209,%22y%22:%200,%22w%22:%203,%22h%22:%2012}],%22initStrategy%22:%20%22auto%22}) is a few HuBMAP datasets properly overlaid - removing the `usePhysicalSizeScaling` should stick the IMS dataset into the top left corner:

```json
{
  "version": "1.0.0",
  "name": "Spraggins Multi-Modal",
  "description": "PAS   IMS   AF From https://portal.hubmapconsortium.org/browse/collection/6a6efd0c1a2681dc7d2faab8e4ab0bca",
  "datasets": [
    {
      "uid": "A",
      "name": "Spraggins",
      "files": [
        {
          "type": "raster",
          "fileType": "raster.json",
          "options": {
            "schemaVersion": "0.0.2",
            "usePhysicalSizeScaling": true,
            "images": [
              {
                "name": "PAS",
                "type": "ome-tiff",
                "url": "https://assets.hubmapconsortium.org/f4188a148e4c759092d19369d310883b/ometiff-pyramids/processedMicroscopy/VAN0006-LK-2-85-PAS_images/VAN0006-LK-2-85-PAS_registered.ome.tif?token="
              },
              {
                "name": "AF",
                "type": "ome-tiff",
                "url": "https://assets.hubmapconsortium.org/2130d5f91ce61d7157a42c0497b06de8/ometiff-pyramids/processedMicroscopy/VAN0006-LK-2-85-AF_preIMS_images/VAN0006-LK-2-85-AF_preIMS_registered.ome.tif?token="
              },
              {
                "name": "IMS",
                "type": "ome-tiff",
                "url": "https://assets.hubmapconsortium.org/be503a021ed910c0918842e318e6efa2/ometiff-pyramids/ometiffs/VAN0006-LK-2-85-IMS_PosMode_multilayer.ome.tif?token="
              }
            ],
            "renderLayers": [
              "PAS",
              "AF",
              "IMS"
            ]
          }
        }
      ]
    }
  ],
  "coordinationSpace": {
    "dataset": {
      "A": "A"
    },
    "spatialZoom": {
      "A": -6
    },
    "spatialTargetX": {
      "A": 20000
    },
    "spatialTargetY": {
      "A": 20000
    },
    "spatialRotation": {
      "A": 0
    },
    "spatialTargetZ": {
      "A": 0
    },
    "cellFilter": {
      "A": null
    },
    "cellHighlight": {
      "A": null
    },
    "cellSetSelection": {
      "A": null
    },
    "cellSetHighlight": {
      "A": null
    },
    "cellSetColor": {
      "A": null
    },
    "geneHighlight": {
      "A": null
    },
    "geneSelection": {
      "A": null
    },
    "geneExpressionColormap": {
      "A": "plasma"
    },
    "geneExpressionColormapRange": {
      "A": [
        0,
        1
      ]
    },
    "cellColorEncoding": {
      "A": "cellSetSelection"
    },
    "spatialLayers": {
      "A": null
    },
    "additionalCellSets": {
      "A": null
    },
    "moleculeHighlight": {
      "A": null
    }
  },
  "layout": [
    {
      "component": "spatial",
      "coordinationScopes": {
        "dataset": "A",
        "spatialZoom": "A",
        "spatialTargetX": "A",
        "spatialTargetY": "A",
        "spatialRotation": "A",
        "spatialTargetZ": "A",
        "cellFilter": "A",
        "cellHighlight": "A",
        "cellSetSelection": "A",
        "cellSetHighlight": "A",
        "cellSetColor": "A",
        "geneHighlight": "A",
        "geneSelection": "A",
        "geneExpressionColormap": "A",
        "geneExpressionColormapRange": "A",
        "cellColorEncoding": "A",
        "spatialLayers": "A",
        "additionalCellSets": "A",
        "moleculeHighlight": "A"
      },
      "x": 0,
      "y": 0,
      "w": 9,
      "h": 12
    },
    {
      "component": "layerController",
      "coordinationScopes": {
        "dataset": "A",
        "spatialLayers": "A"
      },
      "x": 9,
      "y": 0,
      "w": 3,
      "h": 12
    }
  ],
  "initStrategy": "auto"
}
```
<img width="1680" alt="Screen Shot 2021-02-11 at 2 09 25 PM" src="https://user-images.githubusercontent.com/43999641/107686100-c6a97d00-6c72-11eb-840e-e7c1d8945212.png">
<img width="1680" alt="Screen Shot 2021-02-11 at 2 08 37 PM" src="https://user-images.githubusercontent.com/43999641/107686111-cb6e3100-6c72-11eb-90b7-558d0984e39d.png">
