### PR TITLE
Worker Pool for Heatmap

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ### Added
 - Add support for bitmasks to `Spatial` component and raster schema.
+- Worker pool for processing heatmap tiles.
 
 ### Changed
 - Use GH Action for Cypress specifically due to random failures on OME-TIFF example.

--- a/src/Pool.js
+++ b/src/Pool.js
@@ -1,5 +1,3 @@
-import Worker from './heatmap.worker'; // eslint-disable-line import/no-unresolved
-
 // https://developer.mozilla.org/en-US/docs/Web/API/NavigatorConcurrentHardware/hardwareConcurrency
 // We need to give a different way of getting this for safari, so 4 is probably a safe bet
 // for parallel processing in the meantime.  More can't really hurt since they'll just block
@@ -13,44 +11,20 @@ const defaultPoolSize = typeof navigator !== 'undefined' ? navigator.hardwareCon
 export default class Pool {
   /**
    * @constructor
-   * @param {Number} size The size of the pool. Defaults to the number of CPUs
-   *                      available. When this parameter is `null` or 0, then the
-   *                      decoding will be done in the main thread.
+   * @param {object} Worker The worker class to be used for processing;
    */
-  constructor(size = defaultPoolSize) {
+  constructor(Worker) {
     this.workers = [];
     this.idleWorkers = [];
     this.waitQueue = [];
     this.decoder = null;
 
     // eslint-disable-next-line no-plusplus
-    for (let i = 0; i < size; ++i) {
+    for (let i = 0; i < defaultPoolSize; ++i) {
       const w = new Worker();
       this.workers.push(w);
       this.idleWorkers.push(w);
     }
-  }
-
-  /**
-   * Decode the given block of bytes with the set compression method.
-   * @param {ArrayBuffer} buffer the array buffer of bytes to decode.
-   * @returns {Promise.<ArrayBuffer>} the decoded result as a `Promise`
-   */
-  async decode(args) {
-    const currentWorker = await this.waitForWorker();
-    return new Promise((resolve, reject) => {
-      currentWorker.onmessage = (event) => {
-        // this.workers.push(currentWorker);
-        this.finishTask(currentWorker);
-        resolve(event.data);
-      };
-      currentWorker.onerror = (error) => {
-        // this.workers.push(currentWorker);
-        this.finishTask(currentWorker);
-        reject(error);
-      };
-      currentWorker.postMessage(['getTile', args], [args.data]);
-    });
   }
 
   async waitForWorker() {

--- a/src/Pool.js
+++ b/src/Pool.js
@@ -27,6 +27,11 @@ export default class Pool {
     }
   }
 
+  // eslint-disable-next-line class-methods-use-this
+  async process() {
+    throw new Error('Pool needs to implement "process" method');
+  }
+
   async waitForWorker() {
     const idleWorker = this.idleWorkers.pop();
     if (idleWorker) {

--- a/src/Pool.js
+++ b/src/Pool.js
@@ -11,7 +11,7 @@ const defaultPoolSize = typeof navigator !== 'undefined' ? navigator.hardwareCon
 export default class Pool {
   /**
    * @constructor
-   * @param {object} Worker The worker class to be used for processing;
+   * @param {object} Worker The worker class to be used for processing.
    */
   constructor(Worker) {
     this.workers = [];

--- a/src/components/heatmap/Heatmap.js
+++ b/src/components/heatmap/Heatmap.js
@@ -307,7 +307,7 @@ const Heatmap = forwardRef((props, deckRef) => {
         transpose,
         data: matrix.buffer.slice(),
       })));
-      const decode = async () => {
+      const process = async () => {
         const tiles = await Promise.all(promises.flat());
         tilesRef.current = tiles.map(i => i.tile);
         incTileIteration();
@@ -318,7 +318,7 @@ const Heatmap = forwardRef((props, deckRef) => {
           return prev.slice(currIndex + 1, prev.length);
         });
       };
-      decode();
+      process();
     }
   }, [axisLeftLabels, axisTopLabels, backlog, expression, transpose, xTiles, yTiles, workerPool]);
 

--- a/src/components/heatmap/Heatmap.js
+++ b/src/components/heatmap/Heatmap.js
@@ -312,7 +312,11 @@ const Heatmap = forwardRef((props, deckRef) => {
         tilesRef.current = tiles.map(i => i.tile);
         incTileIteration();
         dataRef.current = new Uint8Array(tiles[0].buffer);
-        setBacklog([]);
+        const { curr: currWork } = tiles[0];
+        setBacklog((prev) => {
+          const currIndex = prev.indexOf(currWork);
+          return prev.slice(currIndex + 1, prev.length);
+        });
       };
       decode();
     }

--- a/src/components/heatmap/Heatmap.js
+++ b/src/components/heatmap/Heatmap.js
@@ -277,12 +277,11 @@ const Heatmap = forwardRef((props, deckRef) => {
     // to help identify where in the list it is located
     // after the worker thread asynchronously sends the data back
     // to this thread.
-    // eslint-disable-next-line no-unused-expressions
-    axisTopLabels
-    && axisLeftLabels
-    && xTiles
-    && yTiles
-    && setBacklog(prev => ([...prev, uuidv4()]));
+    if (
+      axisTopLabels && axisLeftLabels && xTiles && yTiles
+    ) {
+      setBacklog(prev => [...prev, uuidv4()]);
+    }
   }, [dataRef, expression, axisTopLabels, axisLeftLabels, xTiles, yTiles]);
 
   // When the backlog has updated, a new worker job can be submitted if:

--- a/src/components/heatmap/Heatmap.js
+++ b/src/components/heatmap/Heatmap.js
@@ -295,7 +295,6 @@ const Heatmap = forwardRef((props, deckRef) => {
     const curr = backlog[backlog.length - 1];
     if (dataRef.current && dataRef.current.buffer.byteLength) {
       const { rows, cols, matrix } = expression;
-      // eslint-disable-next-line no-return-assign
       const promises = range(yTiles).map(i => range(xTiles).map(async j => workerPool.process({
         curr,
         tileI: i,

--- a/src/components/heatmap/Heatmap.js
+++ b/src/components/heatmap/Heatmap.js
@@ -277,7 +277,12 @@ const Heatmap = forwardRef((props, deckRef) => {
     // to help identify where in the list it is located
     // after the worker thread asynchronously sends the data back
     // to this thread.
-    setBacklog(prev => ([...prev, uuidv4()]));
+    // eslint-disable-next-line no-unused-expressions
+    axisTopLabels
+    && axisLeftLabels
+    && xTiles
+    && yTiles
+    && setBacklog(prev => ([...prev, uuidv4()]));
   }, [dataRef, expression, axisTopLabels, axisLeftLabels, xTiles, yTiles]);
 
   // When the backlog has updated, a new worker job can be submitted if:
@@ -302,7 +307,6 @@ const Heatmap = forwardRef((props, deckRef) => {
         transpose,
         data: matrix.buffer.slice(),
       })));
-      console.log(promises); // eslint-disable-line
       const decode = async () => {
         const tiles = await Promise.all(promises.flat());
         tilesRef.current = tiles.map(i => i.tile);
@@ -313,7 +317,6 @@ const Heatmap = forwardRef((props, deckRef) => {
       decode();
     }
   }, [axisLeftLabels, axisTopLabels, backlog, expression, transpose, xTiles, yTiles, workerPool]);
-  console.log(tilesRef) // eslint-disable-line
 
   useEffect(() => {
     setIsRendering(backlog.length > 0);
@@ -325,11 +328,9 @@ const Heatmap = forwardRef((props, deckRef) => {
   // - the `aggSizeX` or `aggSizeY` have changed, or
   // - the cell ordering has changed.
   const heatmapLayers = useMemo(() => {
-    console.log(!tilesRef.current || backlog.length, backlog, tilesRef); // eslint-disable-line
     if (!tilesRef.current || backlog.length) {
       return [];
     }
-    console.log('here', tilesRef.current.flatMap()) // eslint-disable-line
     function getLayer(i, j, tile) {
       return new HeatmapBitmapLayer({
         id: `heatmapLayer-${tileIteration}-${i}-${j}`,
@@ -351,11 +352,10 @@ const Heatmap = forwardRef((props, deckRef) => {
       });
     }
     const layers = tilesRef
-      .current.flatMap((tileRow, i) => tileRow.map((tile, j) => getLayer(i, j, tile)));
-    console.log(layers) // eslint-disable-line
+      .current.map((tile, index) => getLayer(Math.floor(index / xTiles), index % xTiles, tile));
     return layers;
   }, [backlog, tileIteration, matrixLeft, tileWidth, matrixTop, tileHeight,
-    aggSizeX, aggSizeY, colorScaleLo, colorScaleHi, axisLeftLabels, axisTopLabels]);
+    aggSizeX, aggSizeY, colorScaleLo, colorScaleHi, axisLeftLabels, axisTopLabels, xTiles]);
 
 
   // Map cell and gene names to arrays with indices,

--- a/src/components/heatmap/Heatmap.js
+++ b/src/components/heatmap/Heatmap.js
@@ -30,7 +30,7 @@ import {
   COLOR_BAR_SIZE,
   AXIS_MARGIN,
 } from '../../layers/heatmap-constants';
-import Pool from './Pool';
+import HeatmapWorkerPool from './HeatmapWorkerPool';
 /**
  * A heatmap component for cell x gene matrices.
  * @param {object} props
@@ -92,7 +92,7 @@ const Heatmap = forwardRef((props, deckRef) => {
   const axisLeftTitle = (transpose ? variablesTitle : observationsTitle);
   const axisTopTitle = (transpose ? observationsTitle : variablesTitle);
 
-  const workerPool = useMemo(() => new Pool(), []);
+  const workerPool = useMemo(() => new HeatmapWorkerPool(), []);
 
   useEffect(() => {
     if (clearPleaseWait && expression) {
@@ -296,7 +296,7 @@ const Heatmap = forwardRef((props, deckRef) => {
     if (dataRef.current && dataRef.current.buffer.byteLength) {
       const { rows, cols, matrix } = expression;
       // eslint-disable-next-line no-return-assign
-      const promises = range(yTiles).map(i => range(xTiles).map(async j => workerPool.decode({
+      const promises = range(yTiles).map(i => range(xTiles).map(async j => workerPool.process({
         curr,
         tileI: i,
         tileJ: j,

--- a/src/components/heatmap/HeatmapWorkerPool.js
+++ b/src/components/heatmap/HeatmapWorkerPool.js
@@ -1,0 +1,40 @@
+import Worker from './heatmap.worker'; // eslint-disable-line import/no-unresolved
+import Pool from '../../Pool';
+
+/**
+ * Pool for workers to decode chunks of the images.
+ * This is a line-for-line copy of GeoTIFFs old implementation: https://github.com/geotiffjs/geotiff.js/blob/v1.0.0-beta.6/src/pool.js
+ */
+export default class HeatmapPool extends Pool {
+  /**
+   * @constructor
+   * @param {Number} size The size of the pool. Defaults to the number of CPUs
+   *                      available. When this parameter is `null` or 0, then the
+   *                      decoding will be done in the main thread.
+   */
+  constructor() {
+    super(Worker);
+  }
+
+  /**
+   * Decode the given block of bytes with the set compression method.
+   * @param {ArrayBuffer} buffer the array buffer of bytes to decode.
+   * @returns {Promise.<ArrayBuffer>} the decoded result as a `Promise`
+   */
+  async process(args) {
+    const currentWorker = await this.waitForWorker();
+    return new Promise((resolve, reject) => {
+      currentWorker.onmessage = (event) => {
+        // this.workers.push(currentWorker);
+        this.finishTask(currentWorker);
+        resolve(event.data);
+      };
+      currentWorker.onerror = (error) => {
+        // this.workers.push(currentWorker);
+        this.finishTask(currentWorker);
+        reject(error);
+      };
+      currentWorker.postMessage(['getTile', args], [args.data]);
+    });
+  }
+}

--- a/src/components/heatmap/HeatmapWorkerPool.js
+++ b/src/components/heatmap/HeatmapWorkerPool.js
@@ -6,12 +6,7 @@ import Pool from '../../Pool';
  * This is a line-for-line copy of GeoTIFFs old implementation: https://github.com/geotiffjs/geotiff.js/blob/v1.0.0-beta.6/src/pool.js
  */
 export default class HeatmapPool extends Pool {
-  /**
-   * @constructor
-   * @param {Number} size The size of the pool. Defaults to the number of CPUs
-   *                      available. When this parameter is `null` or 0, then the
-   *                      decoding will be done in the main thread.
-   */
+
   constructor() {
     super(Worker);
   }

--- a/src/components/heatmap/HeatmapWorkerPool.js
+++ b/src/components/heatmap/HeatmapWorkerPool.js
@@ -17,8 +17,21 @@ export default class HeatmapPool extends Pool {
   }
 
   /**
-   * Decode the given block of bytes with the set compression method.
-   * @param {ArrayBuffer} buffer the array buffer of bytes to decode.
+   * Process each heatmap tile
+   * @param {object} params The arguments passed to the heatmap worker.
+   * @param {string} params.curr The current task uuid.
+   * @param {number} params.xTiles How many tiles required in the x direction?
+   * @param {number} params.yTiles How many tiles required in the y direction?
+   * @param {number} params.tileSize How many entries along each tile axis?
+   * @param {string[]} params.cellOrdering The current ordering of cells.
+   * @param {string[]} params.rows The name of each row (cell ID).
+   * Does not take transpose into account (always cells).
+   * @param {string[]} params.cols The name of each column (gene ID).
+   * Does not take transpose into account (always genes).
+   * @param {ArrayBuffer} params.data The array buffer.
+   * Need to transfer back to main thread when done.
+   * @param {boolean} params.transpose Is the heatmap transposed?
+   * @returns {array} [message, transfers]
    * @returns {Promise.<ArrayBuffer>} the decoded result as a `Promise`
    */
   async process(args) {

--- a/src/components/heatmap/HeatmapWorkerPool.js
+++ b/src/components/heatmap/HeatmapWorkerPool.js
@@ -6,7 +6,6 @@ import Pool from '../../Pool';
  * This is a line-for-line copy of GeoTIFFs old implementation: https://github.com/geotiffjs/geotiff.js/blob/v1.0.0-beta.6/src/pool.js
  */
 export default class HeatmapPool extends Pool {
-
   constructor() {
     super(Worker);
   }

--- a/src/components/heatmap/Pool.js
+++ b/src/components/heatmap/Pool.js
@@ -42,7 +42,6 @@ export default class Pool {
       currentWorker.onmessage = (event) => {
         // this.workers.push(currentWorker);
         this.finishTask(currentWorker);
-        console.log(event) // eslint-disable-line
         resolve(event.data);
       };
       currentWorker.onerror = (error) => {
@@ -50,7 +49,6 @@ export default class Pool {
         this.finishTask(currentWorker);
         reject(error);
       };
-      console.log(args) // eslint-disable-line
       currentWorker.postMessage(['getTile', args], [args.data]);
     });
   }

--- a/src/components/heatmap/Pool.js
+++ b/src/components/heatmap/Pool.js
@@ -1,0 +1,87 @@
+import Worker from './heatmap.worker'; // eslint-disable-line import/no-unresolved
+
+// https://developer.mozilla.org/en-US/docs/Web/API/NavigatorConcurrentHardware/hardwareConcurrency
+// We need to give a different way of getting this for safari, so 4 is probably a safe bet
+// for parallel processing in the meantime.  More can't really hurt since they'll just block
+// each other and not the UI thread, which is the real benefit.
+const defaultPoolSize = typeof navigator !== 'undefined' ? navigator.hardwareConcurrency || 4 : null;
+
+/**
+ * Pool for workers to decode chunks of the images.
+ * This is a line-for-line copy of GeoTIFFs old implementation: https://github.com/geotiffjs/geotiff.js/blob/v1.0.0-beta.6/src/pool.js
+ */
+export default class Pool {
+  /**
+   * @constructor
+   * @param {Number} size The size of the pool. Defaults to the number of CPUs
+   *                      available. When this parameter is `null` or 0, then the
+   *                      decoding will be done in the main thread.
+   */
+  constructor(size = defaultPoolSize) {
+    this.workers = [];
+    this.idleWorkers = [];
+    this.waitQueue = [];
+    this.decoder = null;
+
+    // eslint-disable-next-line no-plusplus
+    for (let i = 0; i < size; ++i) {
+      const w = new Worker();
+      this.workers.push(w);
+      this.idleWorkers.push(w);
+    }
+  }
+
+  /**
+   * Decode the given block of bytes with the set compression method.
+   * @param {ArrayBuffer} buffer the array buffer of bytes to decode.
+   * @returns {Promise.<ArrayBuffer>} the decoded result as a `Promise`
+   */
+  async decode(args) {
+    const currentWorker = await this.waitForWorker();
+    return new Promise((resolve, reject) => {
+      currentWorker.onmessage = (event) => {
+        // this.workers.push(currentWorker);
+        this.finishTask(currentWorker);
+        console.log(event) // eslint-disable-line
+        resolve(event.data);
+      };
+      currentWorker.onerror = (error) => {
+        // this.workers.push(currentWorker);
+        this.finishTask(currentWorker);
+        reject(error);
+      };
+      console.log(args) // eslint-disable-line
+      currentWorker.postMessage(['getTile', args], [args.data]);
+    });
+  }
+
+  async waitForWorker() {
+    const idleWorker = this.idleWorkers.pop();
+    if (idleWorker) {
+      return idleWorker;
+    }
+    const waiter = {};
+    const promise = new Promise((resolve) => {
+      waiter.resolve = resolve;
+    });
+
+    this.waitQueue.push(waiter);
+    return promise;
+  }
+
+  async finishTask(currentWorker) {
+    const waiter = this.waitQueue.pop();
+    if (waiter) {
+      waiter.resolve(currentWorker);
+    } else {
+      this.idleWorkers.push(currentWorker);
+    }
+  }
+
+  destroy() {
+    // eslint-disable-next-line no-plusplus
+    for (let i = 0; i < this.workers.length; ++i) {
+      this.workers[i].terminate();
+    }
+  }
+}

--- a/src/components/heatmap/heatmap.worker.js
+++ b/src/components/heatmap/heatmap.worker.js
@@ -1,5 +1,4 @@
 /* eslint-disable no-restricted-globals */
-import range from 'lodash/range';
 import { getCellByGeneTile, getGeneByCellTile } from './utils';
 
 /**

--- a/src/components/heatmap/heatmap.worker.js
+++ b/src/components/heatmap/heatmap.worker.js
@@ -20,10 +20,10 @@ import { getCellByGeneTile, getGeneByCellTile } from './utils';
  * @param {boolean} params.transpose Is the heatmap transposed?
  * @returns {array} [message, transfers]
  */
-function getTiles({
+function getTile({
   curr,
-  xTiles,
-  yTiles,
+  tileI,
+  tileJ,
   tileSize,
   cellOrdering,
   rows,
@@ -38,19 +38,19 @@ function getTiles({
 
   const getTileFunction = (transpose ? getGeneByCellTile : getCellByGeneTile);
 
-  const result = range(yTiles).map(i => range(xTiles).map(j => getTileFunction(
+  const result = getTileFunction(
     view,
     {
       tileSize,
-      tileI: i,
-      tileJ: j,
+      tileI,
+      tileJ,
       numCells,
       numGenes,
       cellOrdering,
       cells: rows,
     },
-  )));
-  return [{ tiles: result, buffer: data, curr }, [data]];
+  );
+  return [{ tile: result, buffer: data, curr }, [data]];
 }
 
 /**
@@ -58,7 +58,7 @@ function getTiles({
  */
 if (typeof self !== 'undefined') {
   const nameToFunction = {
-    getTiles,
+    getTile,
   };
 
   self.addEventListener('message', (event) => {


### PR DESCRIPTION
I think this fixes #934.

This PR:

- Adds a generic pool class that could be re-used for whatever need arises by implementing the `process` function.
- A specific pool implementation for the heatmap tiles that is used by the `Heatmap` component.
- Fixes a small bug where `xTiles` and `yTiles` had not been calculated yet but `expression` had been, which sets off one round of processing, but then `xTiles` and `yTiles` are calculated setting off duplicated processing

There should be a noticeable difference for example with the [recent neocortex example](http://localhost:3000/?url=https://second-trimester-neocortex.s3.amazonaws.com/Temporal_gw20/vitessce_config_Temporal_gw20.json) or with [the satija example from the portal](http://localhost:3000/?url=data%3A%2C%7B+++%22version%22%3A+%220.1.0%22%2C+++%22name%22%3A+%22HBM336.FWTN.636%22%2C+++%22layers%22%3A+%5B+++++%7B+++++++%22name%22%3A+%22cells%22%2C+++++++%22type%22%3A+%22CELLS%22%2C+++++++%22fileType%22%3A+%22cells.json%22%2C+++++++%22url%22%3A+%22https%3A%2F%2Fs3.amazonaws.com%2Fvitessce-data%2F0.0.31%2Fmaster_release%2Fsatija%2F2dca1bf5832a4102ba780e9e54f6c350.cells.json%22+++++%7D%2C+++++%7B+++++++%22name%22%3A+%22cell-sets%22%2C+++++++%22type%22%3A+%22CELL-SETS%22%2C+++++++%22fileType%22%3A+%22cell-sets.json%22%2C+++++++%22url%22%3A+%22https%3A%2F%2Fs3.amazonaws.com%2Fvitessce-data%2F0.0.31%2Fmaster_release%2Fsatija%2F2dca1bf5832a4102ba780e9e54f6c350.cell-sets.json%22+++++%7D%2C+++++%7B+++++++%22name%22%3A+%22expression-matrix%22%2C+++++++%22type%22%3A+%22EXPRESSION-MATRIX%22%2C+++++++%22fileType%22%3A+%22expression-matrix.zarr%22%2C+++++++%22url%22%3A+%22https%3A%2F%2Fvitessce-data.storage.googleapis.com%2F0.0.31%2Fmaster_release%2Fsatija%2F2dca1bf5832a4102ba780e9e54f6c350.expression-matrix.zarr%22+++++%7D+++%5D%2C+++%22public%22%3A+true%2C+++%22staticLayout%22%3A+%5B+++++%7B+%22component%22%3A+%22cellSets%22%2C+%22x%22%3A+4%2C+%22y%22%3A+0%2C+%22w%22%3A+4%2C+%22h%22%3A+4+%7D%2C+++++%7B+%22component%22%3A+%22cellSetSizes%22%2C+%22x%22%3A+8%2C+%22y%22%3A+0%2C+%22w%22%3A+4%2C+%22h%22%3A+4+%7D%2C+++++%7B+++++++%22component%22%3A+%22scatterplot%22%2C+++++++%22props%22%3A+%7B+++++++++%22mapping%22%3A+%22UMAP%22%2C+++++++++%22view%22%3A+%7B+%22zoom%22%3A+3%2C+%22target%22%3A+%5B0%2C+0%2C+0%5D+%7D+++++++%7D%2C+++++++%22x%22%3A+0%2C+++++++%22y%22%3A+0%2C+++++++%22w%22%3A+4%2C+++++++%22h%22%3A+4+++++%7D%2C+++++%7B+%22component%22%3A+%22heatmap%22%2C+%22x%22%3A+0%2C+%22y%22%3A+4%2C+%22w%22%3A+12%2C+%22h%22%3A+4+%7D+++%5D+%7D&theme=dark) (both on localhost:3000)