### PR TITLE
Enforce Spatial Raster Type

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,7 +15,7 @@
 - Fixed backwards-compatibility `spatialRasterLayers` bugs:
     - The layer `type` should not be used, since it is currently expected to be either `"raster"` or `"bitmask"`, but previously was allowed to be any string including `"t"`. Instead, need to detect whether the layer is a bitmask layer using `layerMeta.metadata.isBitmask` defined in the `raster.json` file definition.
     - The `visible` property was previously only available for channels. Now, there is a per-layer `visible` property, but old view configs may not contain this. Therefore, we need to explicitly check that the value is a boolean rather than simply falsy `undefined` or `null`.
-
+    - Enforce `type` of `spatialRasterLayers` layer as `bitmask` or `raster`.
 ## [1.1.11](https://www.npmjs.com/package/vitessce/v/1.1.11) - 2021-06-25
 
 ### Added

--- a/src/app/view-config-upgraders.js
+++ b/src/app/view-config-upgraders.js
@@ -223,10 +223,12 @@ export function upgradeFrom1_0_1(config) {
   // to raster layer if it is not one of bitmask or raster from the old config.
 
   const newConfig = cloneDeep(config);
-  Object.keys(newConfig.coordinationSpace.spatialRasterLayers).forEach((key) => {
-    newConfig.coordinationSpace.spatialRasterLayers[key].forEach((layer, index) => {
-      newConfig.coordinationSpace.spatialRasterLayers[key][index].type = ['bitmask', 'raster'].includes(layer.type) ? layer.type : 'raster';
-    });
+  Object.keys((newConfig?.coordinationSpace?.spatialRasterLayers || {})).forEach((key) => {
+    if (newConfig.coordinationSpace.spatialRasterLayers[key]) {
+      newConfig.coordinationSpace.spatialRasterLayers[key].forEach((layer, index) => {
+        newConfig.coordinationSpace.spatialRasterLayers[key][index].type = ['bitmask', 'raster'].includes(layer.type) ? layer.type : 'raster';
+      });
+    }
   });
 
   return {

--- a/src/app/view-config-upgraders.js
+++ b/src/app/view-config-upgraders.js
@@ -1,5 +1,6 @@
 /* eslint-disable camelcase */
 import uuidv4 from 'uuid/v4';
+import cloneDeep from 'lodash/cloneDeep';
 import { getNextScope, capitalize } from '../utils';
 import {
   COMPONENT_COORDINATION_TYPES,
@@ -218,8 +219,18 @@ export function upgradeFrom1_0_1(config) {
     return newComponent;
   });
 
+  // Enforce bitmask or raster as spatial raster layer type, defaulting
+  // to raster layer if it is not one of bitmask or raster from the old config.
+
+  const newConfig = cloneDeep(config);
+  Object.keys(newConfig.coordinationSpace.spatialRasterLayers).forEach((key) => {
+    newConfig.coordinationSpace.spatialRasterLayers[key].forEach((layer, index) => {
+      newConfig.coordinationSpace.spatialRasterLayers[key][index].type = ['bitmask', 'raster'].includes(layer.type) ? layer.type : 'raster';
+    });
+  });
+
   return {
-    ...config,
+    ...newConfig,
     layout,
     version: '1.0.2',
   };

--- a/src/schemas/config-1.0.2.schema.json
+++ b/src/schemas/config-1.0.2.schema.json
@@ -344,7 +344,8 @@
             ]
           },
           "type": {
-            "type": "string"
+            "type": "string",
+            "enum": ["raster", "bitmask"]
           },
           "use3d": {
             "type": "boolean"


### PR DESCRIPTION
Following up on [my comment](https://github.com/vitessce/vitessce/pull/1001#issuecomment-882767563) I think it may actually make more sense to just remove this `type` part of the schema altogether during the schema upgrade.  Do you see any value to either leaving it as-is without this PR or enforcing the type?  The information seems redundant so removing it would make things cleaner.