### PR TITLE
Lookup Table for Heatmap Tiling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 - Upgrade Viv to 0.12.6 to fix shader compilation issue with interleaved RGB images
 - Fixed layer controller raster channel slider bug, related to [MUI slider issue](https://github.com/mui/material-ui/issues/20896).
 - Started to update the documentation to use the term "view" rather than "component".
+- Use a hash table lookup instead of calling `indexOf` repeatedly for the heatmap component tiling.
 
 ## [1.1.18](https://www.npmjs.com/package/vitessce/v/1.1.18) - 2022-02-14
 

--- a/src/components/heatmap/Heatmap.js
+++ b/src/components/heatmap/Heatmap.js
@@ -299,14 +299,13 @@ const Heatmap = forwardRef((props, deckRef) => {
     const curr = backlog[backlog.length - 1];
     if (dataRef.current
       && dataRef.current.buffer.byteLength && Object.keys(expressionRowLookUp).length > 0) {
-      const { rows, cols, matrix } = expression;
+      const { cols, matrix } = expression;
       const promises = range(yTiles).map(i => range(xTiles).map(async j => workerPool.process({
         curr,
         tileI: i,
         tileJ: j,
         tileSize: TILE_SIZE,
         cellOrdering: transpose ? axisTopLabels : axisLeftLabels,
-        rows,
         cols,
         transpose,
         data: matrix.buffer.slice(),

--- a/src/components/heatmap/Heatmap.js
+++ b/src/components/heatmap/Heatmap.js
@@ -174,10 +174,10 @@ const Heatmap = forwardRef((props, deckRef) => {
   // Creating a look up dictionary once is faster than calling indexOf many times
   // i.e when cell ordering changes.
   const expressionRowLookUp = useMemo(() => {
-    const lookUp = {};
+    const lookUp = new Map();
     if (expression?.rows) {
       // eslint-disable-next-line no-return-assign
-      expression.rows.forEach((cell, j) => (lookUp[cell] = j));
+      expression.rows.forEach((cell, j) => (lookUp.set(cell, j)));
     }
     return lookUp;
   }, [expression]);
@@ -298,7 +298,7 @@ const Heatmap = forwardRef((props, deckRef) => {
     }
     const curr = backlog[backlog.length - 1];
     if (dataRef.current
-      && dataRef.current.buffer.byteLength && Object.keys(expressionRowLookUp).length > 0) {
+      && dataRef.current.buffer.byteLength && expressionRowLookUp.size > 0) {
       const { cols, matrix } = expression;
       const promises = range(yTiles).map(i => range(xTiles).map(async j => workerPool.process({
         curr,

--- a/src/components/heatmap/heatmap.worker.js
+++ b/src/components/heatmap/heatmap.worker.js
@@ -17,6 +17,8 @@ import { getCellByGeneTile, getGeneByCellTile } from './utils';
  * @param {ArrayBuffer} params.data The array buffer.
  * Need to transfer back to main thread when done.
  * @param {boolean} params.transpose Is the heatmap transposed?
+ * @param {boolean} params.expressionRowLookUp A lookup table for the array index of a given cell.
+ * This is needed for performance reasons instead of calling `indexOf` repeatedly.
  * @returns {array} [message, transfers]
  */
 function getTile({

--- a/src/components/heatmap/heatmap.worker.js
+++ b/src/components/heatmap/heatmap.worker.js
@@ -29,6 +29,7 @@ function getTile({
   cols,
   data,
   transpose,
+  expressionRowLookUp,
 }) {
   const view = new Uint8Array(data);
 
@@ -47,6 +48,7 @@ function getTile({
       numGenes,
       cellOrdering,
       cells: rows,
+      expressionRowLookUp,
     },
   );
   return [{ tile: result, buffer: data, curr }, [data]];

--- a/src/components/heatmap/heatmap.worker.js
+++ b/src/components/heatmap/heatmap.worker.js
@@ -10,8 +10,6 @@ import { getCellByGeneTile, getGeneByCellTile } from './utils';
  * @param {number} params.yTiles How many tiles required in the y direction?
  * @param {number} params.tileSize How many entries along each tile axis?
  * @param {string[]} params.cellOrdering The current ordering of cells.
- * @param {string[]} params.rows The name of each row (cell ID).
- * Does not take transpose into account (always cells).
  * @param {string[]} params.cols The name of each column (gene ID).
  * Does not take transpose into account (always genes).
  * @param {ArrayBuffer} params.data The array buffer.
@@ -27,7 +25,6 @@ function getTile({
   tileJ,
   tileSize,
   cellOrdering,
-  rows,
   cols,
   data,
   transpose,
@@ -49,7 +46,6 @@ function getTile({
       numCells,
       numGenes,
       cellOrdering,
-      cells: rows,
       expressionRowLookUp,
     },
   );

--- a/src/components/heatmap/utils.js
+++ b/src/components/heatmap/utils.js
@@ -8,7 +8,7 @@ import {
 } from '../../layers/heatmap-constants';
 
 export function getGeneByCellTile(view, {
-  tileSize, tileI, tileJ, numCells, numGenes, cellOrdering, cells,
+  tileSize, tileI, tileJ, numCells, numGenes, cellOrdering, expressionRowLookUp,
 }) {
   const tileData = new Uint8Array(tileSize * tileSize);
   let offset;
@@ -23,7 +23,7 @@ export function getGeneByCellTile(view, {
     // Need to iterate over cells in the outer loop.
     cellI = (tileJ * tileSize) + j;
     if (cellI < numCells) {
-      sortedCellI = cells.indexOf(cellOrdering[cellI]);
+      sortedCellI = expressionRowLookUp[cellOrdering[cellI]];
       if (sortedCellI >= -1) {
         tileSizeRange.forEach((i) => {
           geneI = (tileI * tileSize) + i;
@@ -38,7 +38,7 @@ export function getGeneByCellTile(view, {
 }
 
 export function getCellByGeneTile(view, {
-  tileSize, tileI, tileJ, numCells, numGenes, cellOrdering, cells,
+  tileSize, tileI, tileJ, numCells, numGenes, cellOrdering, expressionRowLookUp,
 }) {
   const tileData = new Uint8Array(tileSize * tileSize);
   let offset;
@@ -53,7 +53,7 @@ export function getCellByGeneTile(view, {
     // Need to iterate over cells in the outer loop.
     cellI = (tileI * tileSize) + i;
     if (cellI < numCells) {
-      sortedCellI = cells.indexOf(cellOrdering[cellI]);
+      sortedCellI = expressionRowLookUp[cellOrdering[cellI]];
       if (sortedCellI >= -1) {
         tileSizeRange.forEach((j) => {
           geneI = (tileJ * tileSize) + j;

--- a/src/components/heatmap/utils.js
+++ b/src/components/heatmap/utils.js
@@ -23,7 +23,7 @@ export function getGeneByCellTile(view, {
     // Need to iterate over cells in the outer loop.
     cellI = (tileJ * tileSize) + j;
     if (cellI < numCells) {
-      sortedCellI = expressionRowLookUp[cellOrdering[cellI]];
+      sortedCellI = expressionRowLookUp.get(cellOrdering[cellI]);
       if (sortedCellI >= -1) {
         tileSizeRange.forEach((i) => {
           geneI = (tileI * tileSize) + i;
@@ -53,7 +53,7 @@ export function getCellByGeneTile(view, {
     // Need to iterate over cells in the outer loop.
     cellI = (tileI * tileSize) + i;
     if (cellI < numCells) {
-      sortedCellI = expressionRowLookUp[cellOrdering[cellI]];
+      sortedCellI = expressionRowLookUp.get(cellOrdering[cellI]);
       if (sortedCellI >= -1) {
         tileSizeRange.forEach((j) => {
           geneI = (tileJ * tileSize) + j;

--- a/src/components/heatmap/utils.test.js
+++ b/src/components/heatmap/utils.test.js
@@ -9,12 +9,14 @@ describe('heatmap tiling utils', () => {
   it('creates cell x gene tiles (transpose = false)', () => {
     const arr = expressionMatrix.matrix;
     const numGenes = expressionMatrix.cols.length;
-    const cells = expressionMatrix.rows;
+    const expressionRowLookUp = {};
+    // eslint-disable-next-line no-return-assign
+    expressionMatrix.rows.forEach((i, j) => expressionRowLookUp[i] = j);
     const cellOrdering = expressionMatrix.rows; // no re-ordering
     const numCells = cellOrdering.length;
     // Tile (0, 0)
     const tile00 = getCellByGeneTile(arr, {
-      tileSize: 3, numCells, numGenes, tileI: 0, tileJ: 0, cellOrdering, cells,
+      tileSize: 3, numCells, numGenes, tileI: 0, tileJ: 0, cellOrdering, expressionRowLookUp,
     });
     expect(Array.from(tile00)).toEqual([
       0, 255, 255,
@@ -23,7 +25,7 @@ describe('heatmap tiling utils', () => {
     ]);
     // Tile (0, 1)
     const tile01 = getCellByGeneTile(arr, {
-      tileSize: 3, numCells, numGenes, tileI: 0, tileJ: 1, cellOrdering, cells,
+      tileSize: 3, numCells, numGenes, tileI: 0, tileJ: 1, cellOrdering, expressionRowLookUp,
     });
     expect(Array.from(tile01)).toEqual([
       0, 0, 0,
@@ -32,7 +34,7 @@ describe('heatmap tiling utils', () => {
     ]);
     // Tile (1, 0)
     const tile10 = getCellByGeneTile(arr, {
-      tileSize: 3, numCells, numGenes, tileI: 1, tileJ: 0, cellOrdering, cells,
+      tileSize: 3, numCells, numGenes, tileI: 1, tileJ: 0, cellOrdering, expressionRowLookUp,
     });
     expect(Array.from(tile10)).toEqual([
       0, 0, 0,
@@ -44,11 +46,13 @@ describe('heatmap tiling utils', () => {
   it('creates gene x cell tile (transpose = true)', () => {
     const arr = expressionMatrix.matrix;
     const numGenes = expressionMatrix.cols.length;
-    const cells = expressionMatrix.rows;
     const cellOrdering = expressionMatrix.rows; // no re-ordering
     const numCells = cellOrdering.length;
+    const expressionRowLookUp = {};
+    // eslint-disable-next-line no-return-assign
+    expressionMatrix.rows.forEach((i, j) => (expressionRowLookUp[i] = j));
     const tile00 = getGeneByCellTile(arr, {
-      tileSize: 3, numCells, numGenes, tileI: 0, tileJ: 0, cellOrdering, cells,
+      tileSize: 3, numCells, numGenes, tileI: 0, tileJ: 0, cellOrdering, expressionRowLookUp,
     });
     expect(Array.from(tile00)).toEqual([
       255, 0, 255,
@@ -56,7 +60,7 @@ describe('heatmap tiling utils', () => {
       0, 0, 0,
     ]);
     const tile01 = getGeneByCellTile(arr, {
-      tileSize: 3, numCells, numGenes, tileI: 0, tileJ: 1, cellOrdering, cells,
+      tileSize: 3, numCells, numGenes, tileI: 0, tileJ: 1, cellOrdering, expressionRowLookUp,
     });
     expect(Array.from(tile01)).toEqual([
       0, 0, 0,
@@ -64,7 +68,7 @@ describe('heatmap tiling utils', () => {
       0, 0, 0,
     ]);
     const tile10 = getGeneByCellTile(arr, {
-      tileSize: 3, numCells, numGenes, tileI: 1, tileJ: 0, cellOrdering, cells,
+      tileSize: 3, numCells, numGenes, tileI: 1, tileJ: 0, cellOrdering, expressionRowLookUp,
     });
     expect(Array.from(tile10)).toEqual([
       255, 255, 255,
@@ -76,12 +80,14 @@ describe('heatmap tiling utils', () => {
   it('creates cell x gene tiles (transpose = false) with re-ordered cells', () => {
     const arr = expressionMatrix.matrix;
     const numGenes = expressionMatrix.cols.length;
-    const cells = expressionMatrix.rows;
+    const expressionRowLookUp = {};
+    // eslint-disable-next-line no-return-assign
+    expressionMatrix.rows.forEach((i, j) => (expressionRowLookUp[i] = j));
     const cellOrdering = Array.from(cellColors.keys());
     const numCells = cellOrdering.length;
     // Tile (0, 0)
     const tile00 = getCellByGeneTile(arr, {
-      tileSize: 3, numCells, numGenes, tileI: 0, tileJ: 0, cellOrdering, cells,
+      tileSize: 3, numCells, numGenes, tileI: 0, tileJ: 0, cellOrdering, expressionRowLookUp,
     });
     expect(Array.from(tile00)).toEqual([
       0, 255, 0,
@@ -90,7 +96,7 @@ describe('heatmap tiling utils', () => {
     ]);
     // Tile (0, 1)
     const tile01 = getCellByGeneTile(arr, {
-      tileSize: 3, numCells, numGenes, tileI: 0, tileJ: 1, cellOrdering, cells,
+      tileSize: 3, numCells, numGenes, tileI: 0, tileJ: 1, cellOrdering, expressionRowLookUp,
     });
     expect(Array.from(tile01)).toEqual([
       0, 0, 0,
@@ -99,7 +105,7 @@ describe('heatmap tiling utils', () => {
     ]);
     // Tile (1, 0)
     const tile10 = getCellByGeneTile(arr, {
-      tileSize: 3, numCells, numGenes, tileI: 1, tileJ: 0, cellOrdering, cells,
+      tileSize: 3, numCells, numGenes, tileI: 1, tileJ: 0, cellOrdering, expressionRowLookUp,
     });
     expect(Array.from(tile10)).toEqual([
       0, 0, 0,

--- a/src/components/heatmap/utils.test.js
+++ b/src/components/heatmap/utils.test.js
@@ -9,9 +9,9 @@ describe('heatmap tiling utils', () => {
   it('creates cell x gene tiles (transpose = false)', () => {
     const arr = expressionMatrix.matrix;
     const numGenes = expressionMatrix.cols.length;
-    const expressionRowLookUp = {};
+    const expressionRowLookUp = new Map();
     // eslint-disable-next-line no-return-assign
-    expressionMatrix.rows.forEach((i, j) => expressionRowLookUp[i] = j);
+    expressionMatrix.rows.forEach((i, j) => expressionRowLookUp.set(i, j));
     const cellOrdering = expressionMatrix.rows; // no re-ordering
     const numCells = cellOrdering.length;
     // Tile (0, 0)
@@ -48,9 +48,9 @@ describe('heatmap tiling utils', () => {
     const numGenes = expressionMatrix.cols.length;
     const cellOrdering = expressionMatrix.rows; // no re-ordering
     const numCells = cellOrdering.length;
-    const expressionRowLookUp = {};
+    const expressionRowLookUp = new Map();
     // eslint-disable-next-line no-return-assign
-    expressionMatrix.rows.forEach((i, j) => (expressionRowLookUp[i] = j));
+    expressionMatrix.rows.forEach((i, j) => expressionRowLookUp.set(i, j));
     const tile00 = getGeneByCellTile(arr, {
       tileSize: 3, numCells, numGenes, tileI: 0, tileJ: 0, cellOrdering, expressionRowLookUp,
     });
@@ -80,9 +80,9 @@ describe('heatmap tiling utils', () => {
   it('creates cell x gene tiles (transpose = false) with re-ordered cells', () => {
     const arr = expressionMatrix.matrix;
     const numGenes = expressionMatrix.cols.length;
-    const expressionRowLookUp = {};
+    const expressionRowLookUp = new Map();
     // eslint-disable-next-line no-return-assign
-    expressionMatrix.rows.forEach((i, j) => (expressionRowLookUp[i] = j));
+    expressionMatrix.rows.forEach((i, j) => expressionRowLookUp.set(i, j));
     const cellOrdering = Array.from(cellColors.keys());
     const numCells = cellOrdering.length;
     // Tile (0, 0)


### PR DESCRIPTION
#### Background
A lot of the time spent on the workers for the heatmap is just calling `indexOf` so this speeds things up quite a bit.  It's still not as fast as #1151 but #1151 might be too complicated (i.e not worth committing) in light of the not-so-bad performance here.
#### Change List
- Usa a hash table lookup instead of calling `indexOf` repeatedly for the heatmap.
#### Checklist
 - [x] Ensure PR works with all demos on the dev.vitessce.io homepage
 - [ ] Open (draft) PR's into [`vitessce-python`](https://github.com/vitessce/vitessce-python) and [`vitessce-r`](https://github.com/vitessce/vitessce-r) if this is a release PR
 - [x] Documentation added or updated