### PR TITLE
Fix `VLenUTF8` Filter Check + Concat Typed Arrays

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@
 - `bitmask` color texture creation assumed that `cellColors` prop was only rgb, but it can be rgba.
 - Fix bug where quadtree wouldn't work with only scatterplot.
 - Fix controller padding bug.
+- Ensure `VlenUtf8` filter is only used/checked when necessary.
 
 ## [1.1.9](https://www.npmjs.com/package/vitessce/v/1.1.9) - 2021-05-07
 

--- a/src/loaders/anndata-loaders/BaseAnnDataLoader.js
+++ b/src/loaders/anndata-loaders/BaseAnnDataLoader.js
@@ -104,8 +104,26 @@ export default class BaseAnnDataLoader extends AbstractZarrLoader {
       path,
       mode: 'r',
     }).then(async (z) => {
-      let data = [];
+      let data;
       let item = 0;
+      const parseAndMergeTextBytes = (dbytes) => {
+        const text = parseVlenUtf8(dbytes);
+        if (!data) {
+          data = text;
+        } else {
+          data = data.concat(text);
+        }
+      };
+      const mergeBytes = (dbytes) => {
+        if (!data) {
+          data = dbytes;
+        } else {
+          const tmp = new Uint8Array(dbytes.buffer.byteLength + data.buffer.byteLength);
+          tmp.set(new Uint8Array(data.buffer), 0);
+          tmp.set(dbytes, data.buffer.byteLength);
+          data = tmp;
+        }
+      };
       // eslint-disable-next-line no-constant-condition
       while (true) {
         try {
@@ -113,11 +131,10 @@ export default class BaseAnnDataLoader extends AbstractZarrLoader {
           const buf = await store.getItem(`${z.keyPrefix}${String(item)}`);
           // eslint-disable-next-line no-await-in-loop
           const dbytes = await z.compressor.decode(buf);
-          if (z.meta.filters[0].id === 'vlen-utf8') {
-            const text = parseVlenUtf8(dbytes);
-            data = data.concat(text);
+          if (Array.isArray(z.meta.filters) && z.meta.filters[0].id === 'vlen-utf8') {
+            parseAndMergeTextBytes(dbytes);
           } else {
-            data = data.concat(dbytes);
+            mergeBytes(dbytes);
           }
           item += 1;
         } catch (err) {

--- a/src/loaders/anndata-loaders/BaseAnnDataLoader.js
+++ b/src/loaders/anndata-loaders/BaseAnnDataLoader.js
@@ -131,8 +131,10 @@ export default class BaseAnnDataLoader extends AbstractZarrLoader {
           const buf = await store.getItem(`${z.keyPrefix}${String(item)}`);
           // eslint-disable-next-line no-await-in-loop
           const dbytes = await z.compressor.decode(buf);
+          // Use vlenutf-8 decoding if necessary and merge `data` as a normal array.
           if (Array.isArray(z.meta.filters) && z.meta.filters[0].id === 'vlen-utf8') {
             parseAndMergeTextBytes(dbytes);
+          // Otherwise just merge the bytes as a typed array.
           } else {
             mergeBytes(dbytes);
           }


### PR DESCRIPTION
This PR fixes two issues introduced by #948 noticed during #939:

1. We removed the `TypedArray` merging on `data` which needs to use different APIs (specifically the `matrixGenesFilter` uses these `TypeArray`s as opposed to arrays of strings)
2. Check the need for using `VLenUtf8` more robustly

I think you can test the problem/fix with ```data:,{"coordinationSpace":{"dataset":{"A":"A"},"embeddingType":{"A":"UMAP"}},"datasets":[{"files":[{"fileType":"anndata-cells.zarr","options":{"factors":["obs/marker_gene_0","obs/marker_gene_1","obs/marker_gene_2","obs/marker_gene_3","obs/marker_gene_4"],"mappings":{"UMAP":{"dims":[0,1],"key":"obsm/X_umap"}}},"type":"cells","url":"https://assets.hubmapconsortium.org/277152f17b5a2f308820ab4d85c5a426/hubmap_ui/anndata-zarr/secondary_analysis.zarr"},{"fileType":"anndata-cell-sets.zarr","options":[{"groupName":"Leiden","setName":"obs/leiden"}],"type":"cell-sets","url":"https://assets.hubmapconsortium.org/277152f17b5a2f308820ab4d85c5a426/hubmap_ui/anndata-zarr/secondary_analysis.zarr"},{"fileType":"anndata-expression-matrix.zarr","options":{"matrix":"X","matrixGeneFilter":"var/marker_genes_for_heatmap"},"type":"expression-matrix","url":"https://assets.hubmapconsortium.org/277152f17b5a2f308820ab4d85c5a426/hubmap_ui/anndata-zarr/secondary_analysis.zarr"}],"name":"277152f17b5a2f308820ab4d85c5a426","uid":"A"}],"description":"","initStrategy":"auto","layout":[{"component":"scatterplot","coordinationScopes":{"dataset":"A","embeddingType":"A"},"h":6,"w":4,"x":0,"y":0},{"component":"cellSetExpression","coordinationScopes":{"dataset":"A"},"h":6,"w":5,"x":4,"y":0},{"component":"cellSets","coordinationScopes":{"dataset":"A"},"h":3,"w":3,"x":9,"y":0},{"component":"genes","coordinationScopes":{"dataset":"A"},"h":3,"w":3,"x":9,"y":4},{"component":"heatmap","coordinationScopes":{"dataset":"A"},"h":4,"w":12,"x":0,"y":6}],"name":"277152f17b5a2f308820ab4d85c5a426","version":"1.0.1"}```