### PR TITLE
Upgrade zarr.js

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 - Fix cell highlight bug with bitmask where tooltip information remains on screen after no longer highlighting.
 - No selection of cells in bitmask now results in default "grey" color instead of the last selected cell set.
 - Cache computation of internal data structures on `AnnData` zarr loaders.
+- Upgrade zarr.js to 0.4.0
 
 ## [1.1.11](https://www.npmjs.com/package/vitessce/v/1.1.11) - 2021-06-25
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -13138,6 +13138,18 @@
       "integrity": "sha512-jbzBzUI+kglGnMrXRZKEash2BCErmM99dXIj9TKDLIQUi8u1oqe4jmTt2n2qe8ozUWzyjlc0h+GFTDFLZAIdDA==",
       "requires": {
         "zarr": "^0.3.0"
+      },
+      "dependencies": {
+        "zarr": {
+          "version": "0.3.1",
+          "resolved": "https://registry.npmjs.org/zarr/-/zarr-0.3.1.tgz",
+          "integrity": "sha512-M0/Qv3IYb0zgxrL6EWQgnS/CNnSggBaybEfi9Bc8eWakJa6Hr+JN/NDGJZIqyd8NgqoW2to3S6VGcIwuMIgTQQ==",
+          "requires": {
+            "numcodecs": "^0.1.0",
+            "p-queue": "6.2.0",
+            "ts-interface-checker": "^0.1.10"
+          }
+        }
       }
     },
     "hmac-drbg": {
@@ -29851,13 +29863,19 @@
       "dev": true
     },
     "zarr": {
-      "version": "0.3.1",
-      "resolved": "https://registry.npmjs.org/zarr/-/zarr-0.3.1.tgz",
-      "integrity": "sha512-M0/Qv3IYb0zgxrL6EWQgnS/CNnSggBaybEfi9Bc8eWakJa6Hr+JN/NDGJZIqyd8NgqoW2to3S6VGcIwuMIgTQQ==",
+      "version": "0.4.2",
+      "resolved": "https://registry.npmjs.org/zarr/-/zarr-0.4.2.tgz",
+      "integrity": "sha512-zyC1DaVURXqSEP6O0R8XOYa83RZkCpEHLUFOCsYn1a5n1j6ojwzwoUgeMOtHuNfuJwUnb8dGK0g3gTGGs87QiQ==",
       "requires": {
-        "numcodecs": "^0.1.0",
-        "p-queue": "6.2.0",
-        "ts-interface-checker": "^0.1.10"
+        "numcodecs": "^0.2.0",
+        "p-queue": "6.2.0"
+      },
+      "dependencies": {
+        "numcodecs": {
+          "version": "0.2.1",
+          "resolved": "https://registry.npmjs.org/numcodecs/-/numcodecs-0.2.1.tgz",
+          "integrity": "sha512-0ktyCFBEno8mLuC/bTfJk8LjDy7GvQOa9Ern2zsAhM8sU5uiUGZPyXVzD7kEtx90fRPzohodg1fd82/xzAupLA=="
+        }
       }
     },
     "zustand": {

--- a/package.json
+++ b/package.json
@@ -73,7 +73,7 @@
     "vega-tooltip": "^0.23.0",
     "whatwg-fetch": "^3.0.0",
     "window-pixi": "5.3.3",
-    "zarr": "^0.3.1",
+    "zarr": "^0.4.0",
     "zustand": "^3.0.2"
   },
   "devDependencies": {

--- a/src/loaders/anndata-loaders/BaseAnnDataLoader.js
+++ b/src/loaders/anndata-loaders/BaseAnnDataLoader.js
@@ -126,7 +126,7 @@ export default class BaseAnnDataLoader extends AbstractZarrLoader {
       };
       const numRequests = Math.ceil(z.meta.shape[0] / z.meta.chunks[0]);
       const requests = range(numRequests).map(async item => store.getItem(`${z.keyPrefix}${String(item)}`)
-        .then(buf => z.compressor.decode(buf)));
+        .then(buf => z.compressor.then(compressor => compressor.decode(buf))));
       const dbytesArr = await Promise.all(requests);
       dbytesArr.forEach((dbytes) => {
         // Use vlenutf-8 decoding if necessary and merge `data` as a normal array.


### PR DESCRIPTION
Upgrading zarr.js gets rid of the 404's for `.zgroup`: https://github.com/gzuidhof/zarr.js/pull/73 (it also causes the compressor to be a Promise because of https://github.com/gzuidhof/zarr.js/pull/63 I think)