### PR TITLE
Fix cell set color bug

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Changed
 - Update deployment scripts to push the documentation site to `vitessce.io` and the minimal demo to `dev.vitessce.io`.
+- Fix bug preventing user-defined colors provided via `cell-sets.json` from being used in the visualization.
 
 ## [1.1.17](https://www.npmjs.com/package/vitessce/v/1.1.17) - 2021-11-04
 

--- a/src/components/sets/cell-set-utils.js
+++ b/src/components/sets/cell-set-utils.js
@@ -615,9 +615,12 @@ export function initializeCellSetColor(cellSets, cellSetColor) {
 
     const nodeColor = nextCellSetColor.find(d => isEqual(d.path, nodePath));
     if (!nodeColor) {
+      // If there is a color for the node specified via the cell set tree,
+      // then use it. Otherwise, use a color from the default color palette.
+      const nodeColorArray = (node.color ? node.color : PALETTE[index % PALETTE.length]);
       nextCellSetColor.push({
         path: nodePath,
-        color: PALETTE[index % PALETTE.length],
+        color: nodeColorArray,
       });
     }
     nodeCountPerTreePerLevel[treeIndex][hierarchyLevel] += 1;


### PR DESCRIPTION
<!-- Credit (as a starting template): https://github.com/visgl/deck.gl/blob/master/.github/pull_request_template.md -->
<!-- For feature, feature enhancement or bug fix, create an issue first and finish To Do List there -->
<!-- Anything doesn't work as expected is a bug, including code, doc and test -->
Fixes #1105 

<!-- For other PRs without open issue -->
#### Background

The function to initialize cell set colors upon loading `cell-sets.json` files was not considering user-provided colors.

#### Checklist
 - [ ] Ensure PR works with all demos on the dev.vitessce.io homepage
 - [ ] Open (draft) PR's into [`vitessce-python`](https://github.com/vitessce/vitessce-python) and [`vitessce-r`](https://github.com/vitessce/vitessce-r) if this is a release PR
 - [ ] Documentation added or updated