### PR TITLE
Cache Data Structures on `AnnData` Loaders

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 - Fix cell highlight bug with bitmask where tooltip information remains on screen after no longer highlighting.
 - No selection of cells in bitmask now results in default "grey" color instead of the last selected cell set.
 - Cache computation of internal data structures on `AnnData` zarr loaders.
+- Upgrade zarr.js to 0.4.0
 
 ## [1.1.11](https://www.npmjs.com/package/vitessce/v/1.1.11) - 2021-06-25
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
   - Use state rather than computing every render.
 - Fix cell highlight bug with bitmask where tooltip information remains on screen after no longer highlighting.
 - No selection of cells in bitmask now results in default "grey" color instead of the last selected cell set.
+- Cache computation of internal data structures on `AnnData` zarr loaders.
 
 ## [1.1.11](https://www.npmjs.com/package/vitessce/v/1.1.11) - 2021-06-25
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -13138,6 +13138,18 @@
       "integrity": "sha512-jbzBzUI+kglGnMrXRZKEash2BCErmM99dXIj9TKDLIQUi8u1oqe4jmTt2n2qe8ozUWzyjlc0h+GFTDFLZAIdDA==",
       "requires": {
         "zarr": "^0.3.0"
+      },
+      "dependencies": {
+        "zarr": {
+          "version": "0.3.1",
+          "resolved": "https://registry.npmjs.org/zarr/-/zarr-0.3.1.tgz",
+          "integrity": "sha512-M0/Qv3IYb0zgxrL6EWQgnS/CNnSggBaybEfi9Bc8eWakJa6Hr+JN/NDGJZIqyd8NgqoW2to3S6VGcIwuMIgTQQ==",
+          "requires": {
+            "numcodecs": "^0.1.0",
+            "p-queue": "6.2.0",
+            "ts-interface-checker": "^0.1.10"
+          }
+        }
       }
     },
     "hmac-drbg": {
@@ -29851,13 +29863,19 @@
       "dev": true
     },
     "zarr": {
-      "version": "0.3.1",
-      "resolved": "https://registry.npmjs.org/zarr/-/zarr-0.3.1.tgz",
-      "integrity": "sha512-M0/Qv3IYb0zgxrL6EWQgnS/CNnSggBaybEfi9Bc8eWakJa6Hr+JN/NDGJZIqyd8NgqoW2to3S6VGcIwuMIgTQQ==",
+      "version": "0.4.2",
+      "resolved": "https://registry.npmjs.org/zarr/-/zarr-0.4.2.tgz",
+      "integrity": "sha512-zyC1DaVURXqSEP6O0R8XOYa83RZkCpEHLUFOCsYn1a5n1j6ojwzwoUgeMOtHuNfuJwUnb8dGK0g3gTGGs87QiQ==",
       "requires": {
-        "numcodecs": "^0.1.0",
-        "p-queue": "6.2.0",
-        "ts-interface-checker": "^0.1.10"
+        "numcodecs": "^0.2.0",
+        "p-queue": "6.2.0"
+      },
+      "dependencies": {
+        "numcodecs": {
+          "version": "0.2.1",
+          "resolved": "https://registry.npmjs.org/numcodecs/-/numcodecs-0.2.1.tgz",
+          "integrity": "sha512-0ktyCFBEno8mLuC/bTfJk8LjDy7GvQOa9Ern2zsAhM8sU5uiUGZPyXVzD7kEtx90fRPzohodg1fd82/xzAupLA=="
+        }
       }
     },
     "zustand": {

--- a/package.json
+++ b/package.json
@@ -73,7 +73,7 @@
     "vega-tooltip": "^0.23.0",
     "whatwg-fetch": "^3.0.0",
     "window-pixi": "5.3.3",
-    "zarr": "^0.3.1",
+    "zarr": "^0.4.0",
     "zustand": "^3.0.2"
   },
   "devDependencies": {

--- a/src/loaders/anndata-loaders/BaseAnnDataLoader.js
+++ b/src/loaders/anndata-loaders/BaseAnnDataLoader.js
@@ -126,7 +126,7 @@ export default class BaseAnnDataLoader extends AbstractZarrLoader {
       };
       const numRequests = Math.ceil(z.meta.shape[0] / z.meta.chunks[0]);
       const requests = range(numRequests).map(async item => store.getItem(`${z.keyPrefix}${String(item)}`)
-        .then(buf => z.compressor.decode(buf)));
+        .then(buf => z.compressor.then(compressor => compressor.decode(buf))));
       const dbytesArr = await Promise.all(requests);
       dbytesArr.forEach((dbytes) => {
         // Use vlenutf-8 decoding if necessary and merge `data` as a normal array.

--- a/src/loaders/anndata-loaders/CellSetsZarrLoader.js
+++ b/src/loaders/anndata-loaders/CellSetsZarrLoader.js
@@ -14,13 +14,15 @@ import LoaderResult from '../LoaderResult';
  * Loader for converting zarr into the cell sets json schema.
  */
 export default class CellSetsZarrLoader extends BaseAnnDataLoader {
-  load() {
-    const { options } = this;
-    // eslint-disable-next-line camelcase
-    const cellSetZarrLocation = options.map(({ setName }) => setName);
-    return Promise
-      .all([this.loadCellNames(), this.loadCellSetIds(cellSetZarrLocation)])
-      .then((data) => {
+  async load() {
+    if (!this.cellSetsTree) {
+      const { options } = this;
+      // eslint-disable-next-line camelcase
+      const cellSetZarrLocation = options.map(({ setName }) => setName);
+      this.cellSetsTree = Promise.all([
+        this.loadCellNames(),
+        this.loadCellSetIds(cellSetZarrLocation),
+      ]).then((data) => {
         const [cellNames, cellSets] = data;
         const cellSetsTree = treeInitialize(SETS_DATATYPE_CELL);
         cellSets.forEach((cellSetIds, j) => {
@@ -29,31 +31,35 @@ export default class CellSetsZarrLoader extends BaseAnnDataLoader {
             name,
             children: [],
           };
-          const uniqueCellSetIds = Array(...(new Set(cellSetIds))).sort();
+          const uniqueCellSetIds = Array(...new Set(cellSetIds)).sort();
           const clusters = {};
           // eslint-disable-next-line no-return-assign
-          uniqueCellSetIds.forEach(id => clusters[id] = {
-            name: id,
-            set: [],
-          });
+          uniqueCellSetIds.forEach(id => (clusters[id] = { name: id, set: [] }));
           cellSetIds.forEach((id, i) => clusters[id].set.push([cellNames[i], null]));
           Object.values(clusters).forEach(
             // eslint-disable-next-line no-return-assign
-            cluster => levelZeroNode = nodeAppendChild(levelZeroNode, cluster),
+            cluster => (levelZeroNode = nodeAppendChild(levelZeroNode, cluster)),
           );
           cellSetsTree.tree.push(levelZeroNode);
         });
-        const coordinationValues = {};
-        const { tree } = cellSetsTree;
-        const newAutoSetSelectionParentName = tree[0].name;
-        // Create a list of set paths to initally select.
-        const newAutoSetSelections = tree[0].children
-          .map(node => ([newAutoSetSelectionParentName, node.name]));
-        // Create a list of cell set objects with color mappings.
-        const newAutoSetColors = initializeCellSetColor(cellSetsTree, []);
-        coordinationValues.cellSetSelection = newAutoSetSelections;
-        coordinationValues.cellSetColor = newAutoSetColors;
-        return Promise.resolve(new LoaderResult(cellSetsTree, null, coordinationValues));
+        return cellSetsTree;
       });
+    }
+    const cellSetsTree = await this.cellSetsTree;
+    const coordinationValues = {};
+    const { tree } = cellSetsTree;
+    const newAutoSetSelectionParentName = tree[0].name;
+    // Create a list of set paths to initally select.
+    const newAutoSetSelections = tree[0].children.map(node => [
+      newAutoSetSelectionParentName,
+      node.name,
+    ]);
+    // Create a list of cell set objects with color mappings.
+    const newAutoSetColors = initializeCellSetColor(cellSetsTree, []);
+    coordinationValues.cellSetSelection = newAutoSetSelections;
+    coordinationValues.cellSetColor = newAutoSetColors;
+    return Promise.resolve(
+      new LoaderResult(cellSetsTree, null, coordinationValues),
+    );
   }
 }


### PR DESCRIPTION
This is just something I noticed that could be better - we shouldn't need to create the data structures every time `load` is called so this caches those computations.