### PR TITLE
Add "log" label to CellSetExpressionPlot when log-transform is active

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ### Added
 
 - Global visibility button next to name in layer controller.
+- Add indication to Y axis title of cell set expression violin plot when log-transformation is active.
 
 ### Changed
 - Cache cell set polygon outputs and do not calculate them unless requested.

--- a/src/components/sets/CellSetExpressionPlot.js
+++ b/src/components/sets/CellSetExpressionPlot.js
@@ -21,6 +21,8 @@ import { colorArrayToString } from './utils';
  * @param {number} props.marginBottom The size of the margin
  * on the bottom of the plot, to account for long x-axis labels.
  * Default is allowing the component to automatically determine the margin.
+ * @param {boolean} props.useGeneExpressionTransform Boolean representing
+ * whether or not the expression values are log-transformed.
  */
 export default function CellSetExpressionPlot(props) {
   const {
@@ -32,6 +34,7 @@ export default function CellSetExpressionPlot(props) {
     height,
     marginRight = 90,
     marginBottom,
+    useGeneExpressionTransform,
   } = props;
   // Get the max characters in an axis label for autsizing the bottom margin.
   const maxCharactersForLabel = data.reduce((acc, val) => {
@@ -148,7 +151,11 @@ export default function CellSetExpressionPlot(props) {
         orient: 'left',
         scale: 'yscale',
         zindex: 1,
-        title: 'Normalized Expression Value',
+        // title: useGeneExpressionTransform
+        //   ? 'Log-Normalized Expression Values' : 'Normalized Expression Values',
+        title: useGeneExpressionTransform
+          ? ['Log-Transformed', 'Normalized Expression Values']
+          : 'Normalized Expression Values',
       },
       {
         orient: 'bottom',

--- a/src/components/sets/CellSetExpressionPlotSubscriber.js
+++ b/src/components/sets/CellSetExpressionPlotSubscriber.js
@@ -103,6 +103,7 @@ export default function CellSetExpressionPlotSubscriber(props) {
             theme={theme}
             width={width}
             height={height}
+            useGeneExpressionTransform={useGeneExpressionTransform}
           />
         ) : (
           <span>Select a gene.</span>


### PR DESCRIPTION
When user activates log-transform, the Y axis title in the violin plot will now change to indicate the transformation (see issue [#902](https://github.com/vitessce/vitessce/issues/902)).

As you can see, there are currently two versions for the Y axis in the code. I'm torn between "Log-Normalized Expression Values" and "Log-Transformed Normalized Expression Values". Since even the shorter of these two labels is borderline long, I split the longer one in two lines. Personally, I prefer the two-line solution, but ultimately it depends on the layout, with either the X or the Y axis being more limiting.

![Screenshot 2021-06-16 at 16 15 10](https://user-images.githubusercontent.com/18103560/122235567-15d01a80-cebe-11eb-81a7-fee99e331b9d.png)
![Screenshot 2021-06-16 at 16 15 15](https://user-images.githubusercontent.com/18103560/122235572-18327480-cebe-11eb-901a-9df380927910.png)
