### PR TITLE
PR into Lazy Load Scatterplot Polygons PR

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Changed
 - Cache cell set polygon outputs and do not calculate them unless requested.
+  - Modify the cache to use an array of tuples, since using an array as an object key results in conversion to string.
 
 ## [1.1.10](https://www.npmjs.com/package/vitessce/v/1.1.9) - 2021-05-19
 


### PR DESCRIPTION
This PR switches the `cellSetPolygonCache` to use an array of tuples, since when it was an object, the keys `[["Leiden", "0"], ["Leiden","1"], ["Leiden","2"]]` get converted to strings like `"Leiden,0,Leiden,1,Leiden,2"`.