### PR TITLE
Don't Filter when All Cells are Selected

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 - Fix bug from #867 where the view config is temporarily invalid due to null values.
 - Separate out hooks to allow for arbitrary gene slicing.
 - Update AnnData loader to handle artbitrary gene slicing.
+- Do not do call `makeDefaultGetCellIsSelected` if not necessary.
 
 ## [1.1.6](https://www.npmjs.com/package/vitessce/v/1.1.6) - 2021-03-05
 

--- a/src/components/scatterplot/Scatterplot.js
+++ b/src/components/scatterplot/Scatterplot.js
@@ -87,6 +87,7 @@ class Scatterplot extends AbstractSpatialOrScatterplot {
   }
 
   createCellsLayer() {
+    const { cellsEntries } = this;
     const {
       theme,
       mapping,
@@ -97,12 +98,13 @@ class Scatterplot extends AbstractSpatialOrScatterplot {
       cellSelection,
       setCellHighlight,
       setComponentHover,
-      getCellIsSelected = makeDefaultGetCellIsSelected(cellSelection),
+      getCellIsSelected = makeDefaultGetCellIsSelected(
+        cellsEntries.length === cellSelection.length ? null : cellSelection,
+      ),
       cellColors,
       getCellColor = makeDefaultGetCellColors(cellColors),
       onCellClick,
     } = this.props;
-    const { cellsEntries } = this;
     const filteredCellsEntries = (cellFilter
       ? cellsEntries.filter(cellEntry => cellFilter.includes(cellEntry[0]))
       : cellsEntries);

--- a/src/components/spatial/Spatial.js
+++ b/src/components/spatial/Spatial.js
@@ -93,12 +93,15 @@ class Spatial extends AbstractSpatialOrScatterplot {
     const {
       radius, stroked, visible, opacity,
     } = layerDef;
+    const { cellsEntries } = this;
     const {
       cellFilter,
       cellSelection,
       setCellHighlight,
       setComponentHover,
-      getCellIsSelected = makeDefaultGetCellIsSelected(cellSelection),
+      getCellIsSelected = makeDefaultGetCellIsSelected(
+        cellsEntries.length === cellSelection.length ? null : cellSelection,
+      ),
       cellColors,
       getCellColor = makeDefaultGetCellColors(cellColors),
       getCellPolygon = makeDefaultGetCellPolygon(radius),
@@ -106,7 +109,6 @@ class Spatial extends AbstractSpatialOrScatterplot {
       lineWidthScale = 10,
       lineWidthMaxPixels = 2,
     } = this.props;
-    const { cellsEntries } = this;
     const filteredCellsEntries = (cellFilter
       ? cellsEntries.filter(cellEntry => cellFilter.includes(cellEntry[0]))
       : cellsEntries);


### PR DESCRIPTION
Because `makeDefaultGetCellIsSelected` create a function where `cellSelection.includes` is called on every iteration over the cells, that can be very costly for large amounts of cells, which especially is noticeable at initial load time when things like concave hull, channel stats etc. are being calculated.  Furthermore, usually, the initial load is of the full cell set.  This PR makes it so that `null` is passed in to `makeDefaultGetCellIsSelected` which in turn causes the returned function not to call `cellSelection.includes` allowing us to speed up initial load time (and other interactions).

See https://github.com/vitessce/vitessce/pull/874/files#diff-e1ffdb1efb8675d0702711de4c2b151e39b9fc60e234489dfa0267d22c4f4c10R101-R102 from #874 for the original idea.

Here is a [demo merging](https://s3.amazonaws.com/vitessce-data/demos/2021-03-15/e4fec9d/index.html?url=data%3A%2C%7B+++%22version%22%3A+%221.0.0%22%2C+++%22name%22%3A+%223ac0768d61c6c84f0ec59d766e123e05%22%2C+++%22datasets%22%3A+%5B+++++%7B+++++++%22uid%22%3A+%2240334a99-2be7-4904-bc75-102609fe53e9%22%2C+++++++%22name%22%3A+%2240334a99-2be7-4904-bc75-102609fe53e9%22%2C+++++++%22files%22%3A+%5B+++++++++%7B+++++++++++%22type%22%3A+%22cells%22%2C+++++++++++%22fileType%22%3A+%22anndata-cells.zarr%22%2C+++++++++++%22url%22%3A+%22https%3A%2F%2Fvitessce-demo-data.storage.googleapis.com%2Fcxg_examples%2FBALF_VIB-UGent_processed_cleaned.zarr%22%2C+++++++++++%22options%22%3A+%7B+++++++++++++%22mappings%22%3A+%7B+%22UMAP%22%3A+%7B+%22key%22%3A+%22obsm%2FX_umap%22%2C+%22dims%22%3A+%5B0%2C+1%5D+%7D+%7D+++++++++++%7D+++++++++%7D%2C+++++++++%7B+++++++++++%22type%22%3A+%22cell-sets%22%2C+++++++++++%22fileType%22%3A+%22anndata-cell-sets.zarr%22%2C+++++++++++%22url%22%3A+%22https%3A%2F%2Fvitessce-demo-data.storage.googleapis.com%2Fcxg_examples%2FBALF_VIB-UGent_processed_cleaned.zarr%22%2C+++++++++++%22options%22%3A+%5B%7B+%22groupName%22%3A+%22Annotation%22%2C+%22setName%22%3A+%22obs%2FAnnotation%22+%7D%2C+%7B+%22groupName%22%3A+%22Age%22%2C+%22setName%22%3A+%22obs%2FAge%22+%7D%2C+%7B+%22groupName%22%3A+%22BMI%22%2C+%22setName%22%3A+%22obs%2FBMI%22+%7D%5D+++++++++%7D%2C+++++++++%7B+++++++++++%22type%22%3A+%22expression-matrix%22%2C+++++++++++%22fileType%22%3A+%22anndata-expression-matrix.zarr%22%2C+++++++++++%22url%22%3A+%22https%3A%2F%2Fvitessce-demo-data.storage.googleapis.com%2Fcxg_examples%2FBALF_VIB-UGent_processed_cleaned.zarr%22%2C+++++++++++%22options%22%3A+%7B+%22matrix%22%3A+%22X%22+%7D+++++++++%7D+++++++%5D+++++%7D+++%5D%2C+++%22initStrategy%22%3A+%22auto%22%2C+++%22coordinationSpace%22%3A+%7B+%22embeddingType%22%3A+%7B+%22UMAP%22%3A+%22UMAP%22+%7D+%7D%2C+++%22layout%22%3A+%5B+++++%7B+++++++%22component%22%3A+%22cellSets%22%2C+++++++%22h%22%3A+3%2C+++++++%22w%22%3A+3%2C+++++++%22x%22%3A+9%2C+++++++%22y%22%3A+0%2C+++++++%22coordinationScopes%22%3A+%7B%7D+++++%7D%2C+++++%7B+++++++%22component%22%3A+%22genes%22%2C+++++++%22h%22%3A+3%2C+++++++%22w%22%3A+3%2C+++++++%22x%22%3A+9%2C+++++++%22y%22%3A+3%2C+++++++%22coordinationScopes%22%3A+%7B%7D+++++%7D%2C+++++%7B+++++++%22component%22%3A+%22scatterplot%22%2C+++++++%22h%22%3A+6%2C+++++++%22w%22%3A+9%2C+++++++%22x%22%3A+0%2C+++++++%22y%22%3A+0%2C+++++++%22coordinationScopes%22%3A+%7B+%22embeddingType%22%3A+%22UMAP%22+%7D+++++%7D+++%5D+%7D&theme=dark) #887 #888 #889 #890 and #891 - using the profiler on the latest release should reveal each of these to be a bottleneck (or using it on each of these branches should reveal the others as a problem as there is one main problem on the current latest release probably).   It probably won't load without these PR's honestly.

Branch with all merged: https://github.com/vitessce/vitessce/tree/ilan-gold/demo_big_sets