### PR TITLE
Add ScopedCssBaseline, update important height style

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Changed
 - Fix `layerController` checkbox `height` css being overriden in Jupyter Lab.
+- Add the `ScopedCssBaseline` component from the Material UI library to reset the CSS within the Vitessce widget.
 
 ## [1.1.7](https://www.npmjs.com/package/vitessce/v/1.1.7) - 2021-03-24
 

--- a/src/app/Vitessce.js
+++ b/src/app/Vitessce.js
@@ -5,6 +5,7 @@ import {
   ThemeProvider, StylesProvider,
   createGenerateClassName,
 } from '@material-ui/core/styles';
+import ScopedCssBaseline from '@material-ui/core/ScopedCssBaseline';
 import isEqual from 'lodash/isEqual';
 import packageJson from '../../package.json';
 import { muiTheme } from '../components/shared-mui/styles';
@@ -19,6 +20,7 @@ import Warning from './Warning';
 import CallbackPublisher from './CallbackPublisher';
 import { getComponent } from './component-registry';
 import { initialize, upgrade } from './view-config-utils';
+import { useBaselineStyles } from './styles';
 
 const generateClassName = createGenerateClassName({
   disableGlobal: true,
@@ -54,6 +56,8 @@ export default function Vitessce(props) {
     onLoaderChange,
     validateOnConfigChange = false,
   } = props;
+
+  const classes = useBaselineStyles();
 
   // Process the view config and memoize the result:
   // - Validate.
@@ -138,19 +142,21 @@ export default function Vitessce(props) {
   return success ? (
     <StylesProvider generateClassName={generateClassName}>
       <ThemeProvider theme={muiTheme[theme]}>
-        <VitessceGrid
-          config={configOrWarning}
-          getComponent={getComponent}
-          rowHeight={rowHeight}
-          height={height}
-          theme={theme}
-        />
-        <CallbackPublisher
-          onWarn={onWarn}
-          onConfigChange={onConfigChange}
-          onLoaderChange={onLoaderChange}
-          validateOnConfigChange={validateOnConfigChange}
-        />
+        <ScopedCssBaseline classes={classes}>
+          <VitessceGrid
+            config={configOrWarning}
+            getComponent={getComponent}
+            rowHeight={rowHeight}
+            height={height}
+            theme={theme}
+          />
+          <CallbackPublisher
+            onWarn={onWarn}
+            onConfigChange={onConfigChange}
+            onLoaderChange={onLoaderChange}
+            validateOnConfigChange={validateOnConfigChange}
+          />
+        </ScopedCssBaseline>
       </ThemeProvider>
     </StylesProvider>
   ) : (

--- a/src/app/styles.js
+++ b/src/app/styles.js
@@ -1,0 +1,8 @@
+import { makeStyles } from '@material-ui/core/styles';
+
+export const useBaselineStyles = makeStyles(() => ({
+  root: {
+    height: '100%',
+    width: '100%',
+  },
+}));

--- a/src/components/layer-controller/ChannelController.js
+++ b/src/components/layer-controller/ChannelController.js
@@ -4,12 +4,13 @@ import { getChannelStats } from '@hms-dbmi/viv';
 import Checkbox from '@material-ui/core/Checkbox';
 import Grid from '@material-ui/core/Grid';
 import Slider from '@material-ui/core/Slider';
-import Select from '@material-ui/core/Select';
+import NativeSelect from '@material-ui/core/NativeSelect';
 import debounce from 'lodash/debounce';
 import isEqual from 'lodash/isEqual';
 
 import ChannelOptions from './ChannelOptions';
 import { DOMAINS } from './constants';
+import { useCheckboxStyles } from './styles';
 import { getSourceFromLoader } from '../../utils';
 
 // Returns an rgb string for display, and changes the color (arr)
@@ -60,8 +61,7 @@ function ChannelSelectionDropdown({
   selectionIndex,
 }) {
   return (
-    <Select
-      native
+    <NativeSelect
       value={selectionIndex}
       onChange={e => handleChange(Number(e.target.value))}
     >
@@ -70,7 +70,7 @@ function ChannelSelectionDropdown({
           {opt}
         </option>
       ))}
-    </Select>
+    </NativeSelect>
   );
 }
 
@@ -112,12 +112,13 @@ function ChannelSlider({
  * @prop {function} toggle Callback for toggling on/off.
  */
 function ChannelVisibilityCheckbox({ color, checked, toggle }) {
+  const classes = useCheckboxStyles();
   return (
     <Checkbox
       onChange={toggle}
       checked={checked}
-      // height attribute needed to solve: https://github.com/vitessce/vitessce/issues/833
-      style={{ color, '&$checked': { color }, height: '100% !important' }}
+      classes={classes}
+      style={{ color, '&$checked': { color } }}
     />
   );
 }

--- a/src/components/layer-controller/LayerOptions.js
+++ b/src/components/layer-controller/LayerOptions.js
@@ -3,11 +3,12 @@ import range from 'lodash/range';
 import Grid from '@material-ui/core/Grid';
 import Slider from '@material-ui/core/Slider';
 import InputLabel from '@material-ui/core/InputLabel';
-import Select from '@material-ui/core/Select';
+import NativeSelect from '@material-ui/core/NativeSelect';
 import Checkbox from '@material-ui/core/Checkbox';
 
 import { COLORMAP_OPTIONS } from '../utils';
 import { DEFAULT_RASTER_DOMAIN_TYPE } from '../spatial/constants';
+import { useCheckboxStyles } from './styles';
 
 const DOMAIN_OPTIONS = ['Full', 'Min/Max'];
 
@@ -19,8 +20,7 @@ const DOMAIN_OPTIONS = ['Full', 'Min/Max'];
  */
 function ColormapSelect({ value, inputId, handleChange }) {
   return (
-    <Select
-      native
+    <NativeSelect
       onChange={e => handleChange(e.target.value === '' ? null : e.target.value)}
       value={value}
       inputProps={{ name: 'colormap', id: inputId }}
@@ -32,15 +32,16 @@ function ColormapSelect({ value, inputId, handleChange }) {
           {name}
         </option>
       ))}
-    </Select>
+    </NativeSelect>
   );
 }
 
 function TransparentColorCheckbox({ value, handleChange }) {
+  const classes = useCheckboxStyles();
   return (
     <Checkbox
-      // height attribute needed to solve: https://github.com/vitessce/vitessce/issues/833
-      style={{ float: 'left', padding: 0, height: '100% !important' }}
+      classes={classes}
+      style={{ float: 'left', padding: 0 }}
       color="default"
       onChange={() => {
         if (value) {
@@ -83,8 +84,7 @@ function OpacitySlider({ value, handleChange }) {
  */
 function SliderDomainSelector({ value, inputId, handleChange }) {
   return (
-    <Select
-      native
+    <NativeSelect
       onChange={e => handleChange(e.target.value)}
       value={value}
       inputProps={{ name: 'domain-selector', id: inputId }}
@@ -95,7 +95,7 @@ function SliderDomainSelector({ value, inputId, handleChange }) {
           {name}
         </option>
       ))}
-    </Select>
+    </NativeSelect>
   );
 }
 

--- a/src/components/layer-controller/VectorLayerController.js
+++ b/src/components/layer-controller/VectorLayerController.js
@@ -5,7 +5,7 @@ import Checkbox from '@material-ui/core/Checkbox';
 import Paper from '@material-ui/core/Paper';
 import Typography from '@material-ui/core/Typography';
 import Slider from '@material-ui/core/Slider';
-import { useExpansionPanelStyles } from './styles';
+import { useExpansionPanelStyles, useCheckboxStyles } from './styles';
 
 export default function VectorLayerController(props) {
   const {
@@ -31,10 +31,11 @@ export default function VectorLayerController(props) {
     handleLayerChange({ ...layer, visible: v });
   }
 
-  const classes = useExpansionPanelStyles();
+  const expansionClasses = useExpansionPanelStyles();
+  const checkboxClasses = useCheckboxStyles();
   return (
     <Grid item style={{ marginTop: '10px' }}>
-      <Paper className={classes.root}>
+      <Paper className={expansionClasses.root}>
         <Typography
           style={{
             paddingTop: '15px',
@@ -47,8 +48,8 @@ export default function VectorLayerController(props) {
         <Grid container direction="row" justify="space-between">
           <Grid item xs={2}>
             <Checkbox
+              classes={checkboxClasses}
               color="primary"
-              style={{ height: '100% !important' }}
               checked={isOn}
               onChange={(e, v) => handleCheckBoxChange(v)}
             />

--- a/src/components/layer-controller/styles.js
+++ b/src/components/layer-controller/styles.js
@@ -1,27 +1,5 @@
 import { makeStyles } from '@material-ui/core/styles';
 
-export const useOptionStyles = makeStyles(theme => ({
-  paper: {
-    backgroundColor: theme.palette.background.paper,
-  },
-  span: {
-    width: '70px',
-    textAlign: 'center',
-    paddingLeft: '2px',
-    paddingRight: '2px',
-  },
-  colors: {
-    '&:hover': {
-      backgroundColor: 'transparent',
-    },
-    paddingLeft: '2px',
-    paddingRight: '2px',
-  },
-  popper: {
-    zIndex: 4,
-  },
-}));
-
 export const useExpansionPanelStyles = makeStyles(theme => ({
   root: {
     paddingLeft: theme.spacing(1),
@@ -51,6 +29,15 @@ export const useExpansionPanelSummaryStyles = makeStyles(theme => ({
   expandIcon: {
     '&$expanded': {
       top: theme.spacing(-1.3),
+    },
+  },
+}));
+
+export const useCheckboxStyles = makeStyles(() => ({
+  root: {
+    // height attribute needed to solve: https://github.com/vitessce/vitessce/issues/833
+    '& input': {
+      height: '100% !important',
     },
   },
 }));

--- a/src/components/shared-plot-options/CellColorEncodingOption.js
+++ b/src/components/shared-plot-options/CellColorEncodingOption.js
@@ -1,5 +1,5 @@
 import React from 'react';
-import Select from '@material-ui/core/Select';
+import NativeSelect from '@material-ui/core/NativeSelect';
 import TableCell from '@material-ui/core/TableCell';
 import TableRow from '@material-ui/core/TableRow';
 import { capitalize } from '../../utils';
@@ -26,8 +26,7 @@ export default function CellColorEncodingOption(props) {
         {observationsLabelNice} Color Encoding
       </TableCell>
       <TableCell className={classes.inputCell}>
-        <Select
-          native
+        <NativeSelect
           className={classes.select}
           value={cellColorEncoding}
           onChange={handleColorEncodingChange}
@@ -37,7 +36,7 @@ export default function CellColorEncodingOption(props) {
         >
           <option value="cellSetSelection">Cell Sets</option>
           <option value="geneSelection">Gene Expression</option>
-        </Select>
+        </NativeSelect>
       </TableCell>
     </TableRow>
   );


### PR DESCRIPTION
This is a PR into your PR #903. In this I added the `useCheckboxStyles` to target the rule to the `input` element within the `<Checkbox />` component. I also wrapped the `<VitessceGrid` component with `ScopedCssBaseline` from MUI which hopefully will prevent future issues if people try to embed the Vitessce component into apps with global non-specific CSS rules (besides `rem` units which are trickier https://github.com/vitessce/vitessce-python/pull/57#issuecomment-808510301).

The switch from `<Select native` to `<NativeSelect` is not really necessary, but I noticed that it was recommended by MUI while I was looking into the other issues. https://material-ui.com/api/native-select/

https://github.com/vitessce/vitessce-python/pull/57 goes along with this.