### PR TITLE
Update set-node-options script

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -22,7 +22,7 @@ jobs:
         env:
           NODE_OPTIONS: ${{ steps.get-options.outputs.node-options }}
       - name: Deploy to NPM
-        continue-on-error: true
+        continue-on-error: false
         run: npm publish
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_AUTH_TOKEN }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@
 
 
 ### Changed
+- Increase `--max_old_space_size` value from `4096` to `8192` in `set-node-options.sh` script.
 
 
 ## [1.2.0](https://www.npmjs.com/package/vitessce/v/1.2.0) - 2022-07-22

--- a/set-node-options.sh
+++ b/set-node-options.sh
@@ -2,10 +2,10 @@ FULL_VERSION=`node --version`
 MAJOR_VERSION_WITH_V=${FULL_VERSION%.*.*}
 MAJOR_VERSION=${MAJOR_VERSION_WITH_V:1}
 
-V_OPTIONS="--max_old_space_size=4096"
+V_OPTIONS="--max_old_space_size=8192"
 if [ "$MAJOR_VERSION" -gt "17" ]; then
   echo "Set node options for >=17"
-  V_OPTIONS="--max_old_space_size=4096 --openssl-legacy-provider"
+  V_OPTIONS="--max_old_space_size=8192 --openssl-legacy-provider"
 fi
 
 if [[ "$1" == "--action" ]]; then


### PR DESCRIPTION
v1.2.0 and v1.2.1 did not deploy via github actions:
- https://github.com/vitessce/vitessce/runs/8122998915?check_suite_focus=true
- https://github.com/vitessce/vitessce/runs/7505874619?check_suite_focus=true

due to `FATAL ERROR: Reached heap limit Allocation failed - JavaScript heap out of memory` during `npm run build-lib:prod` which runs as part of `npm publish`


#### Change List
This updates the deployment scripts to increase the memory for node and also re-enables the publish errors
#### Checklist
 - [ ] Ensure PR works with all demos on the dev.vitessce.io homepage
 - [ ] Open (draft) PR's into [`vitessce-python`](https://github.com/vitessce/vitessce-python) and [`vitessce-r`](https://github.com/vitessce/vitessce-r) if this is a release PR
 - [ ] Documentation added or updated