### PR TITLE
Two-step dataloaders for AnnData

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ### Added
 
 ### Changed
+- Introduce two-step data loaders for AnnData "files".
 
 ## [1.1.12](https://www.npmjs.com/package/vitessce/v/1.1.12) - 2021-07-20
 

--- a/src/app/vitessce-grid-utils.js
+++ b/src/app/vitessce-grid-utils.js
@@ -94,7 +94,7 @@ export function useRowHeight(config, initialRowHeight, height, margin, padding) 
  */
 export function createLoaders(datasets, configDescription) {
   const result = {};
-  const baseLoaders = {};
+  const dataSources = {};
   datasets.forEach((dataset) => {
     const datasetLoaders = {
       name: dataset.name,
@@ -106,12 +106,13 @@ export function createLoaders(datasets, configDescription) {
       const matchingLoaderClass = fileTypeToLoader[file.fileType] || JsonLoader;
       let loader;
       if (Array.isArray(matchingLoaderClass)) {
-        const [BaseLoaderClass, LoaderClass] = matchingLoaderClass;
+        const [DataSourceClass, LoaderClass] = matchingLoaderClass;
         // Create _one_ BaseLoaderClass instance per URL. Derived loaders share this object.
-        if (!(file.url in baseLoaders)) {
-          baseLoaders[file.url] = new BaseLoaderClass(file);
+        if (!(file.url in DataSourceClass)) {
+          const { url, requestInit } = file;
+          dataSources[file.url] = new DataSourceClass({ url, requestInit });
         }
-        loader = new LoaderClass(baseLoaders[file.url]);
+        loader = new LoaderClass(dataSources[file.url], file);
       } else {
         // eslint-disable-next-line new-cap
         loader = new matchingLoaderClass(file);

--- a/src/app/vitessce-grid-utils.js
+++ b/src/app/vitessce-grid-utils.js
@@ -107,6 +107,7 @@ export function createLoaders(datasets, configDescription) {
       let loader;
       if (Array.isArray(matchingLoaderClass)) {
         const [BaseLoaderClass, LoaderClass] = matchingLoaderClass;
+        // Create _one_ BaseLoaderClass instance per URL. Derived loaders share this object.
         if (!(file.url in baseLoaders)) {
           baseLoaders[file.url] = new BaseLoaderClass(file);
         }

--- a/src/app/vitessce-grid-utils.js
+++ b/src/app/vitessce-grid-utils.js
@@ -108,7 +108,7 @@ export function createLoaders(datasets, configDescription) {
       if (Array.isArray(matchingLoaderClass)) {
         const [DataSourceClass, LoaderClass] = matchingLoaderClass;
         // Create _one_ BaseLoaderClass instance per URL. Derived loaders share this object.
-        if (!(file.url in DataSourceClass)) {
+        if (!(file.url in dataSources)) {
           const { url, requestInit } = file;
           dataSources[file.url] = new DataSourceClass({ url, requestInit });
         }

--- a/src/loaders/AbstractTwoStepLoader.js
+++ b/src/loaders/AbstractTwoStepLoader.js
@@ -1,0 +1,8 @@
+import AbstractLoader from './AbstractLoader';
+
+export default class AbstractTwoStepLoader extends AbstractLoader {
+  constructor(dataSource, params) {
+    super(params);
+    this.dataSource = dataSource;
+  }
+}

--- a/src/loaders/GenomicProfilesZarrLoader.js
+++ b/src/loaders/GenomicProfilesZarrLoader.js
@@ -1,28 +1,12 @@
-import { HTTPStore } from 'zarr';
-import AbstractLoader from './AbstractLoader';
+import AbstractTwoStepLoader from './AbstractTwoStepLoader';
 import LoaderResult from './LoaderResult';
 
-export default class GenomicProfilesZarrLoader extends AbstractLoader {
-  constructor(params) {
-    super(params);
-
-    // TODO: Use this.requestInit to provide headers, tokens, etc.
-    // eslint-disable-next-line no-unused-vars
-    const { url, requestInit } = this;
-    this.store = new HTTPStore(url);
-  }
-
+export default class GenomicProfilesZarrLoader extends AbstractTwoStepLoader {
   loadAttrs() {
-    const { store } = this;
     if (this.attrs) {
       return this.attrs;
     }
-    this.attrs = store.getItem('.zattrs')
-      .then((bytes) => {
-        const decoder = new TextDecoder('utf-8');
-        const json = JSON.parse(decoder.decode(bytes));
-        return json;
-      });
+    this.attrs = this.dataSource.store.getJson('.zattrs');
     return this.attrs;
   }
 

--- a/src/loaders/GenomicProfilesZarrLoader.js
+++ b/src/loaders/GenomicProfilesZarrLoader.js
@@ -6,7 +6,7 @@ export default class GenomicProfilesZarrLoader extends AbstractTwoStepLoader {
     if (this.attrs) {
       return this.attrs;
     }
-    this.attrs = this.dataSource.store.getJson('.zattrs');
+    this.attrs = this.dataSource.getJson('.zattrs');
     return this.attrs;
   }
 

--- a/src/loaders/MatrixZarrLoader.js
+++ b/src/loaders/MatrixZarrLoader.js
@@ -1,18 +1,18 @@
 import { openArray } from 'zarr';
-import AbstractZarrLoader from './AbstractZarrLoader';
+import AbstractTwoStepLoader from './AbstractTwoStepLoader';
 import LoaderResult from './LoaderResult';
 
-export default class MatrixZarrLoader extends AbstractZarrLoader {
+export default class MatrixZarrLoader extends AbstractTwoStepLoader {
   loadAttrs() {
     if (this.attrs) {
       return this.attrs;
     }
-    this.attrs = this.getJson('.zattrs');
+    this.attrs = this.dataSource.getJson('.zattrs');
     return this.attrs;
   }
 
   loadArr() {
-    const { store } = this;
+    const { store } = this.dataSource;
     if (this.arr) {
       return this.arr;
     }

--- a/src/loaders/OmeZarrLoader.js
+++ b/src/loaders/OmeZarrLoader.js
@@ -1,9 +1,9 @@
 import { loadOmeZarr } from '@hms-dbmi/viv';
-import AbstractZarrLoader from './AbstractZarrLoader';
 import { AbstractLoaderError } from './errors';
 import LoaderResult from './LoaderResult';
 
 import { initializeRasterLayersAndChannels } from '../components/spatial/utils';
+import AbstractTwoStepLoader from './AbstractTwoStepLoader';
 
 function hexToRgb(hex) {
   const result = /^#?([A-F\d]{2})([A-F\d]{2})([A-F\d]{2})$/i.exec(hex);
@@ -14,9 +14,9 @@ function hexToRgb(hex) {
   ];
 }
 
-export default class OmeZarrLoader extends AbstractZarrLoader {
+export default class OmeZarrLoader extends AbstractTwoStepLoader {
   async load() {
-    const payload = await this.getJson('.zattrs').catch(reason => Promise.resolve(reason));
+    const payload = await this.dataSource.getJson('.zattrs').catch(reason => Promise.resolve(reason));
     if (payload instanceof AbstractLoaderError) {
       return Promise.reject(payload);
     }

--- a/src/loaders/anndata-loaders/BaseAnnDataLoader.js
+++ b/src/loaders/anndata-loaders/BaseAnnDataLoader.js
@@ -160,3 +160,12 @@ export default class BaseAnnDataLoader extends AbstractZarrLoader {
     return this.cellNames;
   }
 }
+
+
+export class DerivedAnnDataLoader {
+  /** @param {BaseAnnDataLoader} */
+  constructor(baseLoader) {
+    /** @type {BaseAnnDataLoader} */
+    this.baseLoader = baseLoader;
+  }
+}

--- a/src/loaders/anndata-loaders/CellSetsZarrLoader.js
+++ b/src/loaders/anndata-loaders/CellSetsZarrLoader.js
@@ -13,12 +13,14 @@ import LoaderResult from '../LoaderResult';
  * Loader for converting zarr into the cell sets json schema.
  */
 export default class CellSetsZarrLoader {
+
   constructor(baseLoader) {
     this.baseLoader = baseLoader;
   }
+
   async load() {
     if (!this.cellSetsTree) {
-      const { options } = this.baseLoader;
+      // const { options } = this.baseLoader;
       // eslint-disable-next-line camelcase
       const cellSetZarrLocation = options.map(({ setName }) => setName);
       this.cellSetsTree = Promise.all([

--- a/src/loaders/anndata-loaders/CellSetsZarrLoader.js
+++ b/src/loaders/anndata-loaders/CellSetsZarrLoader.js
@@ -7,21 +7,21 @@ import {
 import {
   SETS_DATATYPE_CELL,
 } from '../../components/sets/constants';
+import AbstractTwoStepLoader from '../AbstractTwoStepLoader';
 import LoaderResult from '../LoaderResult';
-import { DerivedAnnDataLoader } from './BaseAnnDataLoader';
 
 /**
  * Loader for converting zarr into the cell sets json schema.
  */
-export default class CellSetsZarrLoader extends DerivedAnnDataLoader {
+export default class CellSetsZarrLoader extends AbstractTwoStepLoader {
   async load() {
     if (!this.cellSetsTree) {
-      const { options } = this.baseLoader;
+      const { options } = this;
       // eslint-disable-next-line camelcase
       const cellSetZarrLocation = options.map(({ setName }) => setName);
       this.cellSetsTree = Promise.all([
-        this.baseLoader.loadCellNames(),
-        this.baseLoader.loadCellSetIds(cellSetZarrLocation),
+        this.dataSource.loadCellNames(),
+        this.dataSource.loadCellSetIds(cellSetZarrLocation),
       ]).then((data) => {
         const [cellNames, cellSets] = data;
         const cellSetsTree = treeInitialize(SETS_DATATYPE_CELL);

--- a/src/loaders/anndata-loaders/CellSetsZarrLoader.js
+++ b/src/loaders/anndata-loaders/CellSetsZarrLoader.js
@@ -14,14 +14,18 @@ import LoaderResult from '../LoaderResult';
  * Loader for converting zarr into the cell sets json schema.
  */
 export default class CellSetsZarrLoader extends AbstractTwoStepLoader {
+  loadCellSetIds() {
+    const { options } = this;
+    const cellSetZarrLocation = options.map(({ setName }) => setName);
+    return this.dataSource.loadObsVariables(cellSetZarrLocation);
+  }
+
   async load() {
     if (!this.cellSetsTree) {
       const { options } = this;
-      // eslint-disable-next-line camelcase
-      const cellSetZarrLocation = options.map(({ setName }) => setName);
       this.cellSetsTree = Promise.all([
-        this.dataSource.loadCellNames(),
-        this.dataSource.loadCellSetIds(cellSetZarrLocation),
+        this.dataSource.loadObsIndex(),
+        this.loadCellSetIds(),
       ]).then((data) => {
         const [cellNames, cellSets] = data;
         const cellSetsTree = treeInitialize(SETS_DATATYPE_CELL);

--- a/src/loaders/anndata-loaders/CellSetsZarrLoader.js
+++ b/src/loaders/anndata-loaders/CellSetsZarrLoader.js
@@ -7,21 +7,23 @@ import {
 import {
   SETS_DATATYPE_CELL,
 } from '../../components/sets/constants';
-import BaseAnnDataLoader from './BaseAnnDataLoader';
 import LoaderResult from '../LoaderResult';
 
 /**
  * Loader for converting zarr into the cell sets json schema.
  */
-export default class CellSetsZarrLoader extends BaseAnnDataLoader {
+export default class CellSetsZarrLoader {
+  constructor(baseLoader) {
+    this.baseLoader = baseLoader;
+  }
   async load() {
     if (!this.cellSetsTree) {
-      const { options } = this;
+      const { options } = this.baseLoader;
       // eslint-disable-next-line camelcase
       const cellSetZarrLocation = options.map(({ setName }) => setName);
       this.cellSetsTree = Promise.all([
-        this.loadCellNames(),
-        this.loadCellSetIds(cellSetZarrLocation),
+        this.baseLoader.loadCellNames(),
+        this.baseLoader.loadCellSetIds(cellSetZarrLocation),
       ]).then((data) => {
         const [cellNames, cellSets] = data;
         const cellSetsTree = treeInitialize(SETS_DATATYPE_CELL);

--- a/src/loaders/anndata-loaders/CellSetsZarrLoader.js
+++ b/src/loaders/anndata-loaders/CellSetsZarrLoader.js
@@ -8,19 +8,15 @@ import {
   SETS_DATATYPE_CELL,
 } from '../../components/sets/constants';
 import LoaderResult from '../LoaderResult';
+import { DerivedAnnDataLoader } from './BaseAnnDataLoader';
 
 /**
  * Loader for converting zarr into the cell sets json schema.
  */
-export default class CellSetsZarrLoader {
-
-  constructor(baseLoader) {
-    this.baseLoader = baseLoader;
-  }
-
+export default class CellSetsZarrLoader extends DerivedAnnDataLoader {
   async load() {
     if (!this.cellSetsTree) {
-      // const { options } = this.baseLoader;
+      const { options } = this.baseLoader;
       // eslint-disable-next-line camelcase
       const cellSetZarrLocation = options.map(({ setName }) => setName);
       this.cellSetsTree = Promise.all([

--- a/src/loaders/anndata-loaders/CellsZarrLoader.js
+++ b/src/loaders/anndata-loaders/CellsZarrLoader.js
@@ -1,21 +1,21 @@
+import AbstractTwoStepLoader from '../AbstractTwoStepLoader';
 import LoaderResult from '../LoaderResult';
-import { DerivedAnnDataLoader } from './BaseAnnDataLoader';
 
 /**
  * Loader for converting zarr into the cell json schema.
  */
-export default class CellsZarrLoader extends DerivedAnnDataLoader {
+export default class CellsZarrLoader extends AbstractTwoStepLoader {
   /**
    * Class method for loading spatial cell centroids.
    * @returns {Promise} A promise for an array of tuples/triples for cell centroids.
    */
   loadXy() {
-    const { xy } = this.baseLoader.options || {};
+    const { xy } = (this.options || {});
     if (this.xy) {
       return this.xy;
     }
     if (!this.xy && xy) {
-      this.xy = this.baseLoader.loadNumeric(xy);
+      this.xy = this.dataSource.loadNumeric(xy);
       return this.xy;
     }
     this.xy = Promise.resolve(null);
@@ -27,12 +27,12 @@ export default class CellsZarrLoader extends DerivedAnnDataLoader {
    * @returns {Promise} A promise for an array of arrays for cell polygons.
    */
   loadPoly() {
-    const { poly } = (this.baseLoader.options || {});
+    const { poly } = (this.options || {});
     if (this.poly) {
       return this.poly;
     }
     if (!this.poly && poly) {
-      this.poly = this.baseLoader.loadNumeric(poly);
+      this.poly = this.dataSource.loadNumeric(poly);
       return this.poly;
     }
     this.poly = Promise.resolve(null);
@@ -44,7 +44,7 @@ export default class CellsZarrLoader extends DerivedAnnDataLoader {
    * @returns {Promise} A promise for an array of tuples of coordinates.
    */
   loadMappings() {
-    const { mappings } = (this.baseLoader.options || {});
+    const { mappings } = (this.options || {});
     if (this.mappings) {
       return this.mappings;
     }
@@ -52,7 +52,7 @@ export default class CellsZarrLoader extends DerivedAnnDataLoader {
       this.mappings = Promise.all(
         Object.keys(mappings).map(async (coordinationName) => {
           const { key } = mappings[coordinationName];
-          return { coordinationName, arr: await this.baseLoader.loadNumeric(key) };
+          return { coordinationName, arr: await this.dataSource.loadNumeric(key) };
         }),
       );
       return this.mappings;
@@ -67,9 +67,9 @@ export default class CellsZarrLoader extends DerivedAnnDataLoader {
    * where subarray is a clustering/factor.
    */
   loadFactors() {
-    const { factors } = this.baseLoader.options || {};
+    const { factors } = (this.options || {});
     if (factors) {
-      return this.baseLoader.loadCellSetIds(factors);
+      return this.dataSource.loadCellSetIds(factors);
     }
     return Promise.resolve(null);
   }
@@ -80,7 +80,7 @@ export default class CellsZarrLoader extends DerivedAnnDataLoader {
         this.loadMappings(),
         this.loadXy(),
         this.loadPoly(),
-        this.baseLoader.loadCellNames(),
+        this.dataSource.loadCellNames(),
         this.loadFactors(),
       ]).then(([mappings, xy, poly, cellNames, factors]) => {
         const cells = {};
@@ -91,7 +91,7 @@ export default class CellsZarrLoader extends DerivedAnnDataLoader {
               if (!cells[name].mappings) {
                 cells[name].mappings = {};
               }
-              const { dims } = this.baseLoader.options.mappings[coordinationName];
+              const { dims } = this.options.mappings[coordinationName];
               cells[name].mappings[coordinationName] = dims.map(
                 dim => arr.data[i][dim],
               );
@@ -107,7 +107,7 @@ export default class CellsZarrLoader extends DerivedAnnDataLoader {
             const factorsObj = {};
             factors.forEach(
               // eslint-disable-next-line no-return-assign
-              (factor, j) => (factorsObj[this.baseLoader.options.factors[j].split('/').slice(-1)] = factor[i]),
+              (factor, j) => (factorsObj[this.options.factors[j].split('/').slice(-1)] = factor[i]),
             );
             cells[name].factors = factorsObj;
           }

--- a/src/loaders/anndata-loaders/CellsZarrLoader.js
+++ b/src/loaders/anndata-loaders/CellsZarrLoader.js
@@ -4,15 +4,17 @@ import LoaderResult from '../LoaderResult';
  * Loader for converting zarr into the cell json schema.
  */
 export default class CellsZarrLoader {
+
   constructor(baseLoader) {
     this.baseLoader = baseLoader;
   }
+
   /**
    * Class method for loading spatial cell centroids.
    * @returns {Promise} A promise for an array of tuples/triples for cell centroids.
    */
   loadXy() {
-    const { xy } = this.options || {};
+    const { xy } = this.baseLoader.options || {};
     if (this.xy) {
       return this.xy;
     }
@@ -29,7 +31,7 @@ export default class CellsZarrLoader {
    * @returns {Promise} A promise for an array of arrays for cell polygons.
    */
   loadPoly() {
-    const { poly } = (this.options || {});
+    const { poly } = (this.baseLoader.options || {});
     if (this.poly) {
       return this.poly;
     }
@@ -46,7 +48,7 @@ export default class CellsZarrLoader {
    * @returns {Promise} A promise for an array of tuples of coordinates.
    */
   loadMappings() {
-    const { mappings } = (this.options || {});
+    const { mappings } = (this.baseLoader.options || {});
     if (this.mappings) {
       return this.mappings;
     }
@@ -69,7 +71,7 @@ export default class CellsZarrLoader {
    * where subarray is a clustering/factor.
    */
   loadFactors() {
-    const { factors } = this.options || {};
+    const { factors } = this.baseLoader.options || {};
     if (factors) {
       return this.baseLoader.loadCellSetIds(factors);
     }
@@ -83,7 +85,7 @@ export default class CellsZarrLoader {
         this.loadXy(),
         this.loadPoly(),
         this.baseLoader.loadCellNames(),
-        this.baseLoader.loadFactors(),
+        this.loadFactors(),
       ]).then(([mappings, xy, poly, cellNames, factors]) => {
         const cells = {};
         cellNames.forEach((name, i) => {
@@ -117,6 +119,6 @@ export default class CellsZarrLoader {
         return cells;
       });
     }
-    return Promise.resolve(new LoaderResult(await this.baseLoader.cells, null));
+    return Promise.resolve(new LoaderResult(await this.cells, null));
   }
 }

--- a/src/loaders/anndata-loaders/CellsZarrLoader.js
+++ b/src/loaders/anndata-loaders/CellsZarrLoader.js
@@ -1,5 +1,5 @@
-import AbstractTwoStepLoader from '../AbstractTwoStepLoader';
 import LoaderResult from '../LoaderResult';
+import AbstractTwoStepLoader from '../AbstractTwoStepLoader';
 
 /**
  * Loader for converting zarr into the cell json schema.
@@ -69,7 +69,7 @@ export default class CellsZarrLoader extends AbstractTwoStepLoader {
   loadFactors() {
     const { factors } = (this.options || {});
     if (factors) {
-      return this.dataSource.loadCellSetIds(factors);
+      return this.dataSource.loadObsVariables(factors);
     }
     return Promise.resolve(null);
   }
@@ -80,7 +80,7 @@ export default class CellsZarrLoader extends AbstractTwoStepLoader {
         this.loadMappings(),
         this.loadXy(),
         this.loadPoly(),
-        this.dataSource.loadCellNames(),
+        this.dataSource.loadObsIndex(),
         this.loadFactors(),
       ]).then(([mappings, xy, poly, cellNames, factors]) => {
         const cells = {};

--- a/src/loaders/anndata-loaders/CellsZarrLoader.js
+++ b/src/loaders/anndata-loaders/CellsZarrLoader.js
@@ -1,14 +1,10 @@
 import LoaderResult from '../LoaderResult';
+import { DerivedAnnDataLoader } from './BaseAnnDataLoader';
 
 /**
  * Loader for converting zarr into the cell json schema.
  */
-export default class CellsZarrLoader {
-
-  constructor(baseLoader) {
-    this.baseLoader = baseLoader;
-  }
-
+export default class CellsZarrLoader extends DerivedAnnDataLoader {
   /**
    * Class method for loading spatial cell centroids.
    * @returns {Promise} A promise for an array of tuples/triples for cell centroids.

--- a/src/loaders/anndata-loaders/MatrixZarrLoader.js
+++ b/src/loaders/anndata-loaders/MatrixZarrLoader.js
@@ -2,6 +2,7 @@
 import { openArray, slice } from 'zarr';
 import { extent } from 'd3-array';
 import LoaderResult from '../LoaderResult';
+import { DerivedAnnDataLoader } from './BaseAnnDataLoader';
 
 const normalize = (arr) => {
   const [min, max] = extent(arr);
@@ -30,12 +31,7 @@ const concatenateColumnVectors = (arr) => {
 /**
  * Loader for converting zarr into the a cell x gene matrix for use in Genes/Heatmap components.
  */
-export default class MatrixZarrLoader {
-
-  constructor(baseLoader) {
-    this.baseLoader = baseLoader;
-  }
-
+export default class MatrixZarrLoader extends DerivedAnnDataLoader {
   /**
    * Class method for loading the genes list from AnnData.var.
    * @returns {Promise} A promise for the zarr array contianing the gene names.
@@ -170,7 +166,7 @@ export default class MatrixZarrLoader {
 
   /**
    * Class method for loading row oriented (CSR) sparse data from zarr.
-   * 
+   *
    * @returns {Object} A { data: Float32Array } contianing the CellXGene matrix.
    */
   async _loadCSRSparseCellXGene() {

--- a/src/loaders/anndata-loaders/MatrixZarrLoader.test.js
+++ b/src/loaders/anndata-loaders/MatrixZarrLoader.test.js
@@ -1,10 +1,10 @@
 import expect from 'expect';
 import MatrixZarrLoader from './MatrixZarrLoader';
-import BaseAnnDataLoader from './BaseAnnDataLoader';
+import { AnnDataSource } from '../data-sources';
 
 const createMatrixLoader = (config) => {
-  const baseLoader = new BaseAnnDataLoader(config);
-  return new MatrixZarrLoader(baseLoader);
+  const source = new AnnDataSource(config);
+  return new MatrixZarrLoader(source, config);
 };
 
 describe('loaders/MatrixZarrLoader', () => {

--- a/src/loaders/anndata-loaders/MatrixZarrLoader.test.js
+++ b/src/loaders/anndata-loaders/MatrixZarrLoader.test.js
@@ -8,11 +8,11 @@ const createMatrixLoader = (config) => {
 };
 
 describe('loaders/MatrixZarrLoader', () => {
-  it('loadGeneNames returns gene names', async () => {
+  it('loadFilteredGeneNames returns gene names', async () => {
     const loader = createMatrixLoader({
       url: 'http://127.0.0.1:8080/anndata/anndata-dense.zarr', options: { matrix: 'X' },
     });
-    const names = await loader.loadGeneNames();
+    const names = await loader.loadFilteredGeneNames();
     expect(names).toEqual(Array.from({ length: 15 }).map((_, i) => `gene_${i}`));
   });
 

--- a/src/loaders/anndata-loaders/MatrixZarrLoader.test.js
+++ b/src/loaders/anndata-loaders/MatrixZarrLoader.test.js
@@ -1,10 +1,15 @@
 import expect from 'expect';
 import MatrixZarrLoader from './MatrixZarrLoader';
+import BaseAnnDataLoader from './BaseAnnDataLoader';
 
+const createMatrixLoader = (config) => {
+  const baseLoader = new BaseAnnDataLoader(config);
+  return new MatrixZarrLoader(baseLoader);
+}
 
 describe('loaders/MatrixZarrLoader', () => {
   it('loadGeneNames returns gene names', async () => {
-    const loader = new MatrixZarrLoader({
+    const loader = createMatrixLoader({
       url: 'http://127.0.0.1:8080/anndata/anndata-dense.zarr', options: { matrix: 'X' },
     });
     const names = await loader.loadGeneNames();
@@ -13,15 +18,15 @@ describe('loaders/MatrixZarrLoader', () => {
 
   it('loadGeneSelection matches across storage methods', async () => {
     const selection = { selection: ['gene_1', 'gene_5'] };
-    const loaderCsr = new MatrixZarrLoader({
+    const loaderCsr = createMatrixLoader({
       url: 'http://127.0.0.1:8080/anndata/anndata-csr.zarr', options: { matrix: 'X' },
     });
     const csrSelection = await loaderCsr.loadGeneSelection(selection);
-    const loaderDense = new MatrixZarrLoader({
+    const loaderDense = createMatrixLoader({
       url: 'http://127.0.0.1:8080/anndata/anndata-dense.zarr', options: { matrix: 'X' },
     });
     const denseSelection = await loaderDense.loadGeneSelection(selection);
-    const loaderCsc = new MatrixZarrLoader({
+    const loaderCsc = createMatrixLoader({
       url: 'http://127.0.0.1:8080/anndata/anndata-csc.zarr', options: { matrix: 'X' },
     });
     const cscSelection = await loaderCsc.loadGeneSelection(selection);
@@ -30,15 +35,15 @@ describe('loaders/MatrixZarrLoader', () => {
   });
 
   it('loadCellXGene matches across storage methods', async () => {
-    const loaderCsr = new MatrixZarrLoader({
+    const loaderCsr = createMatrixLoader({
       url: 'http://127.0.0.1:8080/anndata/anndata-csr.zarr', options: { matrix: 'X' },
     });
     const csrMatrix = await loaderCsr.loadCellXGene();
-    const loaderDense = new MatrixZarrLoader({
+    const loaderDense = createMatrixLoader({
       url: 'http://127.0.0.1:8080/anndata/anndata-dense.zarr', options: { matrix: 'X' },
     });
     const denseMatrix = await loaderDense.loadCellXGene();
-    const loaderCsc = new MatrixZarrLoader({
+    const loaderCsc = createMatrixLoader({
       url: 'http://127.0.0.1:8080/anndata/anndata-csc.zarr', options: { matrix: 'X' },
     });
     const cscMatrix = await loaderCsc.loadCellXGene();

--- a/src/loaders/anndata-loaders/MatrixZarrLoader.test.js
+++ b/src/loaders/anndata-loaders/MatrixZarrLoader.test.js
@@ -5,7 +5,7 @@ import BaseAnnDataLoader from './BaseAnnDataLoader';
 const createMatrixLoader = (config) => {
   const baseLoader = new BaseAnnDataLoader(config);
   return new MatrixZarrLoader(baseLoader);
-}
+};
 
 describe('loaders/MatrixZarrLoader', () => {
   it('loadGeneNames returns gene names', async () => {

--- a/src/loaders/anndata-loaders/index.js
+++ b/src/loaders/anndata-loaders/index.js
@@ -3,4 +3,6 @@ import CellsZarrLoader from './CellsZarrLoader';
 import MatrixZarrLoader from './MatrixZarrLoader';
 import BaseAnnDataLoader from './BaseAnnDataLoader';
 
-export default { CellSetsZarrLoader, CellsZarrLoader, MatrixZarrLoader, BaseAnnDataLoader };
+export default {
+  CellSetsZarrLoader, CellsZarrLoader, MatrixZarrLoader, BaseAnnDataLoader,
+};

--- a/src/loaders/anndata-loaders/index.js
+++ b/src/loaders/anndata-loaders/index.js
@@ -1,8 +1,5 @@
 import CellSetsZarrLoader from './CellSetsZarrLoader';
 import CellsZarrLoader from './CellsZarrLoader';
 import MatrixZarrLoader from './MatrixZarrLoader';
-import BaseAnnDataLoader from './BaseAnnDataLoader';
 
-export default {
-  CellSetsZarrLoader, CellsZarrLoader, MatrixZarrLoader, BaseAnnDataLoader,
-};
+export default { CellSetsZarrLoader, CellsZarrLoader, MatrixZarrLoader };

--- a/src/loaders/anndata-loaders/index.js
+++ b/src/loaders/anndata-loaders/index.js
@@ -1,5 +1,6 @@
 import CellSetsZarrLoader from './CellSetsZarrLoader';
 import CellsZarrLoader from './CellsZarrLoader';
 import MatrixZarrLoader from './MatrixZarrLoader';
+import BaseAnnDataLoader from './BaseAnnDataLoader';
 
-export default { CellSetsZarrLoader, CellsZarrLoader, MatrixZarrLoader };
+export default { CellSetsZarrLoader, CellsZarrLoader, MatrixZarrLoader, BaseAnnDataLoader };

--- a/src/loaders/data-sources/AnnDataSource.js
+++ b/src/loaders/data-sources/AnnDataSource.js
@@ -1,6 +1,6 @@
 import { openArray } from 'zarr';
 import range from 'lodash/range';
-import AbstractZarrLoader from '../AbstractZarrLoader';
+import ZarrDataSource from './ZarrDataSource';
 
 const readFloat32FromUint8 = (bytes) => {
   if (bytes.length !== 4) {
@@ -45,7 +45,7 @@ function parseVlenUtf8(buffer) {
  * A base AnnData loader which has all shared methods for more comlpex laoders,
  * like loading cell names and ids. It inherits from AbstractLoader.
  */
-export default class BaseAnnDataLoader extends AbstractZarrLoader {
+export default class AnnDataSource extends ZarrDataSource {
   /**
    * Class method for loading cell set ids.
    * Takes the location as an argument because this is shared across objects,
@@ -158,14 +158,5 @@ export default class BaseAnnDataLoader extends AbstractZarrLoader {
     this.cellNames = this.getJson('obs/.zattrs')
       .then(({ _index }) => this.getFlatArrDecompressed(`/obs/${_index}`));
     return this.cellNames;
-  }
-}
-
-
-export class DerivedAnnDataLoader {
-  /** @param {BaseAnnDataLoader} */
-  constructor(baseLoader) {
-    /** @type {BaseAnnDataLoader} */
-    this.baseLoader = baseLoader;
   }
 }

--- a/src/loaders/data-sources/AnnDataSource.js
+++ b/src/loaders/data-sources/AnnDataSource.js
@@ -49,7 +49,7 @@ function parseVlenUtf8(buffer) {
 export default class AnnDataSource extends ZarrDataSource {
   constructor(...args) {
     super(...args);
-    /** @type {Map<string, Promise<Array<string>>}} */
+    /** @type {Map<string, Promise<string[]>} */
     this.cellSets = new Map();
   }
 
@@ -57,7 +57,7 @@ export default class AnnDataSource extends ZarrDataSource {
    * Class method for loading cell set ids.
    * Takes the location as an argument because this is shared across objects,
    * which have different ways of specifying location.
-   * @param {Array} cellSetZarrLocation An array of strings like obs.leiden or obs.bulk_labels.
+   * @param {string[]} cellSetZarrLocation An array of strings like obs.leiden or obs.bulk_labels.
    * @returns {Promise} A promise for an array of ids with one per cell.
    */
   loadCellSetIds(cellSetZarrLocation) {

--- a/src/loaders/data-sources/AnnDataSource.test.js
+++ b/src/loaders/data-sources/AnnDataSource.test.js
@@ -10,19 +10,19 @@ describe('sources/AnnDataSource', () => {
     expect(zGroup.zarr_format).toEqual(2);
   });
 
-  it('loadCellSetIds returns ids for location in store', async () => {
+  it('loadObsVariables returns ids for location in store', async () => {
     const dataSource = new AnnDataSource({
       url: 'http://127.0.0.1:8080/anndata/anndata-dense.zarr',
     });
-    const ids = await dataSource.loadCellSetIds(['obs/leiden']);
+    const ids = await dataSource.loadObsVariables(['obs/leiden']);
     expect(ids).toEqual([['1', '1', '2']]);
   });
 
-  it('loadCellNames returns names', async () => {
+  it('loadObsIndex returns names', async () => {
     const dataSource = new AnnDataSource({
       url: 'http://127.0.0.1:8080/anndata/anndata-dense.zarr',
     });
-    const names = await dataSource.loadCellNames();
+    const names = await dataSource.loadObsIndex();
     expect(names).toEqual(['CTG', 'GCA', 'CTG']);
   });
 });

--- a/src/loaders/data-sources/AnnDataSource.test.js
+++ b/src/loaders/data-sources/AnnDataSource.test.js
@@ -1,29 +1,28 @@
 import expect from 'expect';
-import BaseAnnDataLoader from './BaseAnnDataLoader';
+import AnnDataSource from './AnnDataSource';
 
-
-describe('loaders/BaseAnnDataLoader', () => {
+describe('sources/AnnDataSource', () => {
   it('getJson reutrns json', async () => {
-    const loader = new BaseAnnDataLoader({
+    const dataSource = new AnnDataSource({
       url: 'http://127.0.0.1:8080/anndata/anndata-dense.zarr',
     });
-    const zGroup = await loader.getJson('.zgroup');
+    const zGroup = await dataSource.getJson('.zgroup');
     expect(zGroup.zarr_format).toEqual(2);
   });
 
   it('loadCellSetIds returns ids for location in store', async () => {
-    const loader = new BaseAnnDataLoader({
+    const dataSource = new AnnDataSource({
       url: 'http://127.0.0.1:8080/anndata/anndata-dense.zarr',
     });
-    const ids = await loader.loadCellSetIds(['obs/leiden']);
+    const ids = await dataSource.loadCellSetIds(['obs/leiden']);
     expect(ids).toEqual([['1', '1', '2']]);
   });
 
   it('loadCellNames returns names', async () => {
-    const loader = new BaseAnnDataLoader({
+    const dataSource = new AnnDataSource({
       url: 'http://127.0.0.1:8080/anndata/anndata-dense.zarr',
     });
-    const names = await loader.loadCellNames();
+    const names = await dataSource.loadCellNames();
     expect(names).toEqual(['CTG', 'GCA', 'CTG']);
   });
 });

--- a/src/loaders/data-sources/ZarrDataSource.js
+++ b/src/loaders/data-sources/ZarrDataSource.js
@@ -1,16 +1,11 @@
 import { HTTPStore, KeyError } from 'zarr';
-import AbstractLoader from './AbstractLoader';
 
 /**
  * A loader ancestor class containing a default constructor
  * and a stub for the required load() method.
  */
-export default class AbstractZarrLoader extends AbstractLoader {
-  constructor(params) {
-    super(params);
-
-    // eslint-disable-next-line no-unused-vars
-    const { url, requestInit } = this;
+export default class ZarrDataSource {
+  constructor({ url, requestInit }) {
     // TODO: We should probably add a way of allowing HEAD requests as well:
     // https://github.com/gzuidhof/zarr.js/blob/375ce0c299469a970da6bb5653513564e25806bb/docs/getting-started/remote-data.md#stores
     const supportedMethods = ['GET'];

--- a/src/loaders/data-sources/index.js
+++ b/src/loaders/data-sources/index.js
@@ -1,0 +1,2 @@
+export { default as AnnDataSource } from './AnnDataSource';
+export { default as ZarrDataSource } from './ZarrDataSource';

--- a/src/loaders/types.js
+++ b/src/loaders/types.js
@@ -20,8 +20,8 @@ export const fileTypeToLoader = {
   'raster.json': RasterJsonLoader,
   'raster.ome-zarr': OmeZarrLoader,
   'cell-sets.json': CellSetsJsonLoader,
-  [`${ANNDATA}-cell-sets.zarr`]: AnnDataLoaders.CellSetsZarrLoader,
-  [`${ANNDATA}-cells.zarr`]: AnnDataLoaders.CellsZarrLoader,
-  [`${ANNDATA}-expression-matrix.zarr`]: AnnDataLoaders.MatrixZarrLoader,
+  [`${ANNDATA}-cell-sets.zarr`]: [AnnDataLoaders.BaseAnnDataLoader, AnnDataLoaders.CellSetsZarrLoader],
+  [`${ANNDATA}-cells.zarr`]: [AnnDataLoaders.BaseAnnDataLoader, AnnDataLoaders.CellsZarrLoader],
+  [`${ANNDATA}-expression-matrix.zarr`]: [AnnDataLoaders.BaseAnnDataLoader, AnnDataLoaders.MatrixZarrLoader],
   'genomic-profiles.zarr': GenomicProfilesZarrLoader,
 };

--- a/src/loaders/types.js
+++ b/src/loaders/types.js
@@ -8,20 +8,22 @@ import CellSetsJsonLoader from './CellSetsJsonLoader';
 import AnnDataLoaders from './anndata-loaders';
 import GenomicProfilesZarrLoader from './GenomicProfilesZarrLoader';
 
+import { AnnDataSource, ZarrDataSource } from './data-sources';
+
 const ANNDATA = 'anndata';
 
 export const fileTypeToLoader = {
-  'expression-matrix.zarr': MatrixZarrLoader,
+  'expression-matrix.zarr': [ZarrDataSource, MatrixZarrLoader],
   'clusters.json': ClustersJsonAsMatrixZarrLoader,
   'genes.json': GenesJsonAsMatrixZarrLoader,
   'cells.json': JsonLoader,
   'molecules.json': JsonLoader,
   'neighborhoods.json': JsonLoader,
   'raster.json': RasterJsonLoader,
-  'raster.ome-zarr': OmeZarrLoader,
+  'raster.ome-zarr': [ZarrDataSource, OmeZarrLoader],
   'cell-sets.json': CellSetsJsonLoader,
-  [`${ANNDATA}-cell-sets.zarr`]: [AnnDataLoaders.BaseAnnDataLoader, AnnDataLoaders.CellSetsZarrLoader],
-  [`${ANNDATA}-cells.zarr`]: [AnnDataLoaders.BaseAnnDataLoader, AnnDataLoaders.CellsZarrLoader],
-  [`${ANNDATA}-expression-matrix.zarr`]: [AnnDataLoaders.BaseAnnDataLoader, AnnDataLoaders.MatrixZarrLoader],
-  'genomic-profiles.zarr': GenomicProfilesZarrLoader,
+  [`${ANNDATA}-cell-sets.zarr`]: [AnnDataSource, AnnDataLoaders.CellSetsZarrLoader],
+  [`${ANNDATA}-cells.zarr`]: [AnnDataSource, AnnDataLoaders.CellsZarrLoader],
+  [`${ANNDATA}-expression-matrix.zarr`]: [AnnDataSource, AnnDataLoaders.MatrixZarrLoader],
+  'genomic-profiles.zarr': [ZarrDataSource, GenomicProfilesZarrLoader],
 };


### PR DESCRIPTION
A different approach to #997 (without a schema change).

Rather than relying on inheritance for the derived AnnDataLoaders, we can have a two step process that creates a *base loader* (`BaseAnnDataLoader`), and then the subsequent loaders are constructed with `baseLoader` as the arguments instead of `file`.

I think this provides a natural way to share behavior (and caching) among derived loaders. The `baseLoader` defines all shared behavior and a "standard" interface for all derived dataloaders. We can cache the `baseLoader` by URL, meaning that files with the same URL end up with the same `baseLoader`.

~This PR is a rough sketch, and I might have missed some conversions of `this` -> `this.baseLoader` in the derived loaders. I'd rather open for discussion first before moving ahead!~

Should be fixed, but would appreciate some _close_ inspection. 