### PR TITLE
Fix Bitmask Removal Button Overflow 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ### Added
 
 ### Changed
+- Fix bitmask remove button style.
 
 ## [1.1.10](https://www.npmjs.com/package/vitessce/v/1.1.9) - 2021-05-19
 

--- a/src/components/layer-controller/BitmaskChannelController.js
+++ b/src/components/layer-controller/BitmaskChannelController.js
@@ -55,7 +55,7 @@ function BitmaskChannelController({
         />
       </Grid>
       <Grid item xs={1}>
-        <IconButton onClick={handleChannelRemove} style={{ padding: 6 }}>
+        <IconButton onClick={handleChannelRemove} style={{ padding: '6px 6px 6px 0px' }}>
           <RemoveCircleIcon />
         </IconButton>
       </Grid>

--- a/src/components/layer-controller/BitmaskChannelController.js
+++ b/src/components/layer-controller/BitmaskChannelController.js
@@ -38,28 +38,26 @@ function BitmaskChannelController({
   */
   const createSelection = index => ({ [dimName]: index });
   return (
-    <Grid container direction="column" m={1} justify="center">
-      <Grid container direction="row" justify="space-between" style={{ width: '100%' }}>
-        <Grid item xs={2}>
-          <ChannelVisibilityCheckbox
-            color={[220, 220, 220]}
-            checked={visibility}
-            toggle={() => handlePropertyChange('visible', !visibility)}
-          />
-        </Grid>
-        <Grid item xs={9}>
-          <ChannelSelectionDropdown
-            handleChange={v => handlePropertyChange('selection', createSelection(v))}
-            selectionIndex={selectionIndex}
-            disableOptions={disableOptions}
-            channelOptions={channelOptions}
-          />
-        </Grid>
-        <Grid item xs={1}>
-          <IconButton onClick={handleChannelRemove}>
-            <RemoveCircleIcon />
-          </IconButton>
-        </Grid>
+    <Grid container direction="row" justify="space-between">
+      <Grid item xs={2}>
+        <ChannelVisibilityCheckbox
+          color={[220, 220, 220]}
+          checked={visibility}
+          toggle={() => handlePropertyChange('visible', !visibility)}
+        />
+      </Grid>
+      <Grid item xs={9}>
+        <ChannelSelectionDropdown
+          handleChange={v => handlePropertyChange('selection', createSelection(v))}
+          selectionIndex={selectionIndex}
+          disableOptions={disableOptions}
+          channelOptions={channelOptions}
+        />
+      </Grid>
+      <Grid item xs={1}>
+        <IconButton onClick={handleChannelRemove} style={{ padding: 6 }}>
+          <RemoveCircleIcon />
+        </IconButton>
       </Grid>
     </Grid>
   );


### PR DESCRIPTION
Fixes #958.

The diff looks like more but I just removed the `width: 100%` off the grid as well as the unnecessary column grid and then padded the button correctly.

Before:
<img width="237" alt="Screen Shot 2021-06-11 at 12 10 56 PM" src="https://user-images.githubusercontent.com/43999641/121716554-27748500-caae-11eb-9be0-9c7c63a0d599.png">
After:
<img width="234" alt="Screen Shot 2021-06-11 at 12 11 01 PM" src="https://user-images.githubusercontent.com/43999641/121716566-2a6f7580-caae-11eb-9fa6-ee211e3fcc18.png">
