### PR TITLE
Contexts for zustand stores

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 - Fix spatial options to only show what is necessary and display at all if necessary.
 - Fix bug introduced by #1037 that broke channel removal/addition.
 - Fix setting default schema values for properties that are not in the current deck.gl view state (for example, the z direction for `target`).
+- Moved creation of `useViewConfigStore` and `useAuxiliaryStore` to the `ViewConfigProvider` and `AuxiliaryProvider` contexts (rather than creating global stores).
 
 ## [1.1.14](https://www.npmjs.com/package/vitessce/v/1.1.14) - 2021-09-01
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -29859,9 +29859,9 @@
       }
     },
     "zustand": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/zustand/-/zustand-3.0.2.tgz",
-      "integrity": "sha512-Vrj1qomDlkcQOrTCda7b1GPJcYuLU+EOgKHQwllgeGABrwm8FmauNFETrhqDjcB2esnusHPEKvDCqpJffl1igA=="
+      "version": "3.5.10",
+      "resolved": "https://registry.npmjs.org/zustand/-/zustand-3.5.10.tgz",
+      "integrity": "sha512-upluvSRWrlCiExu2UbkuMIPJ9AigyjRFoO7O9eUossIj7rPPq7pcJ0NKk6t2P7KF80tg/UdPX6/pNKOSbs9DEg=="
     }
   }
 }

--- a/package.json
+++ b/package.json
@@ -74,7 +74,7 @@
     "whatwg-fetch": "^3.0.0",
     "window-pixi": "5.3.3",
     "zarr": "^0.4.0",
-    "zustand": "^3.0.2"
+    "zustand": "^3.5.10"
   },
   "devDependencies": {
     "@babel/core": "7.9.0",

--- a/src/app/CallbackPublisher.js
+++ b/src/app/CallbackPublisher.js
@@ -1,6 +1,6 @@
 import { useEffect } from 'react';
 import { SCHEMA_HANDLERS, LATEST_VERSION } from './view-config-versions';
-import { useViewConfigStore, useLoaders, useWarning } from './state/hooks';
+import { useViewConfigStoreApi, useLoaders, useWarning } from './state/hooks';
 
 function validateViewConfig(viewConfig) {
   // Need the try-catch here since Zustand will actually
@@ -41,11 +41,13 @@ export default function CallbackPublisher(props) {
   const warning = useWarning();
   const loaders = useLoaders();
 
+  const viewConfigStoreApi = useViewConfigStoreApi();
+
   // View config updates are often-occurring, so
   // we want to use the "transient update" approach
   // to subscribe to view config changes.
   // Reference: https://github.com/react-spring/zustand#transient-updates-for-often-occuring-state-changes
-  useEffect(() => useViewConfigStore.subscribe(
+  useEffect(() => viewConfigStoreApi.subscribe(
     // The function to run on each publish.
     (viewConfig) => {
       if (validateOnConfigChange && viewConfig) {
@@ -58,7 +60,7 @@ export default function CallbackPublisher(props) {
     // The function to specify which part of the store
     // we want to subscribe to.
     state => state.viewConfig,
-  ), [onConfigChange, validateOnConfigChange]);
+  ), [onConfigChange, validateOnConfigChange, viewConfigStoreApi]);
 
   // Emit updates to the warning message.
   useEffect(() => {

--- a/src/app/Vitessce.js
+++ b/src/app/Vitessce.js
@@ -6,6 +6,7 @@ import {
 } from '@material-ui/core/styles';
 import isEqual from 'lodash/isEqual';
 import { muiTheme } from '../components/shared-mui/styles';
+import { ViewConfigProvider, createViewConfigStore } from './state/hooks';
 
 import VitessceGrid from './VitessceGrid';
 import Warning from './Warning';
@@ -89,19 +90,21 @@ export default function Vitessce(props) {
   return success ? (
     <StylesProvider generateClassName={generateClassName}>
       <ThemeProvider theme={muiTheme[theme]}>
-        <VitessceGrid
-          config={configOrWarning}
-          getComponent={getComponent}
-          rowHeight={rowHeight}
-          height={height}
-          theme={theme}
-        />
-        <CallbackPublisher
-          onWarn={onWarn}
-          onConfigChange={onConfigChange}
-          onLoaderChange={onLoaderChange}
-          validateOnConfigChange={validateOnConfigChange}
-        />
+        <ViewConfigProvider createStore={createViewConfigStore}>
+          <VitessceGrid
+            config={configOrWarning}
+            getComponent={getComponent}
+            rowHeight={rowHeight}
+            height={height}
+            theme={theme}
+          />
+          <CallbackPublisher
+            onWarn={onWarn}
+            onConfigChange={onConfigChange}
+            onLoaderChange={onLoaderChange}
+            validateOnConfigChange={validateOnConfigChange}
+          />
+        </ViewConfigProvider>
       </ThemeProvider>
     </StylesProvider>
   ) : (

--- a/src/app/Vitessce.js
+++ b/src/app/Vitessce.js
@@ -6,7 +6,10 @@ import {
 } from '@material-ui/core/styles';
 import isEqual from 'lodash/isEqual';
 import { muiTheme } from '../components/shared-mui/styles';
-import { ViewConfigProvider, createViewConfigStore } from './state/hooks';
+import {
+  ViewConfigProvider, createViewConfigStore,
+  AuxiliaryProvider, createAuxiliaryStore,
+} from './state/hooks';
 
 import VitessceGrid from './VitessceGrid';
 import Warning from './Warning';
@@ -91,19 +94,21 @@ export default function Vitessce(props) {
     <StylesProvider generateClassName={generateClassName}>
       <ThemeProvider theme={muiTheme[theme]}>
         <ViewConfigProvider createStore={createViewConfigStore}>
-          <VitessceGrid
-            config={configOrWarning}
-            getComponent={getComponent}
-            rowHeight={rowHeight}
-            height={height}
-            theme={theme}
-          />
-          <CallbackPublisher
-            onWarn={onWarn}
-            onConfigChange={onConfigChange}
-            onLoaderChange={onLoaderChange}
-            validateOnConfigChange={validateOnConfigChange}
-          />
+          <AuxiliaryProvider createStore={createAuxiliaryStore}>
+            <VitessceGrid
+              config={configOrWarning}
+              getComponent={getComponent}
+              rowHeight={rowHeight}
+              height={height}
+              theme={theme}
+            />
+            <CallbackPublisher
+              onWarn={onWarn}
+              onConfigChange={onConfigChange}
+              onLoaderChange={onLoaderChange}
+              validateOnConfigChange={validateOnConfigChange}
+            />
+          </AuxiliaryProvider>
         </ViewConfigProvider>
       </ThemeProvider>
     </StylesProvider>

--- a/src/app/VitessceGrid.js
+++ b/src/app/VitessceGrid.js
@@ -4,6 +4,7 @@ import React, {
 import { VitessceGridLayout } from './vitessce-grid-layout';
 import { useRowHeight, createLoaders } from './vitessce-grid-utils';
 import {
+  useViewConfigStore,
   useSetViewConfig,
   useSetLoaders,
   useEmitGridResize,
@@ -43,7 +44,7 @@ export default function VitessceGrid(props) {
     onResize();
   }, [rowHeight, onResize]);
 
-  const setViewConfig = useSetViewConfig();
+  const setViewConfig = useSetViewConfig(useViewConfigStore);
   const setLoaders = useSetLoaders();
   const removeComponent = useRemoveComponent();
   const changeLayout = useChangeLayout();

--- a/src/app/VitessceGrid.js
+++ b/src/app/VitessceGrid.js
@@ -4,7 +4,7 @@ import React, {
 import { VitessceGridLayout } from './vitessce-grid-layout';
 import { useRowHeight, createLoaders } from './vitessce-grid-utils';
 import {
-  useViewConfigStore,
+  useViewConfigStoreApi,
   useSetViewConfig,
   useSetLoaders,
   useEmitGridResize,
@@ -44,7 +44,8 @@ export default function VitessceGrid(props) {
     onResize();
   }, [rowHeight, onResize]);
 
-  const setViewConfig = useSetViewConfig(useViewConfigStore);
+  const viewConfigStoreApi = useViewConfigStoreApi();
+  const setViewConfig = useSetViewConfig(viewConfigStoreApi);
   const setLoaders = useSetLoaders();
   const removeComponent = useRemoveComponent();
   const changeLayout = useChangeLayout();

--- a/src/app/VitessceGrid.test.js
+++ b/src/app/VitessceGrid.test.js
@@ -3,6 +3,10 @@ import Adapter from 'enzyme-adapter-react-16';
 import { mount, configure } from 'enzyme';
 import expect from 'expect';
 import VitessceGrid from './VitessceGrid';
+import {
+  ViewConfigProvider, createViewConfigStore,
+  AuxiliaryProvider, createAuxiliaryStore,
+} from './state/hooks';
 
 configure({ adapter: new Adapter() });
 
@@ -28,7 +32,13 @@ describe('VitessceGrid.js', () => {
         return <p>FakeComponent!</p>;
       }
       const getComponent = () => FakeComponent;
-      const wrapper = mount(<VitessceGrid config={config} getComponent={getComponent} />);
+      const wrapper = mount(
+        <ViewConfigProvider createStore={createViewConfigStore}>
+          <AuxiliaryProvider createStore={createAuxiliaryStore}>
+            <VitessceGrid config={config} getComponent={getComponent} />
+          </AuxiliaryProvider>
+        </ViewConfigProvider>
+      );
       expect(wrapper.debug()).toContain('FakeComponent!');
     });
   });

--- a/src/app/VitessceGrid.test.js
+++ b/src/app/VitessceGrid.test.js
@@ -37,7 +37,7 @@ describe('VitessceGrid.js', () => {
           <AuxiliaryProvider createStore={createAuxiliaryStore}>
             <VitessceGrid config={config} getComponent={getComponent} />
           </AuxiliaryProvider>
-        </ViewConfigProvider>
+        </ViewConfigProvider>,
       );
       expect(wrapper.debug()).toContain('FakeComponent!');
     });

--- a/src/app/state/hooks.js
+++ b/src/app/state/hooks.js
@@ -4,10 +4,25 @@ import createContext from 'zustand/context';
 import shallow from 'zustand/shallow';
 import { fromEntries, capitalize } from '../../utils';
 
-const { Provider: ViewConfigProviderLocal, useStore: useViewConfigStoreLocal } = createContext();
+// Reference: https://github.com/pmndrs/zustand#react-context
+// Reference: https://github.com/pmndrs/zustand/blob/e47ea03/tests/context.test.tsx#L60
+const {
+  Provider: ViewConfigProviderLocal,
+  useStore: useViewConfigStoreLocal,
+  useStoreApi: useViewConfigStoreApiLocal,
+} = createContext();
 
 export const ViewConfigProvider = ViewConfigProviderLocal;
 export const useViewConfigStore = useViewConfigStoreLocal;
+export const useViewConfigStoreApi = useViewConfigStoreApiLocal;
+
+const {
+  Provider: AuxiliaryProviderLocal,
+  useStore: useAuxiliaryStoreLocal,
+} = createContext();
+
+export const AuxiliaryProvider = AuxiliaryProviderLocal;
+export const useAuxiliaryStore = useAuxiliaryStoreLocal;
 
 
 /**
@@ -92,7 +107,7 @@ export const useComponentLayout = (component, scopes, coordinationScopes) => use
  * though so they live here.
  * @returns {function} The useStore hook.
  */
-export const useAuxiliaryStore = create(set => ({
+export const createAuxiliaryStore = () => create(set => ({
   auxiliaryStore: null,
   setCoordinationValue: ({ parameter, scope, value }) => set(state => ({
     auxiliaryStore: {
@@ -332,9 +347,8 @@ export function useSetLoaders() {
  * @returns {function} The view config setter function
  * in the `useViewConfigStore` store.
  */
-export function useSetViewConfig(useViewConfigStore2) {
-  console.log(useViewConfigStore2); // eslint-disable-line
-  const setViewConfigRef = useRef(useViewConfigStore2.getState().setViewConfig);
+export function useSetViewConfig(useViewConfigStoreApi2) {
+  const setViewConfigRef = useRef(useViewConfigStoreApi2.getState().setViewConfig);
   const setViewConfig = setViewConfigRef.current;
   return setViewConfig;
 }

--- a/src/app/state/hooks.js
+++ b/src/app/state/hooks.js
@@ -347,8 +347,8 @@ export function useSetLoaders() {
  * @returns {function} The view config setter function
  * in the `useViewConfigStore` store.
  */
-export function useSetViewConfig(useViewConfigStoreApi2) {
-  const setViewConfigRef = useRef(useViewConfigStoreApi2.getState().setViewConfig);
+export function useSetViewConfig(viewConfigStoreApi) {
+  const setViewConfigRef = useRef(viewConfigStoreApi.getState().setViewConfig);
   const setViewConfig = setViewConfigRef.current;
   return setViewConfig;
 }

--- a/src/app/state/hooks.js
+++ b/src/app/state/hooks.js
@@ -1,7 +1,14 @@
 import { useRef, useCallback, useMemo } from 'react';
 import create from 'zustand';
+import createContext from 'zustand/context';
 import shallow from 'zustand/shallow';
 import { fromEntries, capitalize } from '../../utils';
+
+const { Provider: ViewConfigProviderLocal, useStore: useViewConfigStoreLocal } = createContext();
+
+export const ViewConfigProvider = ViewConfigProviderLocal;
+export const useViewConfigStore = useViewConfigStoreLocal;
+
 
 /**
  * The useViewConfigStore hook is initialized via the zustand
@@ -10,7 +17,7 @@ import { fromEntries, capitalize } from '../../utils';
  * Reference: https://github.com/react-spring/zustand
  * @returns {function} The useStore hook.
  */
-export const useViewConfigStore = create(set => ({
+export const createViewConfigStore = () => create(set => ({
   // State:
   // The viewConfig is an object which must conform to the schema
   // found in src/schemas/config.schema.json.
@@ -325,8 +332,9 @@ export function useSetLoaders() {
  * @returns {function} The view config setter function
  * in the `useViewConfigStore` store.
  */
-export function useSetViewConfig() {
-  const setViewConfigRef = useRef(useViewConfigStore.getState().setViewConfig);
+export function useSetViewConfig(useViewConfigStore2) {
+  console.log(useViewConfigStore2); // eslint-disable-line
+  const setViewConfigRef = useRef(useViewConfigStore2.getState().setViewConfig);
   const setViewConfig = setViewConfigRef.current;
   return setViewConfig;
 }

--- a/src/components/layer-controller/LayerControllerSubscriber.js
+++ b/src/components/layer-controller/LayerControllerSubscriber.js
@@ -172,8 +172,8 @@ const LayerControllerMemoized = React.memo(
                     }}
                     setAreLayerChannelsLoading={setAreLayerChannelsLoading}
                     areLayerChannelsLoading={areLayerChannelsLoading}
-                    spatialHeight={(componentHeight * spatialLayout.h) / 12}
-                    spatialWidth={(componentWidth * spatialLayout.w) / 12}
+                    spatialHeight={(componentHeight * (spatialLayout ? spatialLayout.h : 1)) / 12}
+                    spatialWidth={(componentWidth * (spatialLayout ? spatialLayout.w : 1)) / 12}
                     shouldShowRemoveLayerButton={shouldShowImageLayerButton}
                   />
                 </Grid>


### PR DESCRIPTION
<!-- Credit (as a starting template): https://github.com/visgl/deck.gl/blob/master/.github/pull_request_template.md -->
<!-- For feature, feature enhancement or bug fix, create an issue first and finish To Do List there -->
<!-- Anything doesn't work as expected is a bug, including code, doc and test -->
Fixes #1057 
Towards https://github.com/vitessce/vitessce-python/issues/29

<!-- For all the PRs -->
#### Change List
- Uses zustand `createContext` with store creation functions to set up independent zustand stores for each `<Vitessce/>` component instance, rather than using global stores, which causes unintended sharing of state when there are multiple `<Vitessce/>` components on the same page.
#### Checklist
 - [x] Ensure PR works with all demos on the vitessce.io homepage
 - [ ] Open (draft) PR's into [`vitessce-python`](https://github.com/vitessce/vitessce-python) and [`vitessce-r`](https://github.com/vitessce/vitessce-r) if this is a release PR
