### PR TITLE
(fix): Exclude background with "Zero Transparent"

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,7 @@
   - Converted inline worker bundling to `@vitessce/workers` sub-package with rollup + rollup plugin
   - Converted SVG React component imports to `@vitessce/icons` sub-package with vite + svgr
   - Converted glslify #pragma + webpack plugin to glslify CLI in `@vitessce/gl/src/glsl` with string manipulation to prevent need for plugin
+- Make sure to exclude the background image when using `transparentColor`
 
 
 ## [1.2.2](https://www.npmjs.com/package/vitessce/v/1.2.2) - 2022-09-23

--- a/packages/view-types/spatial/src/Spatial.js
+++ b/packages/view-types/spatial/src/Spatial.js
@@ -395,6 +395,7 @@ class Spatial extends AbstractSpatialOrScatterplot {
       visibilities: layerDef.channels.map(c => (!layerDef.visible && typeof layerDef.visible === 'boolean'
         ? false
         : c.visible)),
+      excludeBackground: useTransparentColor,
     };
 
     if (!loader || !layerProps) return null;
@@ -472,6 +473,7 @@ class Spatial extends AbstractSpatialOrScatterplot {
       ySlice: layerProps.ySlice,
       zSlice: layerProps.zSlice,
       onViewportLoad: layerProps.callback,
+      excludeBackground: layerProps.excludeBackground,
       extensions,
     });
   }


### PR DESCRIPTION
<!-- Credit (as a starting template): https://github.com/visgl/deck.gl/blob/master/.github/pull_request_template.md -->
<!-- For feature, feature enhancement or bug fix, create an issue first and finish To Do List there -->
<!-- Anything doesn't work as expected is a bug, including code, doc and test -->
Fixes #1341.  I think the issue highlights why we need to do this (we did do this for a while, must have been a regression when we refactored to Viv extensions since this functionality no longer lived in the core of the `MultiscaleImageLayer`)
#### Change List
- Make sure to exclude the background image when using "Zero Transparent" feature.
#### Checklist
 - [ ] Ensure PR works with all demos on the dev.vitessce.io homepage
 - [ ] Open (draft) PR's into [`vitessce-python`](https://github.com/vitessce/vitessce-python) and [`vitessce-r`](https://github.com/vitessce/vitessce-r) if this is a release PR
 - [ ] Documentation added or updated