### PR TITLE
Fix Cell/Raster Initial View State

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 
 ### Changed
 - Use GH Action for Cypress specifically due to random failures on OME-TIFF example.
+- Use raster loader for initial view state when present instead of cells.
 
 ## [1.1.9](https://www.npmjs.com/package/vitessce/v/1.1.9) - 2021-05-07
 

--- a/src/components/spatial/SpatialSubscriber.js
+++ b/src/components/spatial/SpatialSubscriber.js
@@ -160,6 +160,7 @@ export default function SpatialSubscriber(props) {
         height,
         cells,
         imageLayerLoaders,
+        useRaster: Boolean(loaders[dataset].loaders.raster),
       });
       setTargetX(initialTargetX);
       setTargetY(initialTargetY);

--- a/src/components/spatial/utils.js
+++ b/src/components/spatial/utils.js
@@ -341,13 +341,17 @@ export function getInitialSpatialTargets({
     if (xRange === 0) {
       // The fall back is the firt cell's polygon coordinates, if the original difference
       // of the extent is 0 i.e the centroids are all on the same axis.
-      xExtent = extent(cellValues[0].poly, i => i[0]);
+      const polygonExtents = cellValues.map(cell => extent(cell.poly, i => i[0]));
+      xExtent = [Math.min(...polygonExtents.map(i => i[0])),
+        Math.max(...polygonExtents.map(i => i[1]))];
       xRange = xExtent[1] - xExtent[0];
     }
     if (yRange === 0) {
       // The fall back is the firt cell's polygon coordinates, if the original difference
       // of the extent is 0 i.e the centroids are all on the same axis.
-      yExtent = extent(cellValues[0].poly, i => i[1]);
+      const polygonExtents = cellValues.map(cell => extent(cell.poly, i => i[1]));
+      yExtent = [Math.min(...polygonExtents.map(i => i[0])),
+        Math.max(...polygonExtents.map(i => i[1]))];
       yRange = yExtent[1] - yExtent[0];
     }
     initialTargetX = xExtent[0] + xRange / 2;

--- a/src/components/spatial/utils.js
+++ b/src/components/spatial/utils.js
@@ -338,20 +338,22 @@ export function getInitialSpatialTargets({
     let yExtent = extent(cellCoordinates, c => c[1]);
     let xRange = xExtent[1] - xExtent[0];
     let yRange = yExtent[1] - yExtent[0];
+    const getViewExtentFromPolygonExtents = extents => [
+      Math.min(...extents.map(i => i[0])),
+      Math.max(...extents.map(i => i[1])),
+    ];
     if (xRange === 0) {
-      // The fall back is the firt cell's polygon coordinates, if the original difference
-      // of the extent is 0 i.e the centroids are all on the same axis.
-      const polygonExtents = cellValues.map(cell => extent(cell.poly, i => i[0]));
-      xExtent = [Math.min(...polygonExtents.map(i => i[0])),
-        Math.max(...polygonExtents.map(i => i[1]))];
+      // The fall back is the cells' polygon coordinates, if the original range
+      // is 0 i.e the centroids are all on the same axis.
+      const polygonExtentsX = cellValues.map(cell => extent(cell.poly, i => i[0]));
+      xExtent = getViewExtentFromPolygonExtents(polygonExtentsX);
       xRange = xExtent[1] - xExtent[0];
     }
     if (yRange === 0) {
-      // The fall back is the firt cell's polygon coordinates, if the original difference
-      // of the extent is 0 i.e the centroids are all on the same axis.
-      const polygonExtents = cellValues.map(cell => extent(cell.poly, i => i[1]));
-      yExtent = [Math.min(...polygonExtents.map(i => i[0])),
-        Math.max(...polygonExtents.map(i => i[1]))];
+      // The fall back is the first cells' polygon coordinates, if the original range
+      // is 0 i.e the centroids are all on the same axis.
+      const polygonExtentsY = cellValues.map(cell => extent(cell.poly, i => i[1]));
+      yExtent = getViewExtentFromPolygonExtents(polygonExtentsY);
       yRange = yExtent[1] - yExtent[0];
     }
     initialTargetX = xExtent[0] + xRange / 2;

--- a/src/components/spatial/utils.js
+++ b/src/components/spatial/utils.js
@@ -334,10 +334,22 @@ export function getInitialSpatialTargets({
     && cellValues[0].xy
     && !useRaster) {
     const cellCoordinates = cellValues.map(c => c.xy);
-    const xExtent = extent(cellCoordinates, c => c[0]);
-    const yExtent = extent(cellCoordinates, c => c[1]);
-    const xRange = xExtent[1] - xExtent[0];
-    const yRange = yExtent[1] - yExtent[0];
+    let xExtent = extent(cellCoordinates, c => c[0]);
+    let yExtent = extent(cellCoordinates, c => c[1]);
+    let xRange = xExtent[1] - xExtent[0];
+    let yRange = yExtent[1] - yExtent[0];
+    if (xRange === 0) {
+      // The fall back is the firt cell's polygon coordinates, if the original difference
+      // of the extent is 0 i.e the centroids are all on the same axis.
+      xExtent = extent(cellValues[0].poly, i => i[0]);
+      xRange = xExtent[1] - xExtent[0];
+    }
+    if (yRange === 0) {
+      // The fall back is the firt cell's polygon coordinates, if the original difference
+      // of the extent is 0 i.e the centroids are all on the same axis.
+      yExtent = extent(cellValues[0].poly, i => i[1]);
+      yRange = yExtent[1] - yExtent[0];
+    }
     initialTargetX = xExtent[0] + xRange / 2;
     initialTargetY = yExtent[0] + yRange / 2;
     initialZoom = Math.log2(Math.min(width / xRange, height / yRange)) - zoomBackoff;

--- a/src/components/spatial/utils.js
+++ b/src/components/spatial/utils.js
@@ -301,6 +301,7 @@ export function getInitialSpatialTargets({
   height,
   cells,
   imageLayerLoaders,
+  useRaster,
 }) {
   let initialTargetX = -Infinity;
   let initialTargetY = -Infinity;
@@ -308,7 +309,7 @@ export function getInitialSpatialTargets({
   // Some backoff from completely filling the screen.
   const zoomBackoff = 0.1;
   const cellValues = Object.values(cells);
-  if (imageLayerLoaders.length > 0) {
+  if (imageLayerLoaders.length > 0 && useRaster) {
     for (let i = 0; i < imageLayerLoaders.length; i += 1) {
       const viewSize = { height, width };
       const { target, zoom: newViewStateZoom } = getDefaultInitialViewState(
@@ -330,7 +331,8 @@ export function getInitialSpatialTargets({
   } else if (cellValues.length > 0
     // Only use cellValues in quadtree calculation if there is
     // centroid data in the cells (i.e not just ids).
-    && cellValues[0].xy) {
+    && cellValues[0].xy
+    && !useRaster) {
     const cellCoordinates = cellValues.map(c => c.xy);
     const xExtent = extent(cellCoordinates, c => c[0]);
     const yExtent = extent(cellCoordinates, c => c[1]);


### PR DESCRIPTION
Fixes #937

This PR does two things to fix the issue:
1. If there is a raster image, use it for the initial view state.  This is to prevent the image from looking "punched in" when there are fewer cells like: https://portal.hubmapconsortium.org/browse/dataset/243bf6ec414b3e16695bef1e97809b61 (R001_X003_Y001)
2. If there is only one cell (or colinear cells on either axis), use the polygon bounds to determine the initial view state