### PR TITLE
Fix Margin Bottom for Violin Plot (Again)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 - Fix `cellSetColor` null bug.
 - Improve violin plot performance by making `useExpressionByCellSet` faster.
 - Allow for autosizing `CellSetExpressionPlot` bottom margin depending on axis labels.
+- Make margin bottom of `CellSetExpressionPlot` proportional to the square root of the number of characters because the `labelAngle` is 45.
 
 ## [1.1.8](https://www.npmjs.com/package/vitessce/v/1.1.8) - 2021-03-31
 

--- a/src/components/sets/CellSetExpressionPlot.js
+++ b/src/components/sets/CellSetExpressionPlot.js
@@ -40,7 +40,7 @@ export default function CellSetExpressionPlot(props) {
     return acc;
   }, 0);
   // Use a square-root term because the angle of the labels is 45 degrees (see below)
-  // so the perpindicular distance to the bottom of the labels is proportional to the
+  // so the perpendicular distance to the bottom of the labels is proportional to the
   // square root of the length of the labels along the imaginary hypotenuse.
   // 30 is an estimate of the pixel size of a given character and seems to work well.
   const autoMarginBottom = marginBottom

--- a/src/components/sets/CellSetExpressionPlot.js
+++ b/src/components/sets/CellSetExpressionPlot.js
@@ -39,7 +39,12 @@ export default function CellSetExpressionPlot(props) {
     acc = acc === undefined || val.set.length > acc ? val.set.length : acc;
     return acc;
   }, 0);
-  const autoMarginBottom = marginBottom || Math.max(maxCharactersForLabel * 7, 50);
+  // Use a square-root term because the angle of the labels is 45 degrees (see below)
+  // so the perpindicular distance to the bottom of the labels is proportional to the
+  // square root of the length of the labels along the imaginary hypotenuse.
+  // 30 is an estimate of the pixel size of a given character and seems to work well.
+  const autoMarginBottom = marginBottom
+    || 30 + Math.sqrt(maxCharactersForLabel / 2) * 30;
   // Manually set the color scale so that Vega-Lite does
   // not choose the colors automatically.
   const colorScale = {


### PR DESCRIPTION
Follow up to #924 after noticing an issue on the [Satija demo dataset](https://s3.amazonaws.com/vitessce-data/demos/2021-05-07/748cb9b/index.html?url=data:,%7B%22version%22:%20%221.0.1%22,%22name%22:%20%22Human%20Fetal%20Development%22,%22datasets%22:%20%5B%7B%22uid%22:%20%22human-fetus%22,%22name%22:%20%22Human%20Fetal%20Development%22,%22files%22:%20%5B%7B%22type%22:%20%22cells%22,%22fileType%22:%20%22anndata-cells.zarr%22,%22url%22:%20%22https://azimuth-vitessce.s3.us-west-2.amazonaws.com/human-fetus/vitessce_ref.zarr%22,%22options%22:%20%7B%22mappings%22:%20%7B%22UMAP%22:%20%7B%22key%22:%20%22obsm/X_umap%22,%22dims%22:%20%5B0,1%5D%7D%7D,%22factors%22:%20%5B%22obs/annotation.l1%22,%22obs/annotation.l2%22,%22obs/organ%22%5D%7D%7D,%7B%22type%22:%20%22cell-sets%22,%22fileType%22:%20%22anndata-cell-sets.zarr%22,%22url%22:%20%22https://azimuth-vitessce.s3.us-west-2.amazonaws.com/human-fetus/vitessce_ref.zarr%22,%22options%22:%20%5B%7B%22groupName%22:%20%22annotation.l1%22,%22setName%22:%20%22obs/annotation.l1%22%7D,%7B%22groupName%22:%20%22annotation.l2%22,%22setName%22:%20%22obs/annotation.l2%22%7D,%7B%22groupName%22:%20%22organ%22,%22setName%22:%20%22obs/organ%22%7D%5D%7D,%7B%22type%22:%20%22expression-matrix%22,%22fileType%22:%20%22anndata-expression-matrix.zarr%22,%22url%22:%20%22https://azimuth-vitessce.s3.us-west-2.amazonaws.com/human-fetus/vitessce_ref.zarr%22,%22options%22:%20%7B%22matrix%22:%20%22X%22%7D%7D%5D%7D%5D,%22initStrategy%22:%20%22auto%22,%22coordinationSpace%22:%20%7B%22embeddingType%22:%20%7B%22UMAP%22:%20%22UMAP%22%7D,%22embeddingCellRadius%22:%20%7B%22UMAP%22:%200.03%7D,%22embeddingCellSetLabelsVisible%22:%20%7B%22UMAP%22:%20false%7D,%22embeddingCellSetLabelSize%22:%20%7B%22UMAP%22:%2010%7D%7D,%22layout%22:%20%5B%7B%22component%22:%20%22cellSets%22,%22h%22:%203,%22w%22:%203,%22x%22:%209,%22y%22:%200,%22coordinationScopes%22:%20%7B%7D%7D,%7B%22component%22:%20%22genes%22,%22h%22:%203,%22w%22:%203,%22x%22:%209,%22y%22:%203,%22coordinationScopes%22:%20%7B%7D%7D,%7B%22component%22:%20%22scatterplot%22,%22h%22:%206,%22w%22:%205,%22x%22:%200,%22y%22:%200,%22coordinationScopes%22:%20%7B%22embeddingType%22:%20%22UMAP%22,%22embeddingCellRadius%22:%20%22UMAP%22,%22embeddingCellSetLabelsVisible%22:%20%22UMAP%22,%22embeddingCellSetLabelSize%22:%20%22UMAP%22%7D%7D,%7B%22component%22:%20%22cellSetExpression%22,%22h%22:%206,%22w%22:%204,%22x%22:%205,%22y%22:%200,%22coordinationScopes%22:%20%7B%7D%7D%5D%7D) - see the comment in the code about why this is more correct.  I'll merge this into the release branch #931 once it's been merged