### PR TITLE
Violin Plot Styling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 
 ### Changed
 - Fix `cellSetColor` null bug.
+- Allow for autosizing `CellSetExpressionPlot` bottom margin depending on axis labels.
 
 ## [1.1.8](https://www.npmjs.com/package/vitessce/v/1.1.8) - 2021-03-31
 

--- a/src/components/sets/CellSetExpressionPlot.js
+++ b/src/components/sets/CellSetExpressionPlot.js
@@ -31,9 +31,15 @@ export default function CellSetExpressionPlot(props) {
     width,
     height,
     marginRight = 90,
-    marginBottom = 120,
+    marginBottom,
   } = props;
-
+  // Get the max characters in an axis label for autsizing the bottom margin.
+  const maxCharactersForLabel = data.reduce((acc, val) => {
+    // eslint-disable-next-line no-param-reassign
+    acc = acc === undefined || val.set.length > acc ? val.set.length : acc;
+    return acc;
+  }, 0);
+  const autoMarginBottom = marginBottom || Math.max(maxCharactersForLabel * 6, 50);
   // Manually set the color scale so that Vega-Lite does
   // not choose the colors automatically.
   const colorScale = {
@@ -42,7 +48,7 @@ export default function CellSetExpressionPlot(props) {
   };
 
   const plotWidth = clamp(width - marginRight, 10, Infinity);
-  const plotHeight = clamp(height - marginBottom, 10, Infinity);
+  const plotHeight = clamp(height - autoMarginBottom, 10, Infinity);
 
   const numBands = colors.length;
   const bandWidth = plotWidth / numBands;

--- a/src/components/sets/CellSetExpressionPlot.js
+++ b/src/components/sets/CellSetExpressionPlot.js
@@ -20,7 +20,7 @@ import { colorArrayToString } from './utils';
  * By default, 90.
  * @param {number} props.marginBottom The size of the margin
  * on the bottom of the plot, to account for long x-axis labels.
- * By default, 50.
+ * Default is allowing the component to automatically determine the margin.
  */
 export default function CellSetExpressionPlot(props) {
   const {

--- a/src/components/sets/CellSetExpressionPlot.js
+++ b/src/components/sets/CellSetExpressionPlot.js
@@ -39,7 +39,7 @@ export default function CellSetExpressionPlot(props) {
     acc = acc === undefined || val.set.length > acc ? val.set.length : acc;
     return acc;
   }, 0);
-  const autoMarginBottom = marginBottom || Math.max(maxCharactersForLabel * 6, 50);
+  const autoMarginBottom = marginBottom || Math.max(maxCharactersForLabel * 7, 50);
   // Manually set the color scale so that Vega-Lite does
   // not choose the colors automatically.
   const colorScale = {


### PR DESCRIPTION
Fixes #922.  

The 7 and the 50 come from experimenting but both seem to work very well, both for long and short labels.  I tried fiddling around with vega's "auto sizing" but couldn't really get it going and I'm not an expert in Vega.  If this isn't perfect, it does seem like an improvement.
 
For example, you can now see the "Cell Set" label in the Linnarsson example for the longer labels:
<img width="419" alt="Screen Shot 2021-04-28 at 10 51 43 AM" src="https://user-images.githubusercontent.com/43999641/116424717-bfc0ee00-a80f-11eb-81e6-ce80cf9db2c0.png">
whereas previously you could not:
<img width="425" alt="Screen Shot 2021-04-28 at 10 52 22 AM" src="https://user-images.githubusercontent.com/43999641/116424826-d49d8180-a80f-11eb-8640-6eea5d1be430.png">
Also, now the small labels fill the space:
<img width="434" alt="Screen Shot 2021-04-28 at 10 52 56 AM" src="https://user-images.githubusercontent.com/43999641/116424954-eda63280-a80f-11eb-8b2b-e27caa9e12a9.png">
whereas previously they did not:
<img width="429" alt="Screen Shot 2021-04-28 at 10 52 48 AM" src="https://user-images.githubusercontent.com/43999641/116424980-f434aa00-a80f-11eb-998c-4e6e0d2f4332.png">

Here's the difference for the example from the portal:
<img width="712" alt="Screen Shot 2021-04-28 at 10 54 50 AM" src="https://user-images.githubusercontent.com/43999641/116425319-34942800-a810-11eb-89a3-9d8c224813b3.png">
<img width="710" alt="Screen Shot 2021-04-28 at 10 54 34 AM" src="https://user-images.githubusercontent.com/43999641/116425322-352cbe80-a810-11eb-97e7-2db07e3c6295.png">


