### PR TITLE
PR Template

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,12 @@
+<!-- Credit (as a starting template): https://github.com/visgl/deck.gl/blob/master/.github/pull_request_template.md -->
+<!-- For feature, feature enhancement or bug fix, create an issue first and finish To Do List there -->
+<!-- Anything doesn't work as expected is a bug, including code, doc and test -->
+Fixes #
+<!-- For other PRs without open issue -->
+#### Background
+<!-- For all the PRs -->
+#### Change List
+-
+#### Checklist
+ - [ ] Ensure PR works with all demos on the vitessce.io homepage
+ - [ ] Open (draft) PR's into [`vitessce-python`](https://github.com/vitessce/vitessce-python) and [`vitessce-r`](https://github.com/vitessce/vitessce-r) if the schema has changed

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -9,4 +9,4 @@ Fixes #
 -
 #### Checklist
  - [ ] Ensure PR works with all demos on the vitessce.io homepage
- - [ ] Open (draft) PR's into [`vitessce-python`](https://github.com/vitessce/vitessce-python) and [`vitessce-r`](https://github.com/vitessce/vitessce-r) if the schema has changed
+ - [ ] Open (draft) PR's into [`vitessce-python`](https://github.com/vitessce/vitessce-python) and [`vitessce-r`](https://github.com/vitessce/vitessce-r) if this is a release PR

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## In Progress
 
 ### Added
+- PR template including reminder for potential R and python package PR's when version schema changes.
 
 ### Changed
 - Fix channel settings consistency issue while channels are loading for 3D/large imaging datasets.


### PR DESCRIPTION
I think we should start making sure the R and Python packages keep pace with this package.  They don't have to follow the same release schedule but they should be always-deployable in some sense with the latest Vitessce.  I'm open to other suggestions but I feel like requiring this at the time of the main vitessce PR is helpful (and also forces you test the PR in a different environment).  I can close though if we don't agree.