### PR TITLE
DataFilterExtension for Selections

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ### Added
 
 ### Changed
+- Used `DataFilterExtension` from `deck.gl` to speed up filtering selections.
 
 ## [1.1.5](https://www.npmjs.com/package/vitessce/v/1.1.5) - 2021-02-25
 

--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
   },
   "dependencies": {
     "@deck.gl/core": "8.4.0-alpha.4",
+    "@deck.gl/extensions": "8.4.0-alpha.4",
     "@deck.gl/layers": "8.4.0-alpha.4",
     "@hms-dbmi/viv": "^0.8.3",
     "@loaders.gl/3d-tiles": "^2.3.0",

--- a/src/layers/selection-utils.js
+++ b/src/layers/selection-utils.js
@@ -91,7 +91,7 @@ export function overlayBaseProps(props) {
       data,
       getFilterValue: isSelected,
       extensions: [new DataFilterExtension({ filterSize: 1 })],
-      filterRange: [0.99, 1.01],
+      filterRange: [1, 1],
       ...rest,
     },
     base: {

--- a/src/layers/selection-utils.js
+++ b/src/layers/selection-utils.js
@@ -81,7 +81,7 @@ export function getSelectionLayers(
  */
 export function overlayBaseProps(props) {
   const {
-    id, backgroundColor, getColor, data, isSelected, ...rest
+    id, getColor, data, isSelected, ...rest
   } = props;
   return {
     overlay: {

--- a/src/layers/selection-utils.js
+++ b/src/layers/selection-utils.js
@@ -1,4 +1,5 @@
 import { COORDINATE_SYSTEM } from 'deck.gl';
+import { DataFilterExtension } from '@deck.gl/extensions';
 import SelectionLayer from './SelectionLayer';
 
 /**
@@ -72,26 +73,6 @@ export function getSelectionLayers(
 }
 
 /**
- * Using a color function and a theme name, return a function
- * that mixes a cell color with a theme background color.
- * Reference: https://github.com/bgrins/TinyColor/blob/80f7225029c428c0de0757f7d98ac15f497bee57/tinycolor.js#L701
- * @param {function} colorFunction Returns a color given a cell.
- * @param {number[]} backgroundColor The scatterplot or spatial background color.
- * @returns {function} Returns a color given a cell.
- */
-function mixFunction(colorFunction, backgroundColor) {
-  const p = 0.5;
-  return (cell) => {
-    const rgb = colorFunction(cell);
-    return [
-      ((backgroundColor[0] - rgb[0]) * p) + rgb[0],
-      ((backgroundColor[1] - rgb[1]) * p) + rgb[1],
-      ((backgroundColor[2] - rgb[2]) * p) + rgb[2],
-    ];
-  };
-}
-
-/**
  * Get deck.gl layer props for selection overlays.
  * @param {object} props
  * @returns {object} Object with two properties,
@@ -107,16 +88,19 @@ export function overlayBaseProps(props) {
       id: getSelectedLayerId(id),
       getFillColor: getColor,
       getLineColor: getColor,
-      data: data.filter(isSelected),
+      data,
+      getFilterValue: isSelected,
+      extensions: [new DataFilterExtension({ filterSize: 1 })],
+      filterRange: [0.99, 1.01],
       ...rest,
     },
     base: {
       id: getBaseLayerId(id),
-      getLineColor: getColor ? mixFunction(getColor, backgroundColor) : undefined,
-      getFillColor: getColor ? mixFunction(getColor, backgroundColor) : undefined,
+      getLineColor: getColor,
+      getFillColor: getColor,
       // Alternatively: contrast outlines with solids:
       // getLineColor: getColor,
-      // getFillColor: [255,255,255],
+      // getFillColor: [255, 255, 255],
       data: data.slice(),
       ...rest,
     },


### PR DESCRIPTION
I think this fixes #854 using https://deck.gl/docs/api-reference/extensions/data-filter-extension

The only thing was that I had to remove `mixFunction` although I didn't notice a difference without it and previous to this PR with it.  I don't really understand why it is no longer needed, but presumably this has to do with how the new filtering process works.  To see the improvement in speed, use one of the big slide-seq examples I sent in the Vitessce chat last week and the difference should be considerable when compared with the links I shared for changing genes.