### PR TITLE
Fix Bug in AnnData Categories Parsing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@
 - Fix bug from #867 where the view config is temporarily invalid due to null values.
 - Separate out hooks to allow for arbitrary gene slicing.
 - Update AnnData loader to handle artbitrary gene slicing.
-- Fix `categories` parsing for AnnData with `dtype=|O1`.
+- Fix `categories` parsing for AnnData with `dtype=|O`.
 
 ## [1.1.6](https://www.npmjs.com/package/vitessce/v/1.1.6) - 2021-03-05
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 - Fix bug from #867 where the view config is temporarily invalid due to null values.
 - Separate out hooks to allow for arbitrary gene slicing.
 - Update AnnData loader to handle artbitrary gene slicing.
+- Fix `categories` parsing for AnnData with `dtype=|O1`.
 
 ## [1.1.6](https://www.npmjs.com/package/vitessce/v/1.1.6) - 2021-03-05
 

--- a/src/loaders/anndata-loaders/BaseAnnDataLoader.js
+++ b/src/loaders/anndata-loaders/BaseAnnDataLoader.js
@@ -73,7 +73,7 @@ export default class BaseAnnDataLoader extends AbstractLoader {
         let categoriesValues;
         if (categories) {
           const { dtype } = await this.getJson(
-            `/obs/${categories}/.zattrs`,
+            `/obs/${categories}/.zarray`,
           );
           if (dtype === '|O') {
             categoriesValues = await this.getFlatTextArr(`/obs/${categories}`);

--- a/src/loaders/anndata-loaders/BaseAnnDataLoader.js
+++ b/src/loaders/anndata-loaders/BaseAnnDataLoader.js
@@ -72,7 +72,12 @@ export default class BaseAnnDataLoader extends AbstractLoader {
         );
         let categoriesValues;
         if (categories) {
-          categoriesValues = await this.getFlatTextArr(`/obs/${categories}`);
+          const { dtype } = await this.getJson(
+            `/obs/${categories}/.zattrs`,
+          );
+          if (dtype === '|O') {
+            categoriesValues = await this.getFlatTextArr(`/obs/${categories}`);
+          }
         }
         const cellSetsArr = await openArray({
           store,


### PR DESCRIPTION
If the original `obs` key is a number, the categories may have identical datatype written in the `.zarray` in which case they are identical to the original values and a) do not need to be parsed and b) are not strings so should not have `getFlatTextArr` called on them.

Original idea from #874 at https://github.com/vitessce/vitessce/pull/874/files#diff-c17600274a959e1fd9266918de0c9088d723badfb408b1c8ec1d55d6f587171eR75-R80 (which was wrong - it should have been getting `.zarray` not `.zattrs`)


Here is a [demo merging](https://s3.amazonaws.com/vitessce-data/demos/2021-03-15/e4fec9d/index.html?url=data%3A%2C%7B+++%22version%22%3A+%221.0.0%22%2C+++%22name%22%3A+%223ac0768d61c6c84f0ec59d766e123e05%22%2C+++%22datasets%22%3A+%5B+++++%7B+++++++%22uid%22%3A+%2240334a99-2be7-4904-bc75-102609fe53e9%22%2C+++++++%22name%22%3A+%2240334a99-2be7-4904-bc75-102609fe53e9%22%2C+++++++%22files%22%3A+%5B+++++++++%7B+++++++++++%22type%22%3A+%22cells%22%2C+++++++++++%22fileType%22%3A+%22anndata-cells.zarr%22%2C+++++++++++%22url%22%3A+%22https%3A%2F%2Fvitessce-demo-data.storage.googleapis.com%2Fcxg_examples%2FBALF_VIB-UGent_processed_cleaned.zarr%22%2C+++++++++++%22options%22%3A+%7B+++++++++++++%22mappings%22%3A+%7B+%22UMAP%22%3A+%7B+%22key%22%3A+%22obsm%2FX_umap%22%2C+%22dims%22%3A+%5B0%2C+1%5D+%7D+%7D+++++++++++%7D+++++++++%7D%2C+++++++++%7B+++++++++++%22type%22%3A+%22cell-sets%22%2C+++++++++++%22fileType%22%3A+%22anndata-cell-sets.zarr%22%2C+++++++++++%22url%22%3A+%22https%3A%2F%2Fvitessce-demo-data.storage.googleapis.com%2Fcxg_examples%2FBALF_VIB-UGent_processed_cleaned.zarr%22%2C+++++++++++%22options%22%3A+%5B%7B+%22groupName%22%3A+%22Annotation%22%2C+%22setName%22%3A+%22obs%2FAnnotation%22+%7D%2C+%7B+%22groupName%22%3A+%22Age%22%2C+%22setName%22%3A+%22obs%2FAge%22+%7D%2C+%7B+%22groupName%22%3A+%22BMI%22%2C+%22setName%22%3A+%22obs%2FBMI%22+%7D%5D+++++++++%7D%2C+++++++++%7B+++++++++++%22type%22%3A+%22expression-matrix%22%2C+++++++++++%22fileType%22%3A+%22anndata-expression-matrix.zarr%22%2C+++++++++++%22url%22%3A+%22https%3A%2F%2Fvitessce-demo-data.storage.googleapis.com%2Fcxg_examples%2FBALF_VIB-UGent_processed_cleaned.zarr%22%2C+++++++++++%22options%22%3A+%7B+%22matrix%22%3A+%22X%22+%7D+++++++++%7D+++++++%5D+++++%7D+++%5D%2C+++%22initStrategy%22%3A+%22auto%22%2C+++%22coordinationSpace%22%3A+%7B+%22embeddingType%22%3A+%7B+%22UMAP%22%3A+%22UMAP%22+%7D+%7D%2C+++%22layout%22%3A+%5B+++++%7B+++++++%22component%22%3A+%22cellSets%22%2C+++++++%22h%22%3A+3%2C+++++++%22w%22%3A+3%2C+++++++%22x%22%3A+9%2C+++++++%22y%22%3A+0%2C+++++++%22coordinationScopes%22%3A+%7B%7D+++++%7D%2C+++++%7B+++++++%22component%22%3A+%22genes%22%2C+++++++%22h%22%3A+3%2C+++++++%22w%22%3A+3%2C+++++++%22x%22%3A+9%2C+++++++%22y%22%3A+3%2C+++++++%22coordinationScopes%22%3A+%7B%7D+++++%7D%2C+++++%7B+++++++%22component%22%3A+%22scatterplot%22%2C+++++++%22h%22%3A+6%2C+++++++%22w%22%3A+9%2C+++++++%22x%22%3A+0%2C+++++++%22y%22%3A+0%2C+++++++%22coordinationScopes%22%3A+%7B+%22embeddingType%22%3A+%22UMAP%22+%7D+++++%7D+++%5D+%7D&theme=dark) #887 #888 #889 #890 and #891 - using the profiler on the latest release should reveal each of these to be a bottleneck (or using it on each of these branches should reveal the others as a problem as there is one main problem on the current latest release probably).   It probably won't load without these PR's honestly.

Branch with all merged: https://github.com/vitessce/vitessce/tree/ilan-gold/demo_big_sets