### PR TITLE
Clean up `getFlatArrDecompressed`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Changed
 - Cache cell set polygon outputs and do not calculate them unless requested.
+- Clean up `getFlatArrDecompressed` fetching.
 
 ## [1.1.10](https://www.npmjs.com/package/vitessce/v/1.1.9) - 2021-05-19
 

--- a/src/loaders/anndata-loaders/BaseAnnDataLoader.js
+++ b/src/loaders/anndata-loaders/BaseAnnDataLoader.js
@@ -1,4 +1,5 @@
-import { openArray, KeyError } from 'zarr';
+import { openArray } from 'zarr';
+import range from 'lodash/range';
 import AbstractZarrLoader from '../AbstractZarrLoader';
 
 const readFloat32FromUint8 = (bytes) => {
@@ -105,7 +106,6 @@ export default class BaseAnnDataLoader extends AbstractZarrLoader {
       mode: 'r',
     }).then(async (z) => {
       let data;
-      let item = 0;
       const parseAndMergeTextBytes = (dbytes) => {
         const text = parseVlenUtf8(dbytes);
         if (!data) {
@@ -124,28 +124,18 @@ export default class BaseAnnDataLoader extends AbstractZarrLoader {
           data = tmp;
         }
       };
-      // eslint-disable-next-line no-constant-condition
-      while (true) {
-        try {
-          // eslint-disable-next-line no-await-in-loop
-          const buf = await store.getItem(`${z.keyPrefix}${String(item)}`);
-          // eslint-disable-next-line no-await-in-loop
-          const dbytes = await z.compressor.decode(buf);
-          // Use vlenutf-8 decoding if necessary and merge `data` as a normal array.
-          if (Array.isArray(z.meta.filters) && z.meta.filters[0].id === 'vlen-utf8') {
-            parseAndMergeTextBytes(dbytes);
+      const numRequests = Math.ceil(z.meta.shape[0] / z.meta.chunks[0]);
+      const requests = range(numRequests).map(async item => store.getItem(`${z.keyPrefix}${String(item)}`).then(buf => z.compressor.decode(buf)));
+      const dbytesArr = await Promise.all(requests);
+      dbytesArr.forEach((dbytes) => {
+        // Use vlenutf-8 decoding if necessary and merge `data` as a normal array.
+        if (Array.isArray(z.meta.filters) && z.meta.filters[0].id === 'vlen-utf8') {
+          parseAndMergeTextBytes(dbytes);
           // Otherwise just merge the bytes as a typed array.
-          } else {
-            mergeBytes(dbytes);
-          }
-          item += 1;
-        } catch (err) {
-          if (err instanceof KeyError) {
-            break;
-          }
-          throw err;
+        } else {
+          mergeBytes(dbytes);
         }
-      }
+      });
       const {
         meta: {
           shape: [length],

--- a/src/loaders/anndata-loaders/BaseAnnDataLoader.js
+++ b/src/loaders/anndata-loaders/BaseAnnDataLoader.js
@@ -125,7 +125,8 @@ export default class BaseAnnDataLoader extends AbstractZarrLoader {
         }
       };
       const numRequests = Math.ceil(z.meta.shape[0] / z.meta.chunks[0]);
-      const requests = range(numRequests).map(async item => store.getItem(`${z.keyPrefix}${String(item)}`).then(buf => z.compressor.decode(buf)));
+      const requests = range(numRequests).map(async item => store.getItem(`${z.keyPrefix}${String(item)}`)
+        .then(buf => z.compressor.decode(buf)));
       const dbytesArr = await Promise.all(requests);
       dbytesArr.forEach((dbytes) => {
         // Use vlenutf-8 decoding if necessary and merge `data` as a normal array.


### PR DESCRIPTION
This PR does a bit of refactoring and hopefully speeds thing up by letting the requests/decoding go off truly asynchronously.