### PR TITLE
Fix Condition for Displaying Cells Layer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 ### Changed
 - Use GH Action for Cypress specifically due to random failures on OME-TIFF example.
 - Use raster loader for initial view state when present instead of cells.
+- Fix bug where polygons or centroids would show under the `bitmask`.
 
 ## [1.1.9](https://www.npmjs.com/package/vitessce/v/1.1.9) - 2021-05-07
 

--- a/src/components/layer-controller/LayerControllerSubscriber.js
+++ b/src/components/layer-controller/LayerControllerSubscriber.js
@@ -102,9 +102,10 @@ function LayerControllerSubscriber(props) {
     setRasterLayers(newLayers);
   }
 
-  const shouldWaitForRaster = loaders[dataset].loaders.raster;
+  const hasBitmask = (imageLayerMeta.length ? imageLayerMeta : [{ metadata: { isBitmask: true } }])
+    .every(l => !l?.metadata?.isBitmask);
   // Only want to show vector cells controller if there is no bitmask
-  const canShowCellVecmask = shouldWaitForRaster ? (rasterLayers || [{ type: 'bitmask' }]).findIndex(l => l.type === 'bitmask') < 0 : true;
+  const canShowCellVecmask = hasBitmask;
 
   return (
     <TitleInfo

--- a/src/components/layer-controller/LayerControllerSubscriber.js
+++ b/src/components/layer-controller/LayerControllerSubscriber.js
@@ -102,10 +102,11 @@ function LayerControllerSubscriber(props) {
     setRasterLayers(newLayers);
   }
 
-  const hasBitmask = (imageLayerMeta.length ? imageLayerMeta : [{ metadata: { isBitmask: true } }])
-    .every(l => !l?.metadata?.isBitmask);
+  const hasNoBitmask = (
+    imageLayerMeta.length ? imageLayerMeta : [{ metadata: { isBitmask: true } }]
+  ).every(l => !l?.metadata?.isBitmask);
   // Only want to show vector cells controller if there is no bitmask
-  const canShowCellVecmask = hasBitmask;
+  const canShowCellVecmask = hasNoBitmask;
 
   return (
     <TitleInfo

--- a/src/components/spatial/Spatial.js
+++ b/src/components/spatial/Spatial.js
@@ -383,16 +383,7 @@ class Spatial extends AbstractSpatialOrScatterplot {
   onUpdateCellsLayer() {
     const { layers } = this.props;
     const layerDef = (layers || []).find(layer => layer.type === 'cells');
-    const hasBitmaskLayers = (layers || []).find(
-      layer => layer.type === 'bitmask',
-    );
-    if (layerDef
-      && this.cellsEntries.length
-      // Only use cellsEntries in quadtree calculation if there is
-      // centroid data in the cells (i.e not just ids).
-      // eslint-disable-next-line no-unused-vars
-      && this.cellsEntries[0][1].xy
-      && !hasBitmaskLayers) {
+    if (layerDef) {
       this.cellsLayer = this.createCellsLayer(layerDef);
     } else {
       this.cellsLayer = null;

--- a/src/components/spatial/SpatialSubscriber.js
+++ b/src/components/spatial/SpatialSubscriber.js
@@ -142,7 +142,9 @@ export default function SpatialSubscriber(props) {
   );
 
   const layers = useMemo(() => {
-    // Only want to pass in cells once if there is not `bitmask`.
+    // Only want to pass in cells layer once if there is not `bitmask`.
+    // We pass in the cells data regardless because it is needed for selection,
+    // but the rendering layer itself is not needed.
     const canPassInCellsLayer = !imageLayerMeta.some(l => l?.metadata?.isBitmask);
     return [
       ...(moleculesLayer ? [{ ...moleculesLayer, type: 'molecules' }] : []),

--- a/src/components/spatial/SpatialSubscriber.js
+++ b/src/components/spatial/SpatialSubscriber.js
@@ -135,23 +135,22 @@ export default function SpatialSubscriber(props) {
     loaders, dataset, setItemIsReady, addUrl, false,
   );
   // eslint-disable-next-line no-unused-vars
-  const [raster, imageLayerLoaders] = useRasterData(
+  const [raster, imageLayerLoaders, imageLayerMeta] = useRasterData(
     loaders, dataset, setItemIsReady, addUrl, false,
     { setSpatialRasterLayers: setRasterLayers },
     { spatialRasterLayers: rasterLayers },
   );
 
   const layers = useMemo(() => {
-    const shouldWaitForRaster = loaders[dataset].loaders.raster;
-    // Only want to show cells once the dataset has loaded because centroids are often not visible.
-    const canPassInCellsLayer = shouldWaitForRaster ? rasterLayers : true;
+    // Only want to pass in cells once if there is not `bitmask`.
+    const canPassInCellsLayer = !imageLayerMeta.some(l => l?.metadata?.isBitmask);
     return [
       ...(moleculesLayer ? [{ ...moleculesLayer, type: 'molecules' }] : []),
       ...((cellsLayer && canPassInCellsLayer) ? [{ ...cellsLayer, type: 'cells' }] : []),
       ...(neighborhoodsLayer ? [{ ...neighborhoodsLayer, type: 'neighborhoods' }] : []),
       ...(rasterLayers ? rasterLayers.map(l => ({ ...l, type: l.type || 'raster' })) : []),
     ];
-  }, [cellsLayer, dataset, loaders, moleculesLayer, neighborhoodsLayer, rasterLayers]);
+  }, [cellsLayer, moleculesLayer, neighborhoodsLayer, rasterLayers, imageLayerMeta]);
 
   useEffect(() => {
     if ((typeof targetX !== 'number' || typeof targetY !== 'number')) {


### PR DESCRIPTION
Bug caught while doing release testing.

Previously the `cells` layer would show after the `bitmask` had been removed and the lasso was not showing properly, both because they relied on the `bitmask` layer being present - however that is not always true.  Thus instead we rely on the layer raster metadata for detecting `bitmask` presence so that even if it isn't loaded, it is still detected