### PR TITLE
Fix deploy CI again

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -15,13 +15,16 @@ jobs:
         with:
           node-version: 16
           registry-url: https://registry.npmjs.org/
+      - id: check-deploy
+        run: . ./check-deploy.sh --action
       - id: get-options
         run: . ./set-node-options.sh --action
       - run: npm ci --legacy-peer-deps
       - run: ./test.sh --deploy-action
         env:
           NODE_OPTIONS: ${{ steps.get-options.outputs.node-options }}
-      - name: Deploy to NPM
+      - if: ${{ steps.check-deploy.outputs.needs-deploy }}
+        name: Deploy to NPM
         run: npm publish
         env:
           NODE_OPTIONS: ${{ steps.get-options.outputs.node-options }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 ### Changed
 
 - Speed up heatmap load times (including when cell ordering changes) by implementing a custom indexing scheme on the shaders (see `src/components/heatmap/heatmap-indexing.pdf` for more info)
+- Fixed deploy workflow to only attempt `npm publish` if the local version is higher than the latest version currently on NPM (indicating that a release is needed).
 
 
 ## [1.2.1](https://www.npmjs.com/package/vitessce/v/1.2.1) - 2022-08-03

--- a/check-deploy.sh
+++ b/check-deploy.sh
@@ -1,0 +1,11 @@
+REMOTE_VERSION=`npm view vitessce --json | jq .version`
+LOCAL_VERSION=`cat ./package.json | jq .version`
+
+function version { echo "$@" | awk -F. '{ printf("%d%03d%03d%03d\n", $1,$2,$3,$4); }'; }
+
+if [ $(version $LOCAL_VERSION) -gt $(version $REMOTE_VERSION) ]; then
+  echo "::set-output name=needs-deploy::true"
+else
+  echo "::set-output name=needs-deploy::false"
+fi
+

--- a/check-deploy.sh
+++ b/check-deploy.sh
@@ -1,6 +1,7 @@
 REMOTE_VERSION=`npm view vitessce --json | jq .version`
 LOCAL_VERSION=`cat ./package.json | jq .version`
 
+# Reference: https://stackoverflow.com/a/37939589
 function version { echo "$@" | awk -F. '{ printf("%d%03d%03d%03d\n", $1,$2,$3,$4); }'; }
 
 if [ $(version $LOCAL_VERSION) -gt $(version $REMOTE_VERSION) ]; then

--- a/create-release.sh
+++ b/create-release.sh
@@ -19,7 +19,9 @@ then
 fi
 
 AWS_ACCT=$(aws iam list-account-aliases --query 'AccountAliases[0]')
-if [[ "$AWS_ACCT" != "gehlenborglab" ]]; then
+# Need to check for substring.
+# Some AWS CLI implementations print gehlenborglab while others print "gehlenborglab"
+if [[ "$AWS_ACCT" != *"gehlenborglab"* ]]; then
     die "Deployment requires authentication with the lab account in the AWS CLI (aws)."
 fi
 


### PR DESCRIPTION
I recently removed the `continue-on-error` line (https://github.com/vitessce/vitessce/pull/1323) from the deploy step because it was hiding true deployment errors. I had forgotten that the reason it was needed in the first place was because when `npm publish` is run on a non-release-PR it throws an error (because NPM (rightly) does not allow publishing the same package twice with the same version number).
