### PR TITLE
Fix Raster Initialization

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 - Fix channel settings consistency issue while channels are loading for 3D/large imaging datasets.
 - deck.gl should be pinned to minor version
 - Upgrade Viv to 0.10.6 and deck.gl to 8.5
+- Fix raster channel initilization.
 
 ## [1.1.14](https://www.npmjs.com/package/vitessce/v/1.1.14) - 2021-09-01
 

--- a/src/components/data-hooks.js
+++ b/src/components/data-hooks.js
@@ -632,23 +632,28 @@ export function useRasterData(
         const { data, url: urls, coordinationValues } = payload;
 
         /*
-        We need to merge the spatialRasterLayers properties because there are multiplesub-properties
-        that can be incomplete (for example colors without silders,
+        We need to merge the spatialRasterLayers properties because there are multiple
+        sub-properties that can be incomplete (for example colors without silders,
         or just special selection choices).  Thus we merge the initial values into the (auto) values
         from the `payload` and then null out the initial values so that `initCoordinationSpace`
         sets the coordiantion value for raster layers.
         */
         // eslint-disable-next-line no-unused-expressions
-        initialCoordinationValues?.spatialRasterLayers
-        && coordinationValues.spatialRasterLayers.forEach((layer, layerIndex) => {
-          layer.channels.forEach((channel, channelIndex) => {
+        if (initialCoordinationValues?.spatialRasterLayers) {
+          coordinationValues.spatialRasterLayers.forEach((layer, layerIndex) => {
+            const initialLayer = initialCoordinationValues.spatialRasterLayers[layerIndex];
+            const newChannels = layer.channels.map((channel, channelIndex) => ({
+              ...channel,
+              ...initialLayer.channels[channelIndex],
+            }));
             // eslint-disable-next-line no-param-reassign
-            layer.channels[channelIndex] = {
-              ...layer.channels[channelIndex],
-              ...initialCoordinationValues.spatialRasterLayers[layerIndex].channels[channelIndex],
+            coordinationValues.spatialRasterLayers[layerIndex] = {
+              ...layer,
+              ...initialLayer,
+              channels: newChannels,
             };
           });
-        });
+        }
         const newInitialCoordinationValues = {
           ...(initialCoordinationValues || {}),
           spatialRasterLayers: null,


### PR DESCRIPTION
#### Background
Currently defining only a partial `channels` object or some other partial aspect of `spatialRasterLayers` does not really work because `channels`, for example, is not a coordination type.  So this PR merges the initial `spatialRasterLayers` with the auto-generated one and then forces the hook to set the value
#### Change List
- Allow for partially defined
#### Checklist
 - [ ] Ensure PR works with all demos on the vitessce.io homepage
 - [ ] Open (draft) PR's into [`vitessce-python`](https://github.com/vitessce/vitessce-python) and [`vitessce-r`](https://github.com/vitessce/vitessce-r) if this is a release PR
