### PR TITLE
Fix Schema Bug from Auto-Centering

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 - Added logo to README.
 
 ### Changed
+- Fix bug from #867 where the view config is temporarily invalid due to null values.
 
 ## [1.1.6](https://www.npmjs.com/package/vitessce/v/1.1.6) - 2021-03-05
 

--- a/TESTING.md
+++ b/TESTING.md
@@ -28,9 +28,9 @@ cd ..
 
 ## Application Layout
 
-Click on "Linnarsson: Spatial organization of the somatosensory cortex revealed by cyclic smFISH", and then add `debug=true` as a URL argument.  Before beginning testing, make sure that the dataset loads and you can do a few basic interactions without raising an error about the config schema being invalid.
+Click on "Linnarsson: Spatial organization of the somatosensory cortex revealed by cyclic smFISH", and, after it loads, add `debug=true` as a URL argument before reloading the page.  Make sure that the dataset loads and you can do a few basic interactions without raising an error about the config schema being invalid.
 
-Remove the argument `debug=true` and refresh the page.  While data loads, there should be a spinner over every component on the grid, which disappear independently as data loads.
+Remove the argument `debug=true` and reload the page from the new url.  While data loads, there should be a spinner over every component on the grid, which disappear independently as data loads.
 
 The components are arranged in four columns, with another component (heatmap) as a footer.
 The components in the successive columns should be:

--- a/TESTING.md
+++ b/TESTING.md
@@ -28,9 +28,9 @@ cd ..
 
 ## Application Layout
 
-Click on "Linnarsson: Spatial organization of the somatosensory cortex revealed by cyclic smFISH".
+Click on "Linnarsson: Spatial organization of the somatosensory cortex revealed by cyclic smFISH", and then add `debug=true` as a URL argument.  Before beginning testing, make sure that the dataset loads and you can do a few basic interactions without raising an error about the config schema being invalid.
 
-While data loads, there should be a spinner over every component on the grid, which disappear independently as data loads.
+Remove the argument `debug=true` and refresh the page.  While data loads, there should be a spinner over every component on the grid, which disappear independently as data loads.
 
 The components are arranged in four columns, with another component (heatmap) as a footer.
 The components in the successive columns should be:

--- a/src/schemas/config.schema.json
+++ b/src/schemas/config.schema.json
@@ -414,7 +414,14 @@
         "embeddingZoom": {
           "type": "object",
           "patternProperties": {
-            ".": { "type": "number" }
+            ".": { "oneOf": [
+                {
+                  "type": "null",
+                  "description": "If null is provided, value will be automatically set."
+                },
+                { "type": "number" }
+              ]
+            }
           }
         },
         "embeddingRotation": {

--- a/src/schemas/config.schema.json
+++ b/src/schemas/config.schema.json
@@ -426,13 +426,27 @@
         "embeddingTargetX": {
           "type": "object",
           "patternProperties": {
-            ".": { "type": "number" }
+            ".": { "oneOf": [
+                {
+                  "type": "null",
+                  "description": "If null is provided, value will be automatically set."
+                },
+                { "type": "number" }
+              ]
+            }
           }
         },
         "embeddingTargetY": {
           "type": "object",
           "patternProperties": {
-            ".": { "type": "number" }
+            ".":  { "oneOf": [
+                {
+                  "type": "null",
+                  "description": "If null is provided, value will be automatically set."
+                },
+                { "type": "number" }
+              ]
+            }
           }
         },
         "embeddingTargetZ": {
@@ -474,7 +488,14 @@
         "spatialZoom": {
           "type": "object",
           "patternProperties": {
-            ".": { "type": "number" }
+            ".":  { "oneOf": [
+                {
+                  "type": "null",
+                  "description": "If null is provided, value will be automatically set."
+                },
+                { "type": "number" }
+              ]
+            }
           }
         },
         "spatialRotation": {
@@ -486,13 +507,27 @@
         "spatialTargetX": {
           "type": "object",
           "patternProperties": {
-            ".": { "type": "number" }
+            ".":  { "oneOf": [
+                {
+                  "type": "null",
+                  "description": "If null is provided, value will be automatically set."
+                },
+                { "type": "number" }
+              ]
+            }
           }
         },
         "spatialTargetY": {
           "type": "object",
           "patternProperties": {
-            ".": { "type": "number" }
+            ".":  { "oneOf": [
+                {
+                  "type": "null",
+                  "description": "If null is provided, value will be automatically set."
+                },
+                { "type": "number" }
+              ]
+            }
           }
         },
         "spatialTargetZ": {


### PR DESCRIPTION
Fixes a bug from #867 where the coordination type can be null.  Also adds a note to the testing docs that we should be checking the schema validity as we go.

To see this bug in action, add `debug=true` to vitessce.io or the most recent commit in this repo, and the Linnarsson example will throw an error about the schema.  This PR should fix it.

I want to merge this before #884 so I can test it properly.