### PR TITLE
Add roadmap to documentation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,10 +1,12 @@
 
 ### Added
+- Added a roadmap page to the documentation.
 
 ### Changed
 - Update README: Point users to vitessce.io, use smaller screenshots, drop low-level details.
 - Upgrade Viv to 0.12.6 to fix shader compilation issue with interleaved RGB images
 - Fixed layer controller raster channel slider bug, related to [MUI slider issue](https://github.com/mui/material-ui/issues/20896).
+- Started to update the documentation to use the term "view" rather than "component".
 
 ## [1.1.18](https://www.npmjs.com/package/vitessce/v/1.1.18) - 2022-02-14
 

--- a/docs/docs/components.mdx
+++ b/docs/docs/components.mdx
@@ -1,21 +1,16 @@
 ---
 id: components
-title: Visualization Components
-sidebar_label: Visualization Components
+title: Views
+sidebar_label: Views
 slug: /components
 ---
 import ComponentImage from '../src/pages/_ComponentImage';
 
-Vitessce supports several components for visualization of single-cell data, and several controller components for updating visualization parameters. The component names found on this page are all valid values for the field [`layout[].component`](/docs/view-config-json/#layout) in the view config. On this page you will also find screenshots of each component.
-
-:::note
-The terms "component" and "view" are used interchangeably thoughout this documentation.
-:::
-
+Vitessce supports several views for visualization of single-cell data, and several views for updating visualization parameters. The view names found on this page are all valid values for the field [`layout[].component`](/docs/view-config-json/#layout) in the view config. On this page you will also find screenshots of each view.
 
 ### `scatterplot`
 
-The scatterplot component displays 2-dimensional (pre-computed) embeddings / projections (such as t-SNE or UMAP).
+The scatterplot view displays 2-dimensional (pre-computed) embeddings / projections (such as t-SNE or UMAP).
 Use with the `embeddingType` coordination type to specify which embedding to use when mapping cells onto scatterplot points.
 Use with datasets containing the `cells` data type. Optionally, the `cell-sets` and `genes` data types can be used for coloring cells on the plot.
 
@@ -23,8 +18,8 @@ Use with datasets containing the `cells` data type. Optionally, the `cell-sets` 
 
 ### `heatmap`
 
-The heatmap component displays a (normalized) cell-by-gene (or gene-by-cell) matrix visualization.
-This component uses the `expression-matrix` data type, and optionally displays cell set color assignments if a file with the `cell-sets` data type is available in the same dataset.
+The heatmap view displays a (normalized) cell-by-gene (or gene-by-cell) matrix visualization.
+This view uses the `expression-matrix` data type, and optionally displays cell set color assignments if a file with the `cell-sets` data type is available in the same dataset.
 The heatmap can support very large matrices (~6,000 x ~9,000) when using Zarr-based file types (best performance can be acheived when arrays are saved with the type `uint8`).
 
 <ComponentImage filename="heatmap.png" alt="Screenshot of Heatmap Component" />
@@ -32,64 +27,64 @@ The heatmap can support very large matrices (~6,000 x ~9,000) when using Zarr-ba
 
 ### `spatial`
 
-The spatial component is meant to display data with spatial coordinates, including spatially-resolved cell segmentations as polygons (from the `cells` data type) and molecule positions as points (from the `molecules` data type). The spatial component also includes a multiplexed and multi-scale image viewer (implemented with [Viv](http://viv.gehlenborglab.org/)). Image files can be defined with the `raster` data type. Cell segmentations can be colored by gene expression data through the `expression-matrix` data type or cell set color assignments through the `cell-sets` data type.
+The spatial view is meant to display data with spatial coordinates, including spatially-resolved cell segmentations as polygons (from the `cells` data type) and molecule positions as points (from the `molecules` data type). The spatial view also includes a multiplexed and multi-scale image viewer (implemented with [Viv](http://viv.gehlenborglab.org/)). Image files can be defined with the `raster` data type. Cell segmentations can be colored by gene expression data through the `expression-matrix` data type or cell set color assignments through the `cell-sets` data type.
 
 <ComponentImage filename="spatial-2.png" alt="Screenshot of Spatial Component" />
 <ComponentImage filename="spatial.png" alt="Screenshot of Spatial Component" />
 
 ### `layerController`
 
-The layer controller component provides an interface for manipulating the visualization layers displayed in the `spatial` component.
+The layer controller view provides an interface for manipulating the visualization layers displayed in the `spatial` component.
 The image layers are coordinated through the [`spatialRasterLayers`](/docs/coordination-types/#spatialRasterLayers) coordination type.
 
 <ComponentImage filename="layerController.png" alt="Screenshot of Layer Controller Component" />
 
 ### `genomicProfiles`
 
-The genomic profiles component displays genome browser tracks (using the `genomic-profiles` data type) containing bar plots, where the genome is along the x-axis and the value at each genome position is encoded with a bar along the y-axis.
+The genomic profiles view displays genome browser tracks (using the `genomic-profiles` data type) containing bar plots, where the genome is along the x-axis and the value at each genome position is encoded with a bar along the y-axis.
 Genome tracks may be colored by corresponding cell set color assignments if the `cell-sets` data type is available in the same dataset, coordinated on the [`cellSetSelection`](/docs/coordination-types/#cellSetSelection) coordination type.
-This component was implemented with [HiGlass](https://higlass.io/).
+This view was implemented with [HiGlass](https://higlass.io/).
 
 <ComponentImage filename="genomicProfiles.png" alt="Screenshot of Genomic Profiles Component" />
 
 ### `genes`
 
-The genes component displays an interactive list of genes when used with datasets containing the `expression-matrix` data type.
+The genes view displays an interactive list of genes when used with datasets containing the `expression-matrix` data type.
 
 <ComponentImage filename="genes.png" alt="Screenshot of Expression Levels Component" />
 
 ### `cellSets`
 
-The cell sets component displays an interactive list of (potentially hierarchical) cell sets when used with datasets containing the `cell-sets` data type. This can be useful for managing cell sets representing clustering algorithm outputs or cell type annotations.
+The cell sets view displays an interactive list of (potentially hierarchical) cell sets when used with datasets containing the `cell-sets` data type. This can be useful for managing cell sets representing clustering algorithm outputs or cell type annotations.
 
 <ComponentImage filename="cellSets.png" alt="Screenshot of Cell Set Manager Component" />
 
 ### `cellSetSizes`
 
-The cell set sizes component displays a bar plot with the currently-selected cell sets (using the `cell-sets` data type and [`cellSetSelection`](/docs/coordination-types/#cellSetSelection) coordination type) on the x-axis and bars representing their size (by number of cells) on the y-axis. This component was implemented with [Vega-Lite](https://vega.github.io/vega-lite/).
+The cell set sizes view displays a bar plot with the currently-selected cell sets (using the `cell-sets` data type and [`cellSetSelection`](/docs/coordination-types/#cellSetSelection) coordination type) on the x-axis and bars representing their size (by number of cells) on the y-axis. This view was implemented with [Vega-Lite](https://vega.github.io/vega-lite/).
 
 <ComponentImage filename="cellSetSizes.png" alt="Screenshot of Cell Set Sizes Component" />
 
 ### `description`
 
-The description component can be used to display text content. This may be useful for communicating the details of a dataset or a data analysis process. When the `spatial` component is used for visualization of imaging data, the `description` component also renders a dropdown containing image metadata.
+The description view can be used to display text content. This may be useful for communicating the details of a dataset or a data analysis process. When the `spatial` view is used for visualization of imaging data, the `description` view also renders a dropdown containing image metadata.
 
 <ComponentImage filename="description.png" alt="Screenshot of Description Component" />
 
 ### `status`
 
-The status component displays debugging messages, including app-wide error messages when datasets fail to load or when schemas fail to validate. Details about the entity under the mouse cursor (cell, gene, and/or molecule) are displayed during hover interactions.
+The status view displays debugging messages, including app-wide error messages when datasets fail to load or when schemas fail to validate. Details about the entity under the mouse cursor (cell, gene, and/or molecule) are displayed during hover interactions.
 
 <ComponentImage filename="status.png" alt="Screenshot of Status Component" />
 
 ### `cellSetExpression`
 
-The cell set expression component displays a violin plot with expression values for the selected gene, implemented with [Vega-Lite](https://vega.github.io/vega-lite/).
+The cell set expression view displays a violin plot with expression values for the selected gene, implemented with [Vega-Lite](https://vega.github.io/vega-lite/).
 
 <ComponentImage filename="cellSetExpression.png" alt="Screenshot of Cell Set Expression Component" />
 
 ### `expressionHistogram`
 
-The expression histogram component displays a bar plot with the distribution of expression values for the selected gene, implemented with [Vega-Lite](https://vega.github.io/vega-lite/).
+The expression histogram view displays a bar plot with the distribution of expression values for the selected gene, implemented with [Vega-Lite](https://vega.github.io/vega-lite/).
 
 <ComponentImage filename="expressionHistogram.png" alt="Screenshot of Expression Histogram Component" />

--- a/docs/docs/roadmap.mdx
+++ b/docs/docs/roadmap.mdx
@@ -1,0 +1,140 @@
+---
+id: roadmap
+title: Roadmap
+slug: /roadmap
+---
+
+We have many exciting features planned to enable visualization of additional modalities and larger datasets, as well as visualization of multiple datasets simultaneously. This page lists some of the major features we hope to add in the coming months and details about how we currently envision their implementations and use cases.
+
+To read the latest extended description of each feature please see the corresponding GitHub issue. Feel free to comment on issues or start a [discussion](https://github.com/vitessce/vitessce/discussions/new) to provide feedback.
+
+## Feature observation matrix support
+
+<table>
+    <tr>
+        <th>Issue</th>
+        <td><a href="https://github.com/vitessce/vitessce/issues/1128">vitessce#1128</a></td>
+    </tr>
+    <tr>
+        <th>Status</th>
+        <td>Preliminary implementation on <a href="https://github.com/vitessce/vitessce/tree/keller-mark/obs-feature-generalizations">branch</a></td>
+    </tr>
+    <tr>
+        <th>Use case</th>
+        <td>Enable visualization of single-cell datasets containing both cell-by-gene (gene expression) and cell-by-peak (chromatin accessibility) measurements without the need to first create assay-specific data types, views, and coordination types.</td>
+    </tr>
+</table>
+
+
+## Multi-dataset views
+
+<table>
+    <tr>
+        <th>Issue</th>
+        <td><a href="https://github.com/vitessce/vitessce/issues/1157">vitessce#1157</a></td>
+    </tr>
+    <tr>
+        <th>Status</th>
+        <td>Prototype implementation complete in fork</td>
+    </tr>
+    <tr>
+        <th>Use case</th>
+        <td>Enable simultaneous visualization of query and reference datasets to evaluate single-cell data integration methods.</td>
+    </tr>
+</table>
+
+## More scalable visualization of molecules
+
+<table>
+    <tr>
+        <th>Status</th>
+        <td>Multiple prototype implementations <a href="https://github.com/vitessce/vitessce/tree/keller-mark/merfish-merge">in-progress</a> or <a href="https://github.com/vitessce/vitessce/tree/keller-mark/baysor-v2">complete</a> (<a href="https://s3.amazonaws.com/vitessce-data/demos/2021-10-18/8f814e89/index.html?dataset=petukhov-2021-nat-biotechnol">demo</a>) (reflecting multiple custom file formats). Due to the lack of standard or consensus [cloud-friendly] file formats for this type of data (<a href="https://github.com/ome/ngff/pull/64">ngff#64</a>, <a href="https://github.com/theislab/anndata/issues/609">anndata#609</a>, <a href="https://github.com/ome/ngff/issues/31">ngff#31</a>), official support may ultimately depend on plugin data loaders and views (see below).</td>
+    </tr>
+    <tr>
+        <th>Use case</th>
+        <td>Visualize a MERFISH dataset containing millions of barcodes across hundreds of fields of view, with barcodes rendered as scatterplot points above an individual z-slice of the raw image data.</td>
+    </tr>
+</table>
+
+
+## Plugin data loaders
+
+<table>
+    <tr>
+        <th>Issue</th>
+        <td><a href="https://github.com/vitessce/vitessce/issues/797">vitessce#797</a></td>
+    </tr>
+    <tr>
+        <th>Status</th>
+        <td>Not yet started</td>
+    </tr>
+    <tr>
+        <th>Use case</th>
+        <td>Simplify the process of supporting additional/custom file formats.</td>
+    </tr>
+</table>
+
+## Plugin views
+
+<table>
+    <tr>
+        <th>Issue</th>
+        <td><a href="https://github.com/vitessce/vitessce/issues/875">vitessce#875</a></td>
+    </tr>
+    <tr>
+        <th>Status</th>
+        <td>Not yet started</td>
+    </tr>
+    <tr>
+        <th>Use case</th>
+        <td>Simplify the process of supporting additional/custom visualizations.</td>
+    </tr>
+</table>
+
+## MuData-Zarr support
+
+<table>
+    <tr>
+        <th>Issue</th>
+        <td><a href="https://github.com/vitessce/vitessce/issues/1119">vitessce#1119</a></td>
+    </tr>
+    <tr>
+        <th>Status</th>
+        <td>In-progress implementation on <a href="https://github.com/vitessce/vitessce/tree/keller-mark/mudata-loaders-v2">branch</a></td>
+    </tr>
+    <tr>
+        <th>Use case</th>
+        <td>Load a multi-modal dataset stored as a MuData object written to a Zarr store.</td>
+    </tr>
+</table>
+
+## R package refactor
+
+<table>
+    <tr>
+        <th>Issue</th>
+        <td><a href="https://github.com/vitessce/vitessceR/issues/56">vitessceR#56</a></td>
+    </tr>
+    <tr>
+        <th>Status</th>
+        <td>Not yet started</td>
+    </tr>
+</table>
+
+
+## Sidebar
+
+<table>
+    <tr>
+        <th>Issue</th>
+        <td><a href="https://github.com/vitessce/vitessce/issues/865">vitessce#865</a></td>
+    </tr>
+    <tr>
+        <th>Status</th>
+        <td>In-progress implementation on <a href="https://github.com/vitessce/vitessce/tree/keller-mark/sidebar-v2">branch</a></td>
+    </tr>
+    <tr>
+        <th>Use case</th>
+        <td>Update the view config, for instance to add a view to the current layout, using a GUI or interactive JSON editor.</td>
+    </tr>
+</table>

--- a/docs/sidebars.js
+++ b/docs/sidebars.js
@@ -52,6 +52,10 @@ module.exports = {
     },
     {
       type: 'doc',
+      id: 'roadmap'
+    },
+    {
+      type: 'doc',
       id: 'about'
     } 
   ],


### PR DESCRIPTION

<!-- For other PRs without open issue -->
#### Background
<!-- For all the PRs -->
I wanted to make it more clear to users (or prospective users) about the current state of major planned or in-progress features. I also started to update the docs to use the term "view" rather than "component" since I think "view" is more clear in the view config context, while "component" is more clear in the React / development context.

#### Change List
- Add a roadmap page to the documentation site.

#### Checklist
 - [x] Documentation added or updated