### PR TITLE
Fix set spread syntax bug

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 - Fixed bug preventing opening of the popper menu for channel colors in the spatial layer controller component.
 - Fixed bug where the border of polygons did not show expression values.  Needed to make sure instanced attributes were used when appropriate.
 - Fixed tooltip z-index bug by switching a custom implementation to the MUI `<Popper/>` component.
+- Changed `Array(...new Set(x))` to `Array.from(new Set(x))` in `CellSetsZarrLoader.js` to prevent compilation of the former to `Array.apply(void 0, new Set(x))`.
 
 ## [1.1.16](https://www.npmjs.com/package/vitessce/v/1.1.16) - 2021-10-26
 

--- a/src/loaders/anndata-loaders/CellSetsZarrLoader.js
+++ b/src/loaders/anndata-loaders/CellSetsZarrLoader.js
@@ -89,7 +89,7 @@ export function dataToCellSetsTree(data, options) {
       levelZeroNode.children = levelOneNodes;
     } else {
       // Single-level case.
-      const uniqueCellSetIds = Array(...new Set(cellSetIds)).sort();
+      const uniqueCellSetIds = Array.from(new Set(cellSetIds)).sort();
       const clusters = {};
       // eslint-disable-next-line no-return-assign
       uniqueCellSetIds.forEach(id => (clusters[id] = { name: id, set: [] }));


### PR DESCRIPTION
<!-- Credit (as a starting template): https://github.com/visgl/deck.gl/blob/master/.github/pull_request_template.md -->
<!-- For feature, feature enhancement or bug fix, create an issue first and finish To Do List there -->
<!-- Anything doesn't work as expected is a bug, including code, doc and test -->
<!-- For other PRs without open issue -->
#### Background

![Screen Shot 2021-11-16 at 11 50 10 AM](https://user-images.githubusercontent.com/7525285/142031542-a64fd16e-b389-4f9d-8133-8eb2c47efdc3.png)

In the production build of the documentation site, the minified code has compiled `Array(...new Set(x))` to `Array.apply(void 0, new Set(x))`, which results in the array being `[]` despite the set having 6047 elements (15 unique). 

I thought the underlying issue may be with babel so I tried setting [`iterableIsArray: false`](https://babeljs.io/docs/en/assumptions#iterableisarray) in the babel assumptions but that broke the build further.


#### Checklist
 - [ ] Ensure PR works with all demos on the vitessce.io homepage
 - [ ] Open (draft) PR's into [`vitessce-python`](https://github.com/vitessce/vitessce-python) and [`vitessce-r`](https://github.com/vitessce/vitessce-r) if this is a release PR
