### PR TITLE
PR into var_alias PR

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,15 +1,13 @@
 
 ### Added
+- Support `var` alias for AnnData to display altenrative gene names via new `geneAlias` field.
 
 ### Changed
 
 ## [1.1.19](https://www.npmjs.com/package/vitessce/v/1.1.19) - 2022-03-30
 
-
-
 ### Added
 - Added a roadmap page to the documentation.
-- Support `var` alias for AnnData to display altenrative gene names via new `geneAlias` field.
 
 ### Changed
 - Update README: Point users to vitessce.io, use smaller screenshots, drop low-level details.

--- a/docs/docs/data-file-types.mdx
+++ b/docs/docs/data-file-types.mdx
@@ -204,7 +204,10 @@ json={`
     // All of the genes in \`var\` will display in the \`Genes\` component though.
     // Use \`geneFilter\` instead if you only want to show a subset of the genes there
     // (this must be defined if the matrix is a subset of AnnData.X).
-    "matrixGeneFilter": "var/highly_variable"
+    "matrixGeneFilter": "var/highly_variable",
+    // The gene alias property supports specifying a column containing
+    // alternative gene identifiers.
+    "geneAlias": "var/hugo_symbol"
   }
 }
 `}
@@ -218,7 +221,10 @@ const options = {
   // All of the genes in \`var\` will display in the \`Genes\` component though.
   // Use \`geneFilter\` instead if you only want to show a subset of the genes there
   // (this must be defined if the matrix is a subset of AnnData.X).
-  "matrixGeneFilter": "var/highly_variable"
+  "matrixGeneFilter": "var/highly_variable",
+  // The gene alias property supports specifying a column containing
+  // alternative gene identifiers.
+  "geneAlias": "var/hugo_symbol"
 };
 const dataset = vc
   .addDataset("My dataset")

--- a/docs/docs/view-config-json.md
+++ b/docs/docs/view-config-json.md
@@ -44,6 +44,9 @@ The view config schema version.
 | `1.0.2`| Auto-detection of 3D images was added in this version. |
 | `1.0.3`| Channel sliders for RGB images was added in this version. |
 | `1.0.4`| The coordination types `embeddingCellOpacity`, `embeddingCellRadiusMode`, and `embeddingCellOpacityMode` were added in this version. |
+| `1.0.5`| Adds support for providing an array of columns (rather than a single column) for the value of the `setName` property within options array items for the `anndata-cell-sets.zarr` file type (to specify a cell set hierarcy). |
+| `1.0.6`| The `scoreName` property within the options array items for the `anndata-cell-sets.zarr` file type was added in this version. |
+| `1.0.7`| The `geneAlias` option for the `anndata-expression-matrix.zarr` file type was added in this version. |
 
 ### `initStrategy`
 - Type: `string`

--- a/src/api/VitessceConfig.js
+++ b/src/api/VitessceConfig.js
@@ -232,7 +232,7 @@ export class VitessceConfig {
    */
   constructor(name = undefined, description = undefined) {
     this.config = {
-      version: '1.0.4',
+      version: '1.0.7',
       name,
       description,
       datasets: [],

--- a/src/app/view-config-upgraders.js
+++ b/src/app/view-config-upgraders.js
@@ -300,7 +300,8 @@ export function upgradeFrom1_0_5(config) {
 }
 
 // Added in version 1.0.7:
-// - Support for aliasing the gene list to a different var
+// - Support for aliasing the gene identifiers using a different var dataframe column
+// via a new `geneAlias` option for the `anndata-expression-matrix.zarr` fileType.
 export function upgradeFrom1_0_6(config) {
   const newConfig = cloneDeep(config);
 

--- a/src/loaders/anndata-loaders/CellSetsZarrLoader.js
+++ b/src/loaders/anndata-loaders/CellSetsZarrLoader.js
@@ -116,13 +116,13 @@ export default class CellSetsZarrLoader extends AbstractTwoStepLoader {
   loadCellSetIds() {
     const { options } = this;
     const cellSetZarrLocation = options.map(({ setName }) => setName);
-    return this.dataSource.loadObsVariables(cellSetZarrLocation);
+    return this.dataSource.loadObsColumns(cellSetZarrLocation);
   }
 
   loadCellSetScores() {
     const { options } = this;
     const cellSetScoreZarrLocation = options.map(option => option.scoreName || undefined);
-    return this.dataSource.loadObsVariables(cellSetScoreZarrLocation);
+    return this.dataSource.loadObsColumns(cellSetScoreZarrLocation);
   }
 
   async load() {

--- a/src/loaders/anndata-loaders/CellsZarrLoader.js
+++ b/src/loaders/anndata-loaders/CellsZarrLoader.js
@@ -69,7 +69,7 @@ export default class CellsZarrLoader extends AbstractTwoStepLoader {
   loadFactors() {
     const { factors } = (this.options || {});
     if (factors) {
-      return this.dataSource.loadObsVariables(factors);
+      return this.dataSource.loadObsColumns(factors);
     }
     return Promise.resolve(null);
   }

--- a/src/loaders/data-sources/AnnDataSource.test.js
+++ b/src/loaders/data-sources/AnnDataSource.test.js
@@ -10,11 +10,11 @@ describe('sources/AnnDataSource', () => {
     expect(zGroup.zarr_format).toEqual(2);
   });
 
-  it('loadVariables returns ids for location in store', async () => {
+  it('loadObsColumns returns ids for location in store', async () => {
     const dataSource = new AnnDataSource({
       url: 'http://127.0.0.1:8080/anndata/anndata-dense.zarr',
     });
-    const ids = await dataSource.loadObsVariables(['obs/leiden']);
+    const ids = await dataSource.loadObsColumns(['obs/leiden']);
     expect(ids).toEqual([['1', '1', '2']]);
   });
 

--- a/src/schemas/config-1.0.7.schema.test.js
+++ b/src/schemas/config-1.0.7.schema.test.js
@@ -1,6 +1,6 @@
 import expect from 'expect';
 import { CoordinationType } from '../app/constants';
-import viewConfigSchema from './config-1.0.6.schema.json';
+import viewConfigSchema from './config-1.0.7.schema.json';
 
 describe('view config schema', () => {
   describe('coordination types', () => {


### PR DESCRIPTION
<!-- Credit (as a starting template): https://github.com/visgl/deck.gl/blob/master/.github/pull_request_template.md -->

#### Change List
- Makes the `loadVariable` more general to support more than obs and var dataframes (such as `uns/my_col` for example)
- Documentation for the `geneAlias` property

#### Checklist
 - [ ] Ensure PR works with all demos on the dev.vitessce.io homepage
 - [ ] Open (draft) PR's into [`vitessce-python`](https://github.com/vitessce/vitessce-python) and [`vitessce-r`](https://github.com/vitessce/vitessce-r) if this is a release PR
 - [x] Documentation added or updated