### PR TITLE
John conroy/fix controller styles

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@
 - Fix bug where polygons or centroids would show under the `bitmask`.
 - `bitmask` color texture creation assumed that `cellColors` prop was only rgb, but it can be rgba.
 - Fix bug where quadtree wouldn't work with only scatterplot.
+- Fix controller padding bug.
 
 ## [1.1.9](https://www.npmjs.com/package/vitessce/v/1.1.9) - 2021-05-07
 

--- a/src/components/layer-controller/LayerController.js
+++ b/src/components/layer-controller/LayerController.js
@@ -5,7 +5,6 @@ import Grid from '@material-ui/core/Grid';
 import Button from '@material-ui/core/Button';
 import AddIcon from '@material-ui/icons/Add';
 import Slider from '@material-ui/core/Slider';
-
 import ExpansionPanel from '@material-ui/core/ExpansionPanel';
 import ExpandMoreIcon from '@material-ui/icons/ExpandMore';
 
@@ -16,6 +15,7 @@ import {
   StyledExpansionPanelDetails,
   StyledExpansionPanelSummary,
   StyledInputLabel,
+  OverflowEllipsisGrid,
 } from './styles';
 
 import { GLOBAL_LABELS } from '../spatial/constants';
@@ -267,7 +267,7 @@ export default function LayerController(props) {
         aria-controls={`layer-${name}-controls`}
       >
         <Grid container direction="column" m={1} justify="center">
-          <Grid item>{name}</Grid>
+          <OverflowEllipsisGrid item>{name}</OverflowEllipsisGrid>
           {!isExpanded && (
             <Grid container direction="row" alignItems="center" justify="center">
               <Grid item xs={6}>

--- a/src/components/layer-controller/LayerController.js
+++ b/src/components/layer-controller/LayerController.js
@@ -8,17 +8,17 @@ import Slider from '@material-ui/core/Slider';
 import InputLabel from '@material-ui/core/InputLabel';
 
 import ExpansionPanel from '@material-ui/core/ExpansionPanel';
-import ExpansionPanelSummary from '@material-ui/core/ExpansionPanelSummary';
-import ExpansionPanelDetails from '@material-ui/core/ExpansionPanelDetails';
 import ExpandMoreIcon from '@material-ui/icons/ExpandMore';
 
 import LayerOptions from './LayerOptions';
 
 import {
-  useExpansionPanelStyles,
-  useExpansionPanelSummaryStyles,
+  useControllerSectionStyles,
   useSmallInputLabelStyles,
+  StyledExpansionPanelDetails,
+  StyledExpansionPanelSummary,
 } from './styles';
+
 import { GLOBAL_LABELS } from '../spatial/constants';
 import { getSourceFromLoader, isRgb } from '../../utils';
 import { DOMAINS } from './constants';
@@ -254,21 +254,19 @@ export default function LayerController(props) {
     );
   }
 
-  const classes = useExpansionPanelStyles();
-  const summaryClasses = useExpansionPanelSummaryStyles();
+  const controllerSectionClasses = useControllerSectionStyles();
   const closedOpacityLabelClasses = useSmallInputLabelStyles();
 
   return (
     <ExpansionPanel
-      className={classes.root}
+      className={controllerSectionClasses.root}
       onChange={(e, expanded) => setIsExpanded(expanded && e?.target?.attributes?.role?.value === 'presentation')}
       TransitionProps={{ enter: false }}
       expanded={isExpanded}
     >
-      <ExpansionPanelSummary
+      <StyledExpansionPanelSummary
         expandIcon={<ExpandMoreIcon />}
         aria-controls={`layer-${name}-controls`}
-        classes={{ ...summaryClasses }}
       >
         <Grid container direction="column" m={1} justify="center">
           <Grid item>{name}</Grid>
@@ -293,8 +291,8 @@ export default function LayerController(props) {
             </Grid>
           )}
         </Grid>
-      </ExpansionPanelSummary>
-      <ExpansionPanelDetails className={classes.root}>
+      </StyledExpansionPanelSummary>
+      <StyledExpansionPanelDetails>
         <LayerOptions
           channels={channels}
           labels={labels}
@@ -342,7 +340,7 @@ export default function LayerController(props) {
         >
             Remove Image Layer
         </Button>
-      </ExpansionPanelDetails>
+      </StyledExpansionPanelDetails>
     </ExpansionPanel>
   );
 }

--- a/src/components/layer-controller/LayerController.js
+++ b/src/components/layer-controller/LayerController.js
@@ -5,7 +5,6 @@ import Grid from '@material-ui/core/Grid';
 import Button from '@material-ui/core/Button';
 import AddIcon from '@material-ui/icons/Add';
 import Slider from '@material-ui/core/Slider';
-import InputLabel from '@material-ui/core/InputLabel';
 
 import ExpansionPanel from '@material-ui/core/ExpansionPanel';
 import ExpandMoreIcon from '@material-ui/icons/ExpandMore';
@@ -14,9 +13,9 @@ import LayerOptions from './LayerOptions';
 
 import {
   useControllerSectionStyles,
-  useSmallInputLabelStyles,
   StyledExpansionPanelDetails,
   StyledExpansionPanelSummary,
+  StyledInputLabel,
 } from './styles';
 
 import { GLOBAL_LABELS } from '../spatial/constants';
@@ -255,7 +254,6 @@ export default function LayerController(props) {
   }
 
   const controllerSectionClasses = useControllerSectionStyles();
-  const closedOpacityLabelClasses = useSmallInputLabelStyles();
 
   return (
     <ExpansionPanel
@@ -273,7 +271,7 @@ export default function LayerController(props) {
           {!isExpanded && (
             <Grid container direction="row" alignItems="center" justify="center">
               <Grid item xs={6}>
-                <InputLabel htmlFor={`layer-${name}-opacity-closed`} classes={closedOpacityLabelClasses}>Opacity:</InputLabel>
+                <StyledInputLabel htmlFor={`layer-${name}-opacity-closed`}>Opacity:</StyledInputLabel>
               </Grid>
               <Grid item xs={6}>
                 <Slider

--- a/src/components/layer-controller/VectorLayerController.js
+++ b/src/components/layer-controller/VectorLayerController.js
@@ -5,7 +5,7 @@ import Checkbox from '@material-ui/core/Checkbox';
 import Paper from '@material-ui/core/Paper';
 import Typography from '@material-ui/core/Typography';
 import Slider from '@material-ui/core/Slider';
-import { useExpansionPanelStyles } from './styles';
+import { useControllerSectionStyles } from './styles';
 
 export default function VectorLayerController(props) {
   const {
@@ -31,14 +31,13 @@ export default function VectorLayerController(props) {
     handleLayerChange({ ...layer, visible: v });
   }
 
-  const classes = useExpansionPanelStyles();
+  const classes = useControllerSectionStyles();
   return (
     <Grid item style={{ marginTop: '10px' }}>
       <Paper className={classes.root}>
         <Typography
           style={{
-            paddingTop: '15px',
-            paddingLeft: '10px',
+            padding: '15px 8px 0px 8px',
             marginBottom: '-5px',
           }}
         >

--- a/src/components/layer-controller/styles.js
+++ b/src/components/layer-controller/styles.js
@@ -2,6 +2,8 @@ import { makeStyles, withStyles } from '@material-ui/core/styles';
 import ExpansionPanelSummary from '@material-ui/core/ExpansionPanelSummary';
 import ExpansionPanelDetails from '@material-ui/core/ExpansionPanelDetails';
 import InputLabel from '@material-ui/core/InputLabel';
+import Grid from '@material-ui/core/Grid';
+
 
 export const useOptionStyles = withStyles(theme => ({
   paper: {
@@ -46,19 +48,15 @@ export const StyledExpansionPanelDetails = withStyles(() => ({
 
 export const StyledExpansionPanelSummary = withStyles(theme => ({
   root: {
-    textOverflow: 'ellipsis',
-    whiteSpace: 'nowrap',
     padding: '0px 8px',
   },
   content: {
     margin: '4px 0px',
+    minWidth: '0px',
   },
   expanded: {
     marginBottom: theme.spacing(-3),
     top: theme.spacing(-1),
-    textOverflow: 'ellipsis',
-    overflow: 'hidden',
-    whiteSpace: 'nowrap',
   },
   expandIcon: {
     '&$expanded': {
@@ -72,3 +70,12 @@ export const StyledInputLabel = withStyles(() => ({
     fontSize: '14px',
   },
 }))(InputLabel);
+
+export const OverflowEllipsisGrid = withStyles(() => ({
+  item: {
+    width: '100%',
+    overflow: 'hidden',
+    whiteSpace: 'nowrap',
+    textOverflow: 'ellipsis',
+  },
+}))(Grid);

--- a/src/components/layer-controller/styles.js
+++ b/src/components/layer-controller/styles.js
@@ -1,4 +1,6 @@
-import { makeStyles } from '@material-ui/core/styles';
+import { makeStyles, withStyles } from '@material-ui/core/styles';
+import ExpansionPanelSummary from '@material-ui/core/ExpansionPanelSummary';
+import ExpansionPanelDetails from '@material-ui/core/ExpansionPanelDetails';
 
 export const useOptionStyles = makeStyles(theme => ({
   paper: {
@@ -22,19 +24,32 @@ export const useOptionStyles = makeStyles(theme => ({
   },
 }));
 
-export const useExpansionPanelStyles = makeStyles(() => ({
+const sharedControllerStyles = {
+  width: '100%',
+  flexDirection: 'column',
+};
+
+export const useControllerSectionStyles = makeStyles(() => ({
   root: {
-    width: '100%',
-    flexDirection: 'column',
+    ...sharedControllerStyles,
+    padding: '0px 8px',
   },
 }));
 
-export const useExpansionPanelSummaryStyles = makeStyles(theme => ({
+export const StyledExpansionPanelDetails = withStyles(() => ({
+  root: {
+    ...sharedControllerStyles,
+    padding: '8px 8px 24px 8px',
+  },
+}))(ExpansionPanelDetails);
+
+export const StyledExpansionPanelSummary = withStyles(theme => ({
   root: {
     top: theme.spacing(-1),
     textOverflow: 'ellipsis',
     overflow: 'hidden',
     whiteSpace: 'nowrap',
+    padding: '0px 8px',
   },
   expanded: {
     marginBottom: theme.spacing(-3),
@@ -48,7 +63,7 @@ export const useExpansionPanelSummaryStyles = makeStyles(theme => ({
       top: theme.spacing(-1.3),
     },
   },
-}));
+}))(ExpansionPanelSummary);
 
 export const useSmallInputLabelStyles = makeStyles(() => ({
   root: {

--- a/src/components/layer-controller/styles.js
+++ b/src/components/layer-controller/styles.js
@@ -1,6 +1,7 @@
 import { makeStyles, withStyles } from '@material-ui/core/styles';
 import ExpansionPanelSummary from '@material-ui/core/ExpansionPanelSummary';
 import ExpansionPanelDetails from '@material-ui/core/ExpansionPanelDetails';
+import InputLabel from '@material-ui/core/InputLabel';
 
 export const useOptionStyles = makeStyles(theme => ({
   paper: {
@@ -45,11 +46,13 @@ export const StyledExpansionPanelDetails = withStyles(() => ({
 
 export const StyledExpansionPanelSummary = withStyles(theme => ({
   root: {
-    top: theme.spacing(-1),
     textOverflow: 'ellipsis',
     overflow: 'hidden',
     whiteSpace: 'nowrap',
     padding: '0px 8px',
+  },
+  content: {
+    margin: '4px 0px',
   },
   expanded: {
     marginBottom: theme.spacing(-3),
@@ -65,8 +68,8 @@ export const StyledExpansionPanelSummary = withStyles(theme => ({
   },
 }))(ExpansionPanelSummary);
 
-export const useSmallInputLabelStyles = makeStyles(() => ({
+export const StyledInputLabel = withStyles(() => ({
   root: {
     fontSize: '14px',
   },
-}));
+}))(InputLabel);

--- a/src/components/layer-controller/styles.js
+++ b/src/components/layer-controller/styles.js
@@ -3,7 +3,7 @@ import ExpansionPanelSummary from '@material-ui/core/ExpansionPanelSummary';
 import ExpansionPanelDetails from '@material-ui/core/ExpansionPanelDetails';
 import InputLabel from '@material-ui/core/InputLabel';
 
-export const useOptionStyles = makeStyles(theme => ({
+export const useOptionStyles = withStyles(theme => ({
   paper: {
     backgroundColor: theme.palette.background.paper,
   },
@@ -47,7 +47,6 @@ export const StyledExpansionPanelDetails = withStyles(() => ({
 export const StyledExpansionPanelSummary = withStyles(theme => ({
   root: {
     textOverflow: 'ellipsis',
-    overflow: 'hidden',
     whiteSpace: 'nowrap',
     padding: '0px 8px',
   },


### PR DESCRIPTION
For whatever reason, `makeStyles` wasn't overriding the styles from the default MUI classes. Switching to `useStyles` for the affected components fixes the issue. A lot of people seem to experience these issues with the styling libraries provided by MUI, apparently they are moving away from the libraries in their new major version to styled-components/emotion.

The sections also weren't completely aligned in the previous version. 'Molecules' and 'Cell Segmentations' sections had a total of `18px` horizontal padding on each side whereas the 'Image' section had `16px`, so I fixed that.

Hope this helps!

<img width="1792" alt="Screen Shot 2021-05-28 at 2 36 19 PM" src="https://user-images.githubusercontent.com/62477388/120028004-1a419b80-bfc2-11eb-8980-129cd26aae62.png">
