### PR TITLE
Make MUI class names deterministic

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 ### Added
 
 ### Changed
+- Update parameters of MUI `createGenerateClassName` so that class names are deterministic
 
 ## [2.0.1](https://www.npmjs.com/package/vitessce/v/2.0.1) - 2022-11-20
 

--- a/packages/vit-s/src/VitS.js
+++ b/packages/vit-s/src/VitS.js
@@ -26,7 +26,8 @@ import {
 } from './view-config-utils';
 
 const generateClassName = createGenerateClassName({
-  disableGlobal: true,
+  disableGlobal: false, // Class names need to be deterministic
+  productionPrefix: 'vit', // Avoid conflicts with portal-ui MUI class names
 });
 
 function logConfig(config, name) {


### PR DESCRIPTION
Fixes the case in which multiple instances of Vitessce on the same page try to use the same `.jss-X` class name to style different elements.

#### Checklist
 - [ ] Ensure PR works with all demos on the dev.vitessce.io homepage
 - [ ] Open (draft) PR's into [`vitessce-python`](https://github.com/vitessce/vitessce-python) and [`vitessce-r`](https://github.com/vitessce/vitessce-r) if this is a release PR
 - [ ] Documentation added or updated