### PR TITLE
Allow for Scaling of the Translation and Matrix using Physical Size

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 - Fixed interleaved image not dispalying bug.
 - Fix `layerController` checkbox `height` css being overriden in Jupyter Lab.
 - Add the `ScopedCssBaseline` component from the Material UI library to reset the CSS within the Vitessce widget.
+- Allow `usePhysicalSizeScaling` to be used in conjunction with a matrix
 
 ## [1.1.7](https://www.npmjs.com/package/vitessce/v/1.1.7) - 2021-03-24
 

--- a/src/loaders/RasterJsonLoader.js
+++ b/src/loaders/RasterJsonLoader.js
@@ -91,7 +91,9 @@ export default class RasterLoader extends JsonLoader {
       return Promise.reject(payload);
     }
     const { data: raster } = payload;
-    const { images, renderLayers, usePhysicalSizeScaling = false } = raster;
+    const {
+      images, renderLayers, usePhysicalSizeScaling = false, scaleTranslation = true,
+    } = raster;
 
     // Get image name and URL tuples.
     const urls = images
@@ -114,6 +116,7 @@ export default class RasterLoader extends JsonLoader {
       imagesWithLoaderCreators,
       renderLayers,
       usePhysicalSizeScaling,
+      scaleTranslation,
     );
 
     const coordinationValues = {

--- a/src/schemas/raster.schema.json
+++ b/src/schemas/raster.schema.json
@@ -109,6 +109,7 @@
   "properties": {
     "schemaVersion": { "type": "string" },
     "usePhysicalSizeScaling": { "type": "boolean", "description": "Default is false: passing true in will infer scaling from the reported physcial size" },
+    "scaleTranslation": { "type": "boolean", "description": "Default is true: passing false in will cause the physical size scaling not to be applied to the metadata.transform.matrix" },
     "renderLayers": { "type": "array", "items": { "type": "string" } },
     "images": {
       "type": "array",


### PR DESCRIPTION
From Heath
```
My images do have the pixel res. embedded
3:12
but the transformations I use are in physical coordinates ( i.e., the translation elements say "translate 200 µm" rather than 200 px)
3:12
So I had to compose the pixel scaling transform with the transform for it to work
```
So this PR allows the matrix to automatically be scaled by the physical size, which I think is cleaner and makes more sense anyway.  They should not have been mutually exclusive.  I also don't think this affects "backward compatibility" except for those who were using the matrix with the scale pre-multiplied in which case they would now need to set `usePhysicalSizeScaling` to `false`.  This is a price I am willing to pay though