### PR TITLE
Fix `bitmask` Layer Add/Remove Bug

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 ### Changed
 - Use GH Action for Cypress specifically due to random failures on OME-TIFF example.
 - Use raster loader for initial view state when present instead of cells.
+- Fix bug where adding/removing layers only adds a `bitmask` controller.
 
 ## [1.1.9](https://www.npmjs.com/package/vitessce/v/1.1.9) - 2021-05-07
 

--- a/src/components/layer-controller/LayerControllerSubscriber.js
+++ b/src/components/layer-controller/LayerControllerSubscriber.js
@@ -85,6 +85,7 @@ function LayerControllerSubscriber(props) {
       modelMatrix: imageLayerMeta[index]?.metadata?.transform?.matrix,
       ...DEFAULT_RASTER_LAYER_PROPS,
       channels: newChannels,
+      type: imageLayerMeta[index]?.metadata?.isBitmask ? 'bitmask' : 'raster',
     };
     const newLayers = [...rasterLayers, newLayer];
     setRasterLayers(newLayers);


### PR DESCRIPTION
Found a bug while doing release testing for #939.  If you remove and then re-add (or just add) an image layer with the current demo in #939, it will always add a `bitmask` controller instead of `raster` regardless of the actual image.  This should be the fix for that.