### PR TITLE
Opacity Slider for Closed LayerController - addition of label

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 ## In Progress
 
 ### Added
-- Add opacity slider when `layerController` is closed.
+- Add opacity slider when `layerController` is closed, with label.
 
 ### Changed
 - Don't request `zattrs` every time when running `loadGeneSelection` on the AnnData loader.

--- a/src/components/layer-controller/RasterLayerController.js
+++ b/src/components/layer-controller/RasterLayerController.js
@@ -5,6 +5,7 @@ import Grid from '@material-ui/core/Grid';
 import Button from '@material-ui/core/Button';
 import AddIcon from '@material-ui/icons/Add';
 import Slider from '@material-ui/core/Slider';
+import InputLabel from '@material-ui/core/InputLabel';
 
 import ExpansionPanel from '@material-ui/core/ExpansionPanel';
 import ExpansionPanelSummary from '@material-ui/core/ExpansionPanelSummary';
@@ -14,7 +15,11 @@ import ExpandMoreIcon from '@material-ui/icons/ExpandMore';
 import ChannelController from './ChannelController';
 import LayerOptions from './LayerOptions';
 
-import { useExpansionPanelStyles, useExpansionPanelSummaryStyles } from './styles';
+import {
+  useExpansionPanelStyles,
+  useExpansionPanelSummaryStyles,
+  useSmallInputLabelStyles,
+} from './styles';
 import { GLOBAL_LABELS } from '../spatial/constants';
 import { getSourceFromLoader, isRgb } from '../../utils';
 import { DOMAINS } from './constants';
@@ -255,6 +260,8 @@ export default function RasterLayerController(props) {
 
   const classes = useExpansionPanelStyles();
   const summaryClasses = useExpansionPanelSummaryStyles();
+  const closedOpacityLabelClasses = useSmallInputLabelStyles();
+
   return (
     <ExpansionPanel
       className={classes.root}
@@ -270,17 +277,23 @@ export default function RasterLayerController(props) {
         <Grid container direction="column" m={1} justify="center">
           <Grid item>{name}</Grid>
           {!isExpanded && (
-            <Grid item>
-              <Slider
-                value={opacity}
-                onChange={(e, v) => setOpacity(v)}
-                valueLabelDisplay="auto"
-                getAriaLabel={() => 'opacity slider'}
-                min={0}
-                max={1}
-                step={0.01}
-                orientation="horizontal"
-              />
+            <Grid container direction="row" alignItems="center" justify="center">
+              <Grid item xs={6}>
+                <InputLabel htmlFor={`layer-${name}-opacity-closed`} classes={closedOpacityLabelClasses}>Opacity:</InputLabel>
+              </Grid>
+              <Grid item xs={6}>
+                <Slider
+                  id={`layer-${name}-opacity-closed`}
+                  value={opacity}
+                  onChange={(e, v) => setOpacity(v)}
+                  valueLabelDisplay="auto"
+                  getAriaLabel={() => 'opacity slider'}
+                  min={0}
+                  max={1}
+                  step={0.01}
+                  orientation="horizontal"
+                />
+              </Grid>
             </Grid>
           )}
         </Grid>

--- a/src/components/layer-controller/styles.js
+++ b/src/components/layer-controller/styles.js
@@ -41,3 +41,9 @@ export const useCheckboxStyles = makeStyles(() => ({
     },
   },
 }));
+
+export const useSmallInputLabelStyles = makeStyles(() => ({
+  root: {
+    fontSize: '14px',
+  },
+}));


### PR DESCRIPTION
I'm not sure if this is the best solution, but with the layer closed the functionality of the slider seemed unclear, so this PR adds a label to your PR.

![Screen Shot 2021-04-16 at 5 48 55 PM](https://user-images.githubusercontent.com/7525285/115087432-283cd080-9edc-11eb-86b3-4120b12bf231.png)

Maybe in the future a photoshop-like interface in the closed state would be even more compact 
<img width="280" alt="1804244_fix" src="https://user-images.githubusercontent.com/7525285/115087651-88cc0d80-9edc-11eb-9348-e9eb9d133f50.png">
