### PR TITLE
`npm run start:nolint` script

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
   - `featureType`
   - `featureValueType`
 - Add more usage examples to the `about` documentation page.
+- Added `npm run start:nolint` script to disable linting for quickly prototyping code.
 
 ### Changed
 - Fixed buggy view closing behavior by using the view `uid` rather than the index as the component `key`.

--- a/package.json
+++ b/package.json
@@ -174,6 +174,7 @@
     "prepublishOnly": "npm run build-lib:prod",
     "clean": "rm -r dist-demo dist",
     "start": "node scripts/start-demo.js",
+    "start:nolint": "node scripts/start-demo.js --disable-linting",
     "start:fixtures": "http-server src/loaders/fixtures/ --cors=\"*\" -s",
     "start:fixtures-concurrently": "concurrently --kill-others \"npm run start:fixtures\"",
     "test": "node scripts/karma.run.js",

--- a/scripts/build-demo.js
+++ b/scripts/build-demo.js
@@ -17,6 +17,6 @@ const target = 'demo';
 const environment = process.argv[2];
 // Build demo output files.
 (async () => {
-    const config = configFactory(paths, environment, false);
+    const config = configFactory(paths, environment, true);
     await utils.build(config, paths, environment, target);
 })();

--- a/scripts/build-demo.js
+++ b/scripts/build-demo.js
@@ -17,6 +17,6 @@ const target = 'demo';
 const environment = process.argv[2];
 // Build demo output files.
 (async () => {
-    const config = configFactory(paths, environment);
+    const config = configFactory(paths, environment, false);
     await utils.build(config, paths, environment, target);
 })();

--- a/scripts/karma.config.js
+++ b/scripts/karma.config.js
@@ -31,7 +31,7 @@ module.exports = config => {
       '**/*.js': ['webpack', 'sourcemap']
     },
 
-    webpack: configFactory(paths, process.env.NODE_ENV),
+    webpack: configFactory(paths, process.env.NODE_ENV, false),
     webpackServer: {
       noInfo: true // please don't spam the console when running in karma!
     },

--- a/scripts/karma.config.js
+++ b/scripts/karma.config.js
@@ -31,7 +31,7 @@ module.exports = config => {
       '**/*.js': ['webpack', 'sourcemap']
     },
 
-    webpack: configFactory(paths, process.env.NODE_ENV, false),
+    webpack: configFactory(paths, process.env.NODE_ENV, true),
     webpackServer: {
       noInfo: true // please don't spam the console when running in karma!
     },

--- a/scripts/start-demo.js
+++ b/scripts/start-demo.js
@@ -32,7 +32,7 @@ const createDevServerConfig = require('./webpackDevServer.config');
 utils.scriptInit();
 utils.checkRequiredFilesForTarget(paths, true);
 
-const isLintingDisabled = process.argv[2] == "--disable-linting";
+const isLintingEnabled = process.argv[2] !== "--disable-linting";
 
 const isEnvDevelopment = true;
 const publicUrlOrPath = getPublicUrlOrPath(isEnvDevelopment, ".", process.env.PUBLIC_URL);
@@ -60,7 +60,7 @@ checkBrowsers(paths.appPath, isInteractive)
       return;
     }
     
-    const config = configFactory(paths, process.env.NODE_ENV, isLintingDisabled);
+    const config = configFactory(paths, process.env.NODE_ENV, isLintingEnabled);
     const protocol = process.env.HTTPS === 'true' ? 'https' : 'http';
     const appName = require(paths.appPackageJson).name;
     const useTypeScript = false;

--- a/scripts/start-demo.js
+++ b/scripts/start-demo.js
@@ -32,6 +32,8 @@ const createDevServerConfig = require('./webpackDevServer.config');
 utils.scriptInit();
 utils.checkRequiredFilesForTarget(paths, true);
 
+const isLintingDisabled = process.argv[2] == "--disable-linting";
+
 const isEnvDevelopment = true;
 const publicUrlOrPath = getPublicUrlOrPath(isEnvDevelopment, ".", process.env.PUBLIC_URL);
 
@@ -58,7 +60,7 @@ checkBrowsers(paths.appPath, isInteractive)
       return;
     }
     
-    const config = configFactory(paths, process.env.NODE_ENV);
+    const config = configFactory(paths, process.env.NODE_ENV, isLintingDisabled);
     const protocol = process.env.HTTPS === 'true' ? 'https' : 'http';
     const appName = require(paths.appPackageJson).name;
     const useTypeScript = false;

--- a/scripts/webpack.config-common.js
+++ b/scripts/webpack.config-common.js
@@ -333,7 +333,7 @@ function getAdditionalModulePaths(paths) {
   );
 }
 
-function getModuleInfo(paths, environment, publicUrlOrPath, shouldUseSourceMap) {
+function getModuleInfo(paths, environment, publicUrlOrPath, shouldUseSourceMap, isLintingDisabled) {
   const isEnvProduction = environment === 'production';
 
   return {
@@ -344,7 +344,7 @@ function getModuleInfo(paths, environment, publicUrlOrPath, shouldUseSourceMap) 
 
       // First, run the linter.
       // It's important to do this before Babel processes the JS.
-      {
+      ...(isLintingDisabled ? [] : [{
         test: /\.(js|mjs|jsx|ts|tsx)$/,
         enforce: 'pre',
         use: [
@@ -360,7 +360,7 @@ function getModuleInfo(paths, environment, publicUrlOrPath, shouldUseSourceMap) 
           },
         ],
         include: paths.appSrc,
-      },
+      }]),
       {
         // "oneOf" will traverse all following loaders until one will
         // match the requirements. When no loader matches it will fall

--- a/scripts/webpack.config-common.js
+++ b/scripts/webpack.config-common.js
@@ -333,7 +333,7 @@ function getAdditionalModulePaths(paths) {
   );
 }
 
-function getModuleInfo(paths, environment, publicUrlOrPath, shouldUseSourceMap, isLintingDisabled) {
+function getModuleInfo(paths, environment, publicUrlOrPath, shouldUseSourceMap, shouldLint) {
   const isEnvProduction = environment === 'production';
 
   return {
@@ -344,7 +344,7 @@ function getModuleInfo(paths, environment, publicUrlOrPath, shouldUseSourceMap, 
 
       // First, run the linter.
       // It's important to do this before Babel processes the JS.
-      ...(isLintingDisabled ? [] : [{
+      ...(shouldLint ? [{
         test: /\.(js|mjs|jsx|ts|tsx)$/,
         enforce: 'pre',
         use: [
@@ -360,7 +360,7 @@ function getModuleInfo(paths, environment, publicUrlOrPath, shouldUseSourceMap, 
           },
         ],
         include: paths.appSrc,
-      }]),
+      }] : []),
       {
         // "oneOf" will traverse all following loaders until one will
         // match the requirements. When no loader matches it will fall

--- a/scripts/webpack.config-demo.js
+++ b/scripts/webpack.config-demo.js
@@ -37,7 +37,7 @@ const useTypeScript = false;
  * {object} paths Paths object (such as the one exported from ./paths)
  * {string} environment One of "development", "production"
  */
-module.exports = function(paths, environment) {
+module.exports = function(paths, environment, isLintingDisabled) {
     process.env.BABEL_ENV = environment;
     process.env.PUBLIC_URL = '';
 
@@ -55,7 +55,7 @@ module.exports = function(paths, environment) {
     const devtoolInfo = getDevtoolInfo(environment, shouldUseSourceMap);
     const resolveInfo = getResolveInfo(paths, additionalModulePaths, useTypeScript, shouldDoProfiling, webpackAliases);
     const resolveLoaderInfo = getResolveLoaderInfo();
-    const moduleInfo = getModuleInfo(paths, environment, publicUrlOrPath, shouldUseSourceMap);
+    const moduleInfo = getModuleInfo(paths, environment, publicUrlOrPath, shouldUseSourceMap, isLintingDisabled);
     const nodeInfo = getNodeInfo();
     const performanceInfo = getPerformanceInfo();
 

--- a/scripts/webpack.config-demo.js
+++ b/scripts/webpack.config-demo.js
@@ -37,7 +37,7 @@ const useTypeScript = false;
  * {object} paths Paths object (such as the one exported from ./paths)
  * {string} environment One of "development", "production"
  */
-module.exports = function(paths, environment, isLintingDisabled) {
+module.exports = function(paths, environment, shouldLint) {
     process.env.BABEL_ENV = environment;
     process.env.PUBLIC_URL = '';
 
@@ -55,7 +55,7 @@ module.exports = function(paths, environment, isLintingDisabled) {
     const devtoolInfo = getDevtoolInfo(environment, shouldUseSourceMap);
     const resolveInfo = getResolveInfo(paths, additionalModulePaths, useTypeScript, shouldDoProfiling, webpackAliases);
     const resolveLoaderInfo = getResolveLoaderInfo();
-    const moduleInfo = getModuleInfo(paths, environment, publicUrlOrPath, shouldUseSourceMap, isLintingDisabled);
+    const moduleInfo = getModuleInfo(paths, environment, publicUrlOrPath, shouldUseSourceMap, shouldLint);
     const nodeInfo = getNodeInfo();
     const performanceInfo = getPerformanceInfo();
 

--- a/scripts/webpack.config-lib.js
+++ b/scripts/webpack.config-lib.js
@@ -55,7 +55,7 @@ module.exports = function(paths, environment, target) {
     const devtoolInfo = getDevtoolInfo(environment, shouldUseSourceMap);
     const resolveInfo = getResolveInfo(paths, additionalModulePaths, useTypeScript, shouldDoProfiling, webpackAliases);
     const resolveLoaderInfo = getResolveLoaderInfo();
-    const moduleInfo = getModuleInfo(paths, environment, publicUrlOrPath, shouldUseSourceMap, false);
+    const moduleInfo = getModuleInfo(paths, environment, publicUrlOrPath, shouldUseSourceMap, true);
     const nodeInfo = getNodeInfo();
     const performanceInfo = getPerformanceInfo();
 

--- a/scripts/webpack.config-lib.js
+++ b/scripts/webpack.config-lib.js
@@ -55,7 +55,7 @@ module.exports = function(paths, environment, target) {
     const devtoolInfo = getDevtoolInfo(environment, shouldUseSourceMap);
     const resolveInfo = getResolveInfo(paths, additionalModulePaths, useTypeScript, shouldDoProfiling, webpackAliases);
     const resolveLoaderInfo = getResolveLoaderInfo();
-    const moduleInfo = getModuleInfo(paths, environment, publicUrlOrPath, shouldUseSourceMap);
+    const moduleInfo = getModuleInfo(paths, environment, publicUrlOrPath, shouldUseSourceMap, false);
     const nodeInfo = getNodeInfo();
     const performanceInfo = getPerformanceInfo();
 


### PR DESCRIPTION
#### Background
It can be helpful to disable linting when quickly prototyping code or making a lot of changes before cleaning up when ready to make a PR.

#### Change List
- Adds the script `npm run start:nolint` which disables linting.

#### Checklist
 - [ ] Ensure PR works with all demos on the dev.vitessce.io homepage
 - [ ] Open (draft) PR's into [`vitessce-python`](https://github.com/vitessce/vitessce-python) and [`vitessce-r`](https://github.com/vitessce/vitessce-r) if this is a release PR
 - [ ] Documentation added or updated