### PR TITLE
Fix `cellColors` Assumed to be RGB (Can be RGBA)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 ### Changed
 - Use GH Action for Cypress specifically due to random failures on OME-TIFF example.
 - Use raster loader for initial view state when present instead of cells.
+- `bitmask` color texture creation assumed that `cellColors` prop was only rgb, but it can be rgba.
 
 ## [1.1.9](https://www.npmjs.com/package/vitessce/v/1.1.9) - 2021-05-07
 

--- a/src/components/spatial/Spatial.js
+++ b/src/components/spatial/Spatial.js
@@ -414,7 +414,7 @@ class Spatial extends AbstractSpatialOrScatterplot {
         if (id > 0) {
           const cellColor = this.props.cellColors.get(id);
           if (cellColor) {
-            color.data.set(cellColor, Number(id) * 3);
+            color.data.set(cellColor.slice(0, 3), Number(id) * 3);
           }
         }
       }


### PR DESCRIPTION
Another bug caught during release testing.  The cell colors can have opacity as well it appears but we don't use that information when creating the lookup texture for colors for the cells in the bitmask.