### PR TITLE
(fix): Cache promises, not payloads, in `AnnData` loaders

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 ### Added
 
 ### Changed
+- Don't `await` AnnData payloads that might be accessed in quickly repeatedly (i.e cache the promise, not the payload).
 
 ## [2.0.1](https://www.npmjs.com/package/vitessce/v/2.0.1) - 2022-11-20
 

--- a/packages/file-types/zarr/src/anndata-loaders/FeatureLabelsAnndataLoader.js
+++ b/packages/file-types/zarr/src/anndata-loaders/FeatureLabelsAnndataLoader.js
@@ -25,14 +25,14 @@ export default class FeatureLabelsAnndataLoader extends AbstractTwoStepLoader {
    * Class method for loading feature string labels.
    * @returns {Promise} A promise for the array.
    */
-  async loadLabels() {
+  loadLabels() {
     const { path } = this.options;
     if (this.labels) {
       return this.labels;
     }
     if (!this.labels) {
       // eslint-disable-next-line no-underscore-dangle
-      this.labels = await this.dataSource._loadColumn(path);
+      this.labels = this.dataSource._loadColumn(path);
       return this.labels;
     }
     this.labels = Promise.resolve(null);

--- a/packages/file-types/zarr/src/anndata-loaders/ObsEmbeddingAnndataLoader.js
+++ b/packages/file-types/zarr/src/anndata-loaders/ObsEmbeddingAnndataLoader.js
@@ -15,13 +15,13 @@ export default class ObsEmbeddingAnndataLoader extends AbstractTwoStepLoader {
    * Class method for loading embedding coordinates, such as those from UMAP or t-SNE.
    * @returns {Promise} A promise for an array of columns.
    */
-  async loadEmbedding() {
+  loadEmbedding() {
     const { path, dims = [0, 1] } = this.options;
     if (this.embedding) {
       return this.embedding;
     }
     if (!this.embedding) {
-      this.embedding = await this.dataSource.loadNumericForDims(path, dims);
+      this.embedding = this.dataSource.loadNumericForDims(path, dims);
       return this.embedding;
     }
     this.embedding = Promise.resolve(null);

--- a/packages/file-types/zarr/src/anndata-loaders/ObsLabelsAnndataLoader.js
+++ b/packages/file-types/zarr/src/anndata-loaders/ObsLabelsAnndataLoader.js
@@ -16,14 +16,14 @@ export default class ObsLabelsAnndataLoader extends AbstractTwoStepLoader {
    * Class method for loading observation string labels.
    * @returns {Promise} A promise for the array.
    */
-  async loadLabels() {
+  loadLabels() {
     const { path } = this.options;
     if (this.labels) {
       return this.labels;
     }
     if (!this.labels) {
       // eslint-disable-next-line no-underscore-dangle
-      this.labels = await this.dataSource._loadColumn(path);
+      this.labels = this.dataSource._loadColumn(path);
       return this.labels;
     }
     this.labels = Promise.resolve(null);

--- a/packages/file-types/zarr/src/anndata-loaders/ObsLocationsAnndataLoader.js
+++ b/packages/file-types/zarr/src/anndata-loaders/ObsLocationsAnndataLoader.js
@@ -15,13 +15,13 @@ export default class ObsLocationsAnndataLoader extends AbstractTwoStepLoader {
    * Class method for loading embedding coordinates, such as those from UMAP or t-SNE.
    * @returns {Promise} A promise for an array of columns.
    */
-  async loadLocations() {
+  loadLocations() {
     const { path, dims = [0, 1] } = this.options;
     if (this.locations) {
       return this.locations;
     }
     if (!this.locations) {
-      this.locations = await this.dataSource.loadNumericForDims(path, dims);
+      this.locations = this.dataSource.loadNumericForDims(path, dims);
       return this.locations;
     }
     this.locations = Promise.resolve(null);

--- a/packages/file-types/zarr/src/anndata-loaders/ObsSegmentationsAnndataLoader.js
+++ b/packages/file-types/zarr/src/anndata-loaders/ObsSegmentationsAnndataLoader.js
@@ -17,13 +17,13 @@ export default class ObsSegmentationsAnndataLoader extends AbstractTwoStepLoader
    * Class method for loading embedding coordinates, such as those from UMAP or t-SNE.
    * @returns {Promise} A promise for an array of columns.
    */
-  async loadSegmentations() {
+  loadSegmentations() {
     const { path } = this.options;
     if (this.segmentations) {
       return this.segmentations;
     }
     if (!this.segmentations) {
-      this.segmentations = await this.dataSource.loadNumeric(path);
+      this.segmentations = this.dataSource.loadNumeric(path);
       return this.segmentations;
     }
     this.segmentations = Promise.resolve(null);


### PR DESCRIPTION
#### Background
I noticed that the `combat` example was loading slowly in 2.0.1 and I think this is part of the reason.  I'm gonna try a few little improvements beyond just this to speed up loading but this is definitely a start.

#### Change List
- Cache the promise not the payload of the AnnData loaders

#### Checklist
 - [x] Ensure PR works with all demos on the dev.vitessce.io homepage
 - [ ] Open (draft) PR's into [`vitessce-python`](https://github.com/vitessce/vitessce-python) and [`vitessce-r`](https://github.com/vitessce/vitessce-r) if this is a release PR
 - [ ] Documentation added or updated