### PR TITLE
Fix `format` Bug on Image Metadata.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@
 - Fix `categories` parsing for AnnData with `dtype=|O`.
 - Do not do call `makeDefaultGetCellIsSelected` if not necessary.
 - Upgrade `Viv` to 0.9.3.
+- Fix bug where formatting was required for image loader `metadata`.
 
 ## [1.1.6](https://www.npmjs.com/package/vitessce/v/1.1.6) - 2021-03-05
 

--- a/src/components/description/DescriptionSubscriber.js
+++ b/src/components/description/DescriptionSubscriber.js
@@ -58,9 +58,10 @@ export default function DescriptionSubscriber(props) {
       rasterLayers.forEach((layer) => {
         if (imageLayerMeta[layer.index]) {
           // Want to ensure that layer index is a string.
+          const { format } = imageLayerLoaders[layer.index].metadata;
           result.set(`${layer.index}`, {
             name: raster.meta[layer.index].name,
-            metadata: imageLayerLoaders[layer.index].metadata?.format(),
+            metadata: format && format(),
           });
         }
       });


### PR DESCRIPTION
Without this change, the Linnarsson example is broken because `format` is actually called even though it may not exist.  Didn't know `?` worked that way.