### PR TITLE
Fix Quadtree Condition Bug

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 - Fix 0's displaying when selection is not enabled for `Spatial`.
 - Fix bug where polygons or centroids would show under the `bitmask`.
 - `bitmask` color texture creation assumed that `cellColors` prop was only rgb, but it can be rgba.
+- Fix bug where quadtree wouldn't work with only scatterplot.
 
 ## [1.1.9](https://www.npmjs.com/package/vitessce/v/1.1.9) - 2021-05-07
 

--- a/src/components/shared-spatial-scatterplot/quadtree.js
+++ b/src/components/shared-spatial-scatterplot/quadtree.js
@@ -14,7 +14,7 @@ export function createCellsQuadTree(cellsEntries, getCellCoords) {
   // Only use cellsEntries in quadtree calculation if there is
   // centroid data in the cells (i.e not just ids).
   // eslint-disable-next-line no-unused-vars
-  if (!cellsEntries || !cellsEntries.length || !cellsEntries[0][1].xy) {
+  if (!cellsEntries || !cellsEntries.length || !getCellCoords(cellsEntries[0][1])) {
     // Abort if the cells data is not yet available.
     return null;
   }


### PR DESCRIPTION
Fixes a bug where scatterplots alone i.e `cells.json` without `xy` centroids don't work.