### PR TITLE
Upgrade higlass zarr datafetchers to 0.2.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 - Introduce two-step data loaders for AnnData "files".
 - Update README to have more info on using view configs via url parameters.
 - Make two-step data loaders universal for all file types.
+- Upgrade `higlass-zarr-datafetchers` to 0.2.1 to prevent the latest Zarr.js from making failed HEAD requests.
 
 ## [1.1.12](https://www.npmjs.com/package/vitessce/v/1.1.12) - 2021-07-20
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -13133,23 +13133,11 @@
       "integrity": "sha512-D4I+ATxFuTn+Q6p8Y9rUa+X3b3cqMqhu9Tya6uHtvgV5cs39Mk7i6Z+7PMA8YuwQd5gLMSxCm2lCyWmxRVBQsQ=="
     },
     "higlass-zarr-datafetchers": {
-      "version": "0.2.0",
-      "resolved": "https://registry.npmjs.org/higlass-zarr-datafetchers/-/higlass-zarr-datafetchers-0.2.0.tgz",
-      "integrity": "sha512-jbzBzUI+kglGnMrXRZKEash2BCErmM99dXIj9TKDLIQUi8u1oqe4jmTt2n2qe8ozUWzyjlc0h+GFTDFLZAIdDA==",
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/higlass-zarr-datafetchers/-/higlass-zarr-datafetchers-0.2.1.tgz",
+      "integrity": "sha512-co/WtJ+K1RI2n4Okf2qUobkRGnM/YjqNdbXOGb01ogci21fjQbDWlltDxpZssGgVZJu786WQGQIAuHbJjwQOEQ==",
       "requires": {
-        "zarr": "^0.3.0"
-      },
-      "dependencies": {
-        "zarr": {
-          "version": "0.3.1",
-          "resolved": "https://registry.npmjs.org/zarr/-/zarr-0.3.1.tgz",
-          "integrity": "sha512-M0/Qv3IYb0zgxrL6EWQgnS/CNnSggBaybEfi9Bc8eWakJa6Hr+JN/NDGJZIqyd8NgqoW2to3S6VGcIwuMIgTQQ==",
-          "requires": {
-            "numcodecs": "^0.1.0",
-            "p-queue": "6.2.0",
-            "ts-interface-checker": "^0.1.10"
-          }
-        }
+        "zarr": "^0.4.0"
       }
     },
     "hmac-drbg": {
@@ -16547,14 +16535,6 @@
       "resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.1.tgz",
       "integrity": "sha1-CXtgK1NCKlIsGvuHkDGDNpQaAR0=",
       "dev": true
-    },
-    "numcodecs": {
-      "version": "0.1.1",
-      "resolved": "https://registry.npmjs.org/numcodecs/-/numcodecs-0.1.1.tgz",
-      "integrity": "sha512-UjKulZ6GIFKLdBIczEbsoXNZQmiHafpoIdo39YcdecHVGyMKh0+azsfHTrybXm5RZwepqLZv24mkjqGdZGm24Q==",
-      "requires": {
-        "pako": "^1.0.11"
-      }
     },
     "oauth-sign": {
       "version": "0.9.0",
@@ -26521,11 +26501,6 @@
       "requires": {
         "glob": "^7.1.2"
       }
-    },
-    "ts-interface-checker": {
-      "version": "0.1.13",
-      "resolved": "https://registry.npmjs.org/ts-interface-checker/-/ts-interface-checker-0.1.13.tgz",
-      "integrity": "sha512-Y/arvbn+rrz3JCKl9C4kVNfTfSm2/mEp5FSz5EsZSANGPSlQrpRI5M4PKF+mJnE52jOO90PnPSc3Ur3bTQw0gA=="
     },
     "ts-pnp": {
       "version": "1.1.5",

--- a/package.json
+++ b/package.json
@@ -50,7 +50,7 @@
     "glslify": "^7.0.0",
     "higlass": "1.11.4",
     "higlass-register": "^0.3.0",
-    "higlass-zarr-datafetchers": "^0.2.0",
+    "higlass-zarr-datafetchers": "^0.2.1",
     "json2csv": "^4.5.2",
     "lodash": "^4.17.15",
     "lz-string": "^1.4.4",


### PR DESCRIPTION
The scATAC demo currently fails to load because `higlass-zarr-datafetchers` uses zarr via peer dependency and was never updated to account for the `supportedMethods` option in zarr.js `0.3.1`.