### PR TITLE
Add Global Visibility per Raster Layer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ### Added
 
 - Global visibility button next to name in layer controller.
+- Global visbiility prop per layer in `spatialRasterLayers`.
 - Add indication to Y axis title of cell set expression violin plot when log-transformation is active.
 
 ### Changed

--- a/src/components/layer-controller/LayerController.js
+++ b/src/components/layer-controller/LayerController.js
@@ -79,10 +79,7 @@ export default function LayerController(props) {
   );
 
   function setVisible(v) {
-    const newChannels = [...channels];
-    // eslint-disable-next-line no-param-reassign,no-return-assign
-    newChannels.forEach(ch => (ch.visible = v));
-    handleLayerChange({ ...layer, channels: newChannels });
+    handleLayerChange({ ...layer, visible: v });
   }
 
   function setColormap(v) {
@@ -263,7 +260,7 @@ export default function LayerController(props) {
   }
 
   const controllerSectionClasses = useControllerSectionStyles();
-  const visible = channels.some(ch => ch.visible);
+  const { visible } = layer;
   const Visibility = visible ? VisibilityIcon : VisibilityOffIcon;
   return (
     <ExpansionPanel

--- a/src/components/spatial/Spatial.js
+++ b/src/components/spatial/Spatial.js
@@ -291,7 +291,9 @@ class Spatial extends AbstractSpatialOrScatterplot {
       transparentColor: layerDef.transparentColor,
       colors: layerDef.channels.map(c => c.color),
       sliders: layerDef.channels.map(c => c.slider),
-      visibilities: layerDef.channels.map(c => c.visible),
+      visibilities: layerDef.channels.map(
+        c => (!layerDef.visible && typeof layerDef.visible === 'boolean' ? false : c.visible),
+      ),
     };
 
     if (!loader || !layerProps) return null;

--- a/src/components/spatial/constants.js
+++ b/src/components/spatial/constants.js
@@ -3,6 +3,7 @@ export const GLOBAL_LABELS = ['z', 't'];
 export const DEFAULT_RASTER_DOMAIN_TYPE = 'Min/Max';
 
 export const DEFAULT_RASTER_LAYER_PROPS = {
+  visible: true,
   colormap: null,
   opacity: 1,
   domainType: DEFAULT_RASTER_DOMAIN_TYPE,

--- a/src/schemas/config-1.0.1.schema.json
+++ b/src/schemas/config-1.0.1.schema.json
@@ -289,6 +289,10 @@
         },
         "type": {
           "type": "string"
+        },
+        "visible": {
+          "type": "boolean",
+          "description": "Determines whether this entire layer will be rendered in the spatial component."
         }
       }
     },


### PR DESCRIPTION
Fixes #967 by separating channel visibility from "global" visibility even though there is no such prop in Viv.