### PR TITLE
Add a custom hook and listen for window size changes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Changed
 - Use component height for determining 3D sizing.
+  - Use state rather than computing every render.
 
 ## [1.1.11](https://www.npmjs.com/package/vitessce/v/1.1.11) - 2021-06-25
 

--- a/src/components/hooks.js
+++ b/src/components/hooks.js
@@ -147,3 +147,35 @@ export function useUrls() {
 
   return [urls, addUrl, resetUrls];
 }
+
+/**
+ * Custom hook, subscribes to the width and height of the closest .vitessce-container
+ * element and updates upon window resize events.
+ * @param {Ref} ref A React ref object within the `.vitessce-container`.
+ * @returns {array} `[width, height]` where width and height
+ * are numbers.
+ */
+export function useClosestVitessceContainerSize(ref) {
+  const [height, setHeight] = useState();
+  const [width, setWidth] = useState();
+
+  useEffect(() => {
+    function onWindowResize() {
+      if (ref.current) {
+        const {
+          clientHeight: componentHeight, clientWidth: componentWidth,
+        } = ref.current.closest('.vitessce-container');
+        setWidth(componentWidth);
+        setHeight(componentHeight);
+      }
+    }
+    const onResizeDebounced = debounce(onWindowResize, 100, { trailing: true });
+    window.addEventListener('resize', onResizeDebounced);
+    onWindowResize();
+    return () => {
+      window.removeEventListener('resize', onResizeDebounced);
+    };
+  }, [ref]);
+
+  return [width, height];
+}

--- a/src/components/layer-controller/LayerControllerSubscriber.js
+++ b/src/components/layer-controller/LayerControllerSubscriber.js
@@ -9,7 +9,7 @@ import BitmaskChannelController from './BitmaskChannelController';
 import VectorLayerController from './VectorLayerController';
 import LayerController from './LayerController';
 import ImageAddButton from './ImageAddButton';
-import { useReady } from '../hooks';
+import { useReady, useClosestVitessceContainerSize } from '../hooks';
 import { useCellsData, useMoleculesData, useRasterData } from '../data-hooks';
 import {
   useCoordination,
@@ -246,15 +246,7 @@ function LayerControllerSubscriber(props) {
   // a nice, centered view.
   const [spatialLayout] = useComponentLayout('spatial', ['spatialRasterLayers'], coordinationScopes);
   const layerControllerRef = useRef();
-  const getVitessceContainer = useCallback(() => {
-    if (layerControllerRef.current) {
-      return layerControllerRef.current.closest('.vitessce-container');
-    }
-    return {};
-  }, [layerControllerRef]);
-  const {
-    clientHeight: componentHeight, clientWidth: componentWidth,
-  } = getVitessceContainer();
+  const [componentWidth, componentHeight] = useClosestVitessceContainerSize(layerControllerRef);
 
   const [isReady, setItemIsReady, resetReadyItems] = useReady(
     LAYER_CONTROLLER_DATA_TYPES,


### PR DESCRIPTION
This is a PR into #979 since it should also respond to window resizes, and this also should prevent from running the `.closest` on every LayerController render.