### PR TITLE
Don't Show Any 3D UI When not Available

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@
 - Clean up `getFlatArrDecompressed` fetching.
 - Fix bitmask remove button style.
 - Don't show 3D dropdown if only 2D is available.
+- Don't show Volume tab (or any tabs) when 3D is not available.
 
 ## [1.1.10](https://www.npmjs.com/package/vitessce/v/1.1.9) - 2021-05-19
 

--- a/src/components/layer-controller/LayerController.js
+++ b/src/components/layer-controller/LayerController.js
@@ -355,7 +355,7 @@ export default function LayerController(props) {
   const { visible } = layer;
   const Visibility = visible ? VisibilityIcon : VisibilityOffIcon;
   // Only show Volume tabs if 3D is available.
-  const useVolumeTabs = !disable3d && shape[labels.indexOf('z')];
+  const useVolumeTabs = !disable3d && shape[labels.indexOf('z')] > 1;
   const FullController = (
     <>
       <LayerOptions

--- a/src/components/layer-controller/LayerController.js
+++ b/src/components/layer-controller/LayerController.js
@@ -355,7 +355,7 @@ export default function LayerController(props) {
   const { visible } = layer;
   const Visibility = visible ? VisibilityIcon : VisibilityOffIcon;
   // Only show Volume tabs if 3D is available.
-  const useVolumeTabs = disable3d || shape[labels.indexOf('z')];
+  const useVolumeTabs = !disable3d && shape[labels.indexOf('z')];
   const FullController = (
     <>
       <LayerOptions

--- a/src/components/layer-controller/LayerController.js
+++ b/src/components/layer-controller/LayerController.js
@@ -107,7 +107,7 @@ export default function LayerController(props) {
   const handleTabChange = (event, newTab) => {
     setTab(newTab);
   };
-  const { labels } = Array.isArray(data) ? data[data.length - 1] : data;
+  const { labels, shape } = Array.isArray(data) ? data[data.length - 1] : data;
   const [domainType, setDomainType] = useState(layer.domainType);
   const [isExpanded, setIsExpanded] = useState(true);
   const [globalLabelValues, setGlobalLabelValues] = useState(
@@ -354,6 +354,57 @@ export default function LayerController(props) {
 
   const { visible } = layer;
   const Visibility = visible ? VisibilityIcon : VisibilityOffIcon;
+  // Only show Volume tabs if 3D is available.
+  const useVolumeTabs = disable3d || shape[labels.indexOf('z')];
+  const FullController = (
+    <>
+      <LayerOptions
+        channels={channels}
+        opacity={opacity}
+        colormap={colormap}
+        transparentColor={transparentColor}
+        domainType={domainType}
+      // Only allow for global dimension controllers that
+      // exist in the `dimensions` part of the loader.
+        globalControlLabels={labels.filter(label => GLOBAL_LABELS.includes(label))}
+        globalLabelValues={globalLabelValues}
+        handleOpacityChange={setOpacity}
+        handleColormapChange={setColormap}
+        handleGlobalChannelsSelectionChange={handleGlobalChannelsSelectionChange}
+        handleTransparentColorChange={setTransparentColor}
+        isRgb={isRgb(loader)}
+        handleDomainChange={handleDomainChange}
+        shouldShowTransparentColor={shouldShowTransparentColor}
+        shouldShowDomain={shouldShowDomain}
+        shouldShowColormap={shouldShowColormap}
+        use3d={use3d}
+        loader={loader}
+        handleMultiPropertyChange={handleMultiPropertyChange}
+        resolution={resolution}
+        disable3d={disable3d}
+        setRasterLayerCallback={setRasterLayerCallback}
+        setAreAllChannelsLoading={setAreAllChannelsLoading}
+        setViewState={setViewState}
+        spatialHeight={spatialHeight}
+        spatialWidth={spatialWidth}
+        modelMatrix={modelMatrix}
+      />
+      {!isRgb(loader) ? channelControllers : null}
+      {!isRgb(loader) && (
+      <Button
+        disabled={channels.length === MAX_SLIDERS_AND_CHANNELS}
+        onClick={handleChannelAdd}
+        fullWidth
+        variant="outlined"
+        style={buttonStyles}
+        startIcon={<AddIcon />}
+        size="small"
+      >
+                Add Channel
+      </Button>
+      )}
+    </>
+  );
   return (
     <ExpansionPanel
       className={controllerSectionClasses.root}
@@ -406,97 +457,55 @@ export default function LayerController(props) {
         </Grid>
       </StyledExpansionPanelSummary>
       <StyledExpansionPanelDetails>
-        <Tabs
-          value={tab}
-          onChange={handleTabChange}
-          aria-label="simple tabs example"
-          style={{ height: '24px', minHeight: '24px' }}
-        >
-          <Tab
-            label="Channels"
-            style={{
-              fontSize: '.75rem',
-              bottom: 12,
-              width: '50%',
-              minWidth: '50%',
-            }}
-            disableRipple
-          />
-          <Tab
-            label="Volume"
-            style={{
-              fontSize: '.75rem',
-              bottom: 12,
-              width: '50%',
-              minWidth: '50%',
-            }}
-          />
-        </Tabs>
-        <TabPanel value={tab} index={0}>
-          <LayerOptions
-            channels={channels}
-            opacity={opacity}
-            colormap={colormap}
-            transparentColor={transparentColor}
-            domainType={domainType}
-            // Only allow for global dimension controllers that
-            // exist in the `dimensions` part of the loader.
-            globalControlLabels={labels.filter(label => GLOBAL_LABELS.includes(label))}
-            globalLabelValues={globalLabelValues}
-            handleOpacityChange={setOpacity}
-            handleColormapChange={setColormap}
-            handleGlobalChannelsSelectionChange={
-              handleGlobalChannelsSelectionChange
-            }
-            handleTransparentColorChange={setTransparentColor}
-            isRgb={isRgb(loader)}
-            handleDomainChange={handleDomainChange}
-            shouldShowTransparentColor={shouldShowTransparentColor}
-            shouldShowDomain={shouldShowDomain}
-            shouldShowColormap={shouldShowColormap}
-            use3d={use3d}
-            loader={loader}
-            handleMultiPropertyChange={handleMultiPropertyChange}
-            resolution={resolution}
-            disable3d={disable3d}
-            setRasterLayerCallback={setRasterLayerCallback}
-            setAreAllChannelsLoading={setAreAllChannelsLoading}
-            setViewState={setViewState}
-            spatialHeight={spatialHeight}
-            spatialWidth={spatialWidth}
-            modelMatrix={modelMatrix}
-          />
-          {!isRgb(loader) ? channelControllers : null}
-          {!isRgb(loader) && (
-            <Button
-              disabled={channels.length === MAX_SLIDERS_AND_CHANNELS}
-              onClick={handleChannelAdd}
-              fullWidth
-              variant="outlined"
-              style={buttonStyles}
-              startIcon={<AddIcon />}
-              size="small"
+        {useVolumeTabs ? (
+          <>
+            <Tabs
+              value={tab}
+              onChange={handleTabChange}
+              aria-label="simple tabs example"
+              style={{ height: '24px', minHeight: '24px' }}
             >
-              Add Channel
-            </Button>
-          )}
-        </TabPanel>
-        <TabPanel value={tab} index={1} style={{ marginTop: 4 }}>
-          <VolumeOptions
-            loader={loader}
-            handleSlicerSetting={handleSlicerSetting}
-            handleRenderingModeChange={setRenderingMode}
-            renderingMode={renderingMode}
-            xSlice={xSlice}
-            ySlice={ySlice}
-            zSlice={zSlice}
-            use3d={use3d}
-            setViewState={setViewState}
-            spatialHeight={spatialHeight}
-            spatialWidth={spatialWidth}
-            modelMatrix={modelMatrix}
-          />
-        </TabPanel>
+              <Tab
+                label="Channels"
+                style={{
+                  fontSize: '.75rem',
+                  bottom: 12,
+                  width: '50%',
+                  minWidth: '50%',
+                }}
+                disableRipple
+              />
+              <Tab
+                label="Volume"
+                style={{
+                  fontSize: '.75rem',
+                  bottom: 12,
+                  width: '50%',
+                  minWidth: '50%',
+                }}
+              />
+            </Tabs>
+            <TabPanel value={tab} index={0}>
+              {FullController}
+            </TabPanel>
+            <TabPanel value={tab} index={1} style={{ marginTop: 4 }}>
+              <VolumeOptions
+                loader={loader}
+                handleSlicerSetting={handleSlicerSetting}
+                handleRenderingModeChange={setRenderingMode}
+                renderingMode={renderingMode}
+                xSlice={xSlice}
+                ySlice={ySlice}
+                zSlice={zSlice}
+                use3d={use3d}
+                setViewState={setViewState}
+                spatialHeight={spatialHeight}
+                spatialWidth={spatialWidth}
+                modelMatrix={modelMatrix}
+              />
+            </TabPanel>
+          </>
+        ) : FullController}
         <Button
           onClick={handleLayerRemove}
           fullWidth

--- a/src/components/layer-controller/LayerOptions.js
+++ b/src/components/layer-controller/LayerOptions.js
@@ -395,6 +395,7 @@ function LayerOptions({
   return (
     <Grid container direction="column" style={{ width: '100%' }}>
       {hasZStack
+        && !disable3d
         && (
         <VolumeDropdown
           loader={loader}


### PR DESCRIPTION
Request from Nils
- Don't show the tabs at all when 3D is not available (disabled or no z-stack)
- Don't show dropdown if 3D is disabled.