### PR TITLE
Fix Lasso Display Bug for Centroids.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 ### Changed
 - Use GH Action for Cypress specifically due to random failures on OME-TIFF example.
 - Use raster loader for initial view state when present instead of cells.
+- Fix condition for showing lasso with bitmask and/or centroids.
 
 ## [1.1.9](https://www.npmjs.com/package/vitessce/v/1.1.9) - 2021-05-07
 

--- a/src/components/shared-spatial-scatterplot/AbstractSpatialOrScatterplot.js
+++ b/src/components/shared-spatial-scatterplot/AbstractSpatialOrScatterplot.js
@@ -178,8 +178,9 @@ export default class AbstractSpatialOrScatterplot extends PureComponent {
     const { gl, tool } = this.state;
     const layers = this.getLayers();
 
-    const showCellSelectionTools = this.cellsLayer !== null || layerProps.findIndex(l => l.type === 'cells') > 0;
-    const showPanTool = this.cellsLayer !== null || layerProps.findIndex(l => l.type === 'bitmask') > 0;
+    const showCellSelectionTools = this.cellsLayer !== null
+      || (this.cellsEntries.length && this.cellsEntries[0][1].xy);
+    const showPanTool = this.cellsLayer !== null || layerProps.findIndex(l => l.type === 'bitmask' || l.type === 'raster') >= 0;
     // For large datasets, the visual quality takes only a small
     // hit in exchange for much better performance by setting this to false:
     // https://deck.gl/docs/api-reference/core/deck#usedevicepixels


### PR DESCRIPTION
Another bug caught during release testing.

Show the lasso if there is `cellsEntries` data with centroids or there is a `cellsLayer`.  I actually am not so sure about the correctness here - it seems like if there are just polygon coordinates and no centroids, there should be no selection option because selection relies on centroids at the moment.

Also the `findIndex` result should be greater than __or equal__ to 0 not just greater than (since not-found returns -1, not 0).