### PR TITLE
(feat): upgrade view configs to use 0.0.34 data

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 - Update parameters of MUI `createGenerateClassName` so that class names are deterministic
 - Fixed broken cell highlight crosshairs upon hover events in scatterplots/spatial/heatmap views by porting SCSS to MUI JSS.
 - Upgrade Viv to `0.13` and deck.gl to `8.8`
+- Move data to `0.0.34`.
 
 ## [2.0.1](https://www.npmjs.com/package/vitessce/v/2.0.1) - 2022-11-20
 

--- a/examples/configs/src/view-configs/codeluppi-via-csv.js
+++ b/examples/configs/src/view-configs/codeluppi-via-csv.js
@@ -10,11 +10,11 @@ export const codeluppiViaCsv = {
       files: [
         {
           fileType: 'obsSegmentations.json',
-          url: 'https://s3.amazonaws.com/vitessce-data/0.0.33/main/codeluppi-2018/codeluppi_2018_nature_methods.cells.segmentations.json',
+          url: 'https://s3.amazonaws.com/vitessce-data/0.0.34/main/codeluppi-2018/codeluppi_2018_nature_methods.cells.segmentations.json',
         },
         {
           fileType: 'obsLocations.csv',
-          url: 'https://s3.amazonaws.com/vitessce-data/0.0.33/main/codeluppi-2018/codeluppi_2018_nature_methods.cells.csv',
+          url: 'https://s3.amazonaws.com/vitessce-data/0.0.34/main/codeluppi-2018/codeluppi_2018_nature_methods.cells.csv',
           options: {
             obsIndex: 'cell_id',
             obsLocations: ['X', 'Y'],
@@ -25,7 +25,7 @@ export const codeluppiViaCsv = {
         },
         {
           fileType: 'obsEmbedding.csv',
-          url: 'https://s3.amazonaws.com/vitessce-data/0.0.33/main/codeluppi-2018/codeluppi_2018_nature_methods.cells.csv',
+          url: 'https://s3.amazonaws.com/vitessce-data/0.0.34/main/codeluppi-2018/codeluppi_2018_nature_methods.cells.csv',
           options: {
             obsIndex: 'cell_id',
             obsEmbedding: ['PCA_1', 'PCA_2'],
@@ -37,7 +37,7 @@ export const codeluppiViaCsv = {
         },
         {
           fileType: 'obsEmbedding.csv',
-          url: 'https://s3.amazonaws.com/vitessce-data/0.0.33/main/codeluppi-2018/codeluppi_2018_nature_methods.cells.csv',
+          url: 'https://s3.amazonaws.com/vitessce-data/0.0.34/main/codeluppi-2018/codeluppi_2018_nature_methods.cells.csv',
           options: {
             obsIndex: 'cell_id',
             obsEmbedding: ['TSNE_1', 'TSNE_2'],
@@ -49,7 +49,7 @@ export const codeluppiViaCsv = {
         },
         {
           fileType: 'obsSets.csv',
-          url: 'https://s3.amazonaws.com/vitessce-data/0.0.33/main/codeluppi-2018/codeluppi_2018_nature_methods.cells.csv',
+          url: 'https://s3.amazonaws.com/vitessce-data/0.0.34/main/codeluppi-2018/codeluppi_2018_nature_methods.cells.csv',
           options: {
             obsIndex: 'cell_id',
             obsSets: [
@@ -65,7 +65,7 @@ export const codeluppiViaCsv = {
         },
         {
           fileType: 'obsLocations.csv',
-          url: 'https://s3.amazonaws.com/vitessce-data/0.0.33/main/codeluppi-2018/codeluppi_2018_nature_methods.molecules.csv',
+          url: 'https://s3.amazonaws.com/vitessce-data/0.0.34/main/codeluppi-2018/codeluppi_2018_nature_methods.molecules.csv',
           options: {
             obsIndex: 'molecule_id',
             obsLocations: ['X', 'Y'],
@@ -76,7 +76,7 @@ export const codeluppiViaCsv = {
         },
         {
           fileType: 'obsLabels.csv',
-          url: 'https://s3.amazonaws.com/vitessce-data/0.0.33/main/codeluppi-2018/codeluppi_2018_nature_methods.molecules.csv',
+          url: 'https://s3.amazonaws.com/vitessce-data/0.0.34/main/codeluppi-2018/codeluppi_2018_nature_methods.molecules.csv',
           options: {
             obsIndex: 'molecule_id',
             obsLabels: 'Gene',
@@ -87,7 +87,7 @@ export const codeluppiViaCsv = {
         },
         {
           fileType: 'obsFeatureMatrix.csv',
-          url: 'https://s3.amazonaws.com/vitessce-data/0.0.33/main/codeluppi-2018/codeluppi_2018_nature_methods.cells.matrix.csv',
+          url: 'https://s3.amazonaws.com/vitessce-data/0.0.34/main/codeluppi-2018/codeluppi_2018_nature_methods.cells.matrix.csv',
           coordinationValues: {
             obsType: 'cell',
             featureType: 'gene',

--- a/examples/configs/src/view-configs/codeluppi-via-zarr.js
+++ b/examples/configs/src/view-configs/codeluppi-via-zarr.js
@@ -10,7 +10,7 @@ export const codeluppiViaZarr = {
       files: [
         {
           fileType: 'anndata.zarr',
-          url: 'https://s3.amazonaws.com/vitessce-data/0.0.33/main/codeluppi-2018-via-zarr/codeluppi_2018_nature_methods.cells.h5ad.zarr',
+          url: 'https://s3.amazonaws.com/vitessce-data/0.0.34/main/codeluppi-2018-via-zarr/codeluppi_2018_nature_methods.cells.h5ad.zarr',
           options: {
             obsFeatureMatrix: {
               path: 'X',
@@ -46,7 +46,7 @@ export const codeluppiViaZarr = {
         },
         {
           fileType: 'anndata.zarr',
-          url: 'https://s3.amazonaws.com/vitessce-data/0.0.33/main/codeluppi-2018-via-zarr/codeluppi_2018_nature_methods.molecules.h5ad.zarr',
+          url: 'https://s3.amazonaws.com/vitessce-data/0.0.34/main/codeluppi-2018-via-zarr/codeluppi_2018_nature_methods.molecules.h5ad.zarr',
           options: {
             obsLocations: {
               path: 'obsm/X_spatial',

--- a/examples/configs/src/view-configs/combat_2022_cell.js
+++ b/examples/configs/src/view-configs/combat_2022_cell.js
@@ -8,7 +8,7 @@ export const combat2022cell = {
     files: [
       {
         fileType: 'obsEmbedding.anndata.zarr',
-        url: 'https://s3.amazonaws.com/vitessce-data/0.0.33/main/combat-2022/combat_2022_cell.h5ad.zarr',
+        url: 'https://s3.amazonaws.com/vitessce-data/0.0.34/main/combat-2022/combat_2022_cell.h5ad.zarr',
         coordinationValues: {
           obsType: 'cell',
           embeddingType: 'UMAP',
@@ -19,7 +19,7 @@ export const combat2022cell = {
       },
       {
         fileType: 'obsSets.anndata.zarr',
-        url: 'https://s3.amazonaws.com/vitessce-data/0.0.33/main/combat-2022/combat_2022_cell.h5ad.zarr',
+        url: 'https://s3.amazonaws.com/vitessce-data/0.0.34/main/combat-2022/combat_2022_cell.h5ad.zarr',
         coordinationValues: {
           obsType: 'cell',
         },
@@ -36,7 +36,7 @@ export const combat2022cell = {
       },
       {
         fileType: 'obsFeatureMatrix.anndata.zarr',
-        url: 'https://s3.amazonaws.com/vitessce-data/0.0.33/main/combat-2022/combat_2022_cell.h5ad.zarr',
+        url: 'https://s3.amazonaws.com/vitessce-data/0.0.34/main/combat-2022/combat_2022_cell.h5ad.zarr',
         coordinationValues: {
           obsType: 'cell',
           featureType: 'gene',
@@ -49,7 +49,7 @@ export const combat2022cell = {
       },
       {
         fileType: 'obsFeatureMatrix.anndata.zarr',
-        url: 'https://s3.amazonaws.com/vitessce-data/0.0.33/main/combat-2022/combat_2022_cell.h5ad.zarr',
+        url: 'https://s3.amazonaws.com/vitessce-data/0.0.34/main/combat-2022/combat_2022_cell.h5ad.zarr',
         coordinationValues: {
           obsType: 'cell',
           featureType: 'antibody',

--- a/examples/configs/src/view-configs/eng.js
+++ b/examples/configs/src/view-configs/eng.js
@@ -11,7 +11,7 @@ export const eng2019 = {
       files: [
         {
           fileType: 'obsEmbedding.csv',
-          url: 'https://s3.amazonaws.com/vitessce-data/0.0.33/main/eng-2019/eng_2019_nature.cells.csv',
+          url: 'https://s3.amazonaws.com/vitessce-data/0.0.34/main/eng-2019/eng_2019_nature.cells.csv',
           coordinationValues: {
             obsType: 'cell',
             embeddingType: 't-SNE',
@@ -23,7 +23,7 @@ export const eng2019 = {
         },
         {
           fileType: 'obsEmbedding.csv',
-          url: 'https://s3.amazonaws.com/vitessce-data/0.0.33/main/eng-2019/eng_2019_nature.cells.csv',
+          url: 'https://s3.amazonaws.com/vitessce-data/0.0.34/main/eng-2019/eng_2019_nature.cells.csv',
           coordinationValues: {
             obsType: 'cell',
             embeddingType: 'UMAP',
@@ -35,7 +35,7 @@ export const eng2019 = {
         },
         {
           fileType: 'obsLocations.csv',
-          url: 'https://s3.amazonaws.com/vitessce-data/0.0.33/main/eng-2019/eng_2019_nature.cells.csv',
+          url: 'https://s3.amazonaws.com/vitessce-data/0.0.34/main/eng-2019/eng_2019_nature.cells.csv',
           coordinationValues: {
             obsType: 'cell',
           },
@@ -46,7 +46,7 @@ export const eng2019 = {
         },
         {
           fileType: 'obsSets.csv',
-          url: 'https://s3.amazonaws.com/vitessce-data/0.0.33/main/eng-2019/eng_2019_nature.cells.csv',
+          url: 'https://s3.amazonaws.com/vitessce-data/0.0.34/main/eng-2019/eng_2019_nature.cells.csv',
           coordinationValues: {
             obsType: 'cell',
           },
@@ -66,7 +66,7 @@ export const eng2019 = {
         },
         {
           fileType: 'obsSegmentations.json',
-          url: 'https://s3.amazonaws.com/vitessce-data/0.0.33/main/eng-2019/eng_2019_nature.cells.segmentations.json',
+          url: 'https://s3.amazonaws.com/vitessce-data/0.0.34/main/eng-2019/eng_2019_nature.cells.segmentations.json',
           coordinationValues: {
             obsType: 'cell',
           },

--- a/examples/configs/src/view-configs/habib_2017_nature_methods.js
+++ b/examples/configs/src/view-configs/habib_2017_nature_methods.js
@@ -7,7 +7,7 @@ export const habib2017natureMethods = {
     name: 'Habib 2017',
     files: [{
       fileType: 'anndata.zarr',
-      url: 'https://s3.amazonaws.com/vitessce-data/0.0.33/main/habib-2017/habib_2017_nature_methods.h5ad.zarr',
+      url: 'https://s3.amazonaws.com/vitessce-data/0.0.34/main/habib-2017/habib_2017_nature_methods.h5ad.zarr',
       coordinationValues: {
         obsType: 'cell',
         featureType: 'gene',

--- a/examples/configs/src/view-configs/hubmap.js
+++ b/examples/configs/src/view-configs/hubmap.js
@@ -8,7 +8,7 @@ function getConfig() {
     description: 'Large intestine snATAC-seq HuBMAP dataset with genomic data visualization powered by HiGlass',
   });
   // Add a dataset and its files.
-  const csvUrl = 'https://s3.amazonaws.com/vitessce-data/0.0.33/main/sn-atac-seq-hubmap-2020/human_intestine_2020_hubmap.cells.csv';
+  const csvUrl = 'https://s3.amazonaws.com/vitessce-data/0.0.34/main/sn-atac-seq-hubmap-2020/human_intestine_2020_hubmap.cells.csv';
   const genomicProfilesUrl = 'https://vitessce-data.s3.amazonaws.com/0.0.32/master_release/human_intestine_2020_hubmap/human_intestine_2020_hubmap.genomic-profiles.zarr';
   const dataset = vc
     .addDataset('HBM485.TBWH.322', 'Human large intestine, snATAC-seq')

--- a/examples/configs/src/view-configs/human_lymph_node_10x_visium.js
+++ b/examples/configs/src/view-configs/human_lymph_node_10x_visium.js
@@ -9,7 +9,7 @@ export const humanLymphNode10xVisium = {
       files: [
         {
           fileType: 'anndata.zarr',
-          url: 'https://s3.amazonaws.com/vitessce-data/0.0.33/main/human-lymph-node-10x-visium/human_lymph_node_10x_visium.h5ad.zarr',
+          url: 'https://s3.amazonaws.com/vitessce-data/0.0.34/main/human-lymph-node-10x-visium/human_lymph_node_10x_visium.h5ad.zarr',
           coordinationValues: {
             obsType: 'spot',
             featureType: 'gene',
@@ -46,7 +46,7 @@ export const humanLymphNode10xVisium = {
         },
         {
           fileType: 'image.ome-zarr',
-          url: 'https://vitessce-data.storage.googleapis.com/0.0.33/main/human-lymph-node-10x-visium/human_lymph_node_10x_visium.ome.zarr',
+          url: 'https://vitessce-data.storage.googleapis.com/0.0.34/main/human-lymph-node-10x-visium/human_lymph_node_10x_visium.ome.zarr',
         },
       ],
     },

--- a/examples/configs/src/view-configs/kuppe_2022_nature.js
+++ b/examples/configs/src/view-configs/kuppe_2022_nature.js
@@ -8,7 +8,7 @@ export const kuppe2022nature = {
     files: [
       {
         fileType: 'obsSets.anndata.zarr',
-        url: 'https://s3.amazonaws.com/vitessce-data/0.0.33/main/kuppe-2022/kuppe_2022_nature.joint.h5ad.zarr',
+        url: 'https://s3.amazonaws.com/vitessce-data/0.0.34/main/kuppe-2022/kuppe_2022_nature.joint.h5ad.zarr',
         coordinationValues: {
           obsType: 'cell',
         },
@@ -33,7 +33,7 @@ export const kuppe2022nature = {
       },
       {
         fileType: 'anndata.zarr',
-        url: 'https://s3.amazonaws.com/vitessce-data/0.0.33/main/kuppe-2022/kuppe_2022_nature.rna.h5ad.zarr',
+        url: 'https://s3.amazonaws.com/vitessce-data/0.0.34/main/kuppe-2022/kuppe_2022_nature.rna.h5ad.zarr',
         coordinationValues: {
           obsType: 'cell',
           featureType: 'gene',
@@ -60,7 +60,7 @@ export const kuppe2022nature = {
       },
       {
         fileType: 'anndata.zarr',
-        url: 'https://s3.amazonaws.com/vitessce-data/0.0.33/main/kuppe-2022/kuppe_2022_nature.atac.h5ad.zarr',
+        url: 'https://s3.amazonaws.com/vitessce-data/0.0.34/main/kuppe-2022/kuppe_2022_nature.atac.h5ad.zarr',
         coordinationValues: {
           obsType: 'cell',
           featureType: 'gene',
@@ -83,7 +83,7 @@ export const kuppe2022nature = {
       },
       {
         fileType: 'anndata.zarr',
-        url: 'https://s3.amazonaws.com/vitessce-data/0.0.33/main/kuppe-2022/kuppe_2022_nature.visium.h5ad.zarr',
+        url: 'https://s3.amazonaws.com/vitessce-data/0.0.34/main/kuppe-2022/kuppe_2022_nature.visium.h5ad.zarr',
         coordinationValues: {
           obsType: 'spot',
           featureType: 'gene',
@@ -124,7 +124,7 @@ export const kuppe2022nature = {
       },
       {
         fileType: 'image.ome-zarr',
-        url: 'https://vitessce-data.storage.googleapis.com/0.0.33/main/kuppe-2022/kuppe_2022_nature.visium.ome.zarr',
+        url: 'https://vitessce-data.storage.googleapis.com/0.0.34/main/kuppe-2022/kuppe_2022_nature.visium.ome.zarr',
       },
     ],
   }],

--- a/examples/configs/src/view-configs/marshall_2022_iscience.js
+++ b/examples/configs/src/view-configs/marshall_2022_iscience.js
@@ -7,7 +7,7 @@ export const marshall2022iScience = {
     name: 'marshall_2022',
     files: [{
       fileType: 'anndata.zarr',
-      url: 'https://s3.amazonaws.com/vitessce-data/0.0.33/main/marshall-2022/marshall_2022_iscience.h5ad.zarr',
+      url: 'https://s3.amazonaws.com/vitessce-data/0.0.34/main/marshall-2022/marshall_2022_iscience.h5ad.zarr',
       coordinationValues: {
         obsType: 'bead',
         featureType: 'gene',

--- a/examples/configs/src/view-configs/meta_2022_azimuth.js
+++ b/examples/configs/src/view-configs/meta_2022_azimuth.js
@@ -7,7 +7,7 @@ export const meta2022azimuth = {
     name: 'azimuth_2022_meta',
     files: [{
       fileType: 'anndata.zarr',
-      url: 'https://s3.amazonaws.com/vitessce-data/0.0.33/main/meta-2022-azimuth/meta_2022_azimuth.h5ad.zarr',
+      url: 'https://s3.amazonaws.com/vitessce-data/0.0.34/main/meta-2022-azimuth/meta_2022_azimuth.h5ad.zarr',
       coordinationValues: {
         obsType: 'cell',
         featureType: 'gene',

--- a/examples/configs/src/view-configs/satija.js
+++ b/examples/configs/src/view-configs/satija.js
@@ -12,7 +12,7 @@ export const satija2020 = {
       files: [
         {
           fileType: 'anndata.zarr',
-          url: 'https://s3.amazonaws.com/vitessce-data/0.0.33/main/satija-2020/satija_2020.h5ad.zarr',
+          url: 'https://s3.amazonaws.com/vitessce-data/0.0.34/main/satija-2020/satija_2020.h5ad.zarr',
           coordinationValues: {
             obsType: 'cell',
             featureType: 'gene',
@@ -36,7 +36,7 @@ export const satija2020 = {
         },
         {
           fileType: 'obsSets.json',
-          url: 'https://s3.amazonaws.com/vitessce-data/0.0.33/main/satija-2020/satija_2020.cell-sets.json',
+          url: 'https://s3.amazonaws.com/vitessce-data/0.0.34/main/satija-2020/satija_2020.cell-sets.json',
           coordinationValues: {
             obsType: 'cell',
           },

--- a/examples/configs/src/view-configs/wang.js
+++ b/examples/configs/src/view-configs/wang.js
@@ -10,14 +10,14 @@ export const wang2018 = {
       files: [
         {
           fileType: 'obsSegmentations.json',
-          url: 'https://s3.amazonaws.com/vitessce-data/0.0.33/main/wang-2018/wang_2018_scientific_reports.cells.segmentations.json',
+          url: 'https://s3.amazonaws.com/vitessce-data/0.0.34/main/wang-2018/wang_2018_scientific_reports.cells.segmentations.json',
           coordinationValues: {
             obsType: 'cell',
           },
         },
         {
           fileType: 'obsLocations.csv',
-          url: 'https://s3.amazonaws.com/vitessce-data/0.0.33/main/wang-2018/wang_2018_scientific_reports.cells.csv',
+          url: 'https://s3.amazonaws.com/vitessce-data/0.0.34/main/wang-2018/wang_2018_scientific_reports.cells.csv',
           options: {
             obsIndex: 'cell_id',
             obsLocations: ['X', 'Y'],
@@ -28,7 +28,7 @@ export const wang2018 = {
         },
         {
           fileType: 'obsLocations.csv',
-          url: 'https://s3.amazonaws.com/vitessce-data/0.0.33/main/wang-2018/wang_2018_scientific_reports.molecules.csv',
+          url: 'https://s3.amazonaws.com/vitessce-data/0.0.34/main/wang-2018/wang_2018_scientific_reports.molecules.csv',
           options: {
             obsIndex: 'molecule_id',
             obsLocations: ['X', 'Y'],
@@ -39,7 +39,7 @@ export const wang2018 = {
         },
         {
           fileType: 'obsLabels.csv',
-          url: 'https://s3.amazonaws.com/vitessce-data/0.0.33/main/wang-2018/wang_2018_scientific_reports.molecules.csv',
+          url: 'https://s3.amazonaws.com/vitessce-data/0.0.34/main/wang-2018/wang_2018_scientific_reports.molecules.csv',
           options: {
             obsIndex: 'molecule_id',
             obsLabels: 'Gene',
@@ -50,7 +50,7 @@ export const wang2018 = {
         },
         {
           fileType: 'obsFeatureMatrix.csv',
-          url: 'https://s3.amazonaws.com/vitessce-data/0.0.33/main/wang-2018/wang_2018_scientific_reports.cells.matrix.csv',
+          url: 'https://s3.amazonaws.com/vitessce-data/0.0.34/main/wang-2018/wang_2018_scientific_reports.cells.matrix.csv',
           coordinationValues: {
             obsType: 'cell',
             featureType: 'gene',

--- a/sites/docs/src/pages/_live-editor-examples.js
+++ b/sites/docs/src/pages/_live-editor-examples.js
@@ -21,7 +21,7 @@ const vc = new VitessceConfig({
   description: "This demonstrates the JavaScript API"
 });
 // Add a dataset and its files.
-const baseUrl = "https://s3.amazonaws.com/vitessce-data/0.0.33/main/eng-2019";
+const baseUrl = "https://s3.amazonaws.com/vitessce-data/0.0.34/main/eng-2019";
 const dataset = vc
   .addDataset("Eng et al., Nature 2019")
   .addFile({
@@ -77,7 +77,7 @@ export const exampleJson = `{
       "files": [
         {
           "fileType": "obsEmbedding.csv",
-          "url": "https://s3.amazonaws.com/vitessce-data/0.0.33/main/eng-2019/eng_2019_nature.cells.csv",
+          "url": "https://s3.amazonaws.com/vitessce-data/0.0.34/main/eng-2019/eng_2019_nature.cells.csv",
           "coordinationValues": {
             "obsType": "cell",
             "embeddingType": "t-SNE"
@@ -89,7 +89,7 @@ export const exampleJson = `{
         },
         {
           "fileType": "obsEmbedding.csv",
-          "url": "https://s3.amazonaws.com/vitessce-data/0.0.33/main/eng-2019/eng_2019_nature.cells.csv",
+          "url": "https://s3.amazonaws.com/vitessce-data/0.0.34/main/eng-2019/eng_2019_nature.cells.csv",
           "coordinationValues": {
             "obsType": "cell",
             "embeddingType": "UMAP"
@@ -101,7 +101,7 @@ export const exampleJson = `{
         },
         {
           "fileType": "obsSets.csv",
-          "url": "https://s3.amazonaws.com/vitessce-data/0.0.33/main/eng-2019/eng_2019_nature.cells.csv",
+          "url": "https://s3.amazonaws.com/vitessce-data/0.0.34/main/eng-2019/eng_2019_nature.cells.csv",
           "coordinationValues": {
             "obsType": "cell"
           },

--- a/sites/html/src/es.js
+++ b/sites/html/src/es.js
@@ -16,7 +16,7 @@ const eng2019 = {
       files: [
         {
           fileType: 'obsEmbedding.csv',
-          url: 'https://s3.amazonaws.com/vitessce-data/0.0.33/main/eng-2019/eng_2019_nature.cells.csv',
+          url: 'https://s3.amazonaws.com/vitessce-data/0.0.34/main/eng-2019/eng_2019_nature.cells.csv',
           coordinationValues: {
             obsType: 'cell',
             embeddingType: 't-SNE',
@@ -28,7 +28,7 @@ const eng2019 = {
         },
         {
           fileType: 'obsEmbedding.csv',
-          url: 'https://s3.amazonaws.com/vitessce-data/0.0.33/main/eng-2019/eng_2019_nature.cells.csv',
+          url: 'https://s3.amazonaws.com/vitessce-data/0.0.34/main/eng-2019/eng_2019_nature.cells.csv',
           coordinationValues: {
             obsType: 'cell',
             embeddingType: 'UMAP',
@@ -40,7 +40,7 @@ const eng2019 = {
         },
         {
           fileType: 'obsLocations.csv',
-          url: 'https://s3.amazonaws.com/vitessce-data/0.0.33/main/eng-2019/eng_2019_nature.cells.csv',
+          url: 'https://s3.amazonaws.com/vitessce-data/0.0.34/main/eng-2019/eng_2019_nature.cells.csv',
           coordinationValues: {
             obsType: 'cell',
           },
@@ -51,7 +51,7 @@ const eng2019 = {
         },
         {
           fileType: 'obsSets.csv',
-          url: 'https://s3.amazonaws.com/vitessce-data/0.0.33/main/eng-2019/eng_2019_nature.cells.csv',
+          url: 'https://s3.amazonaws.com/vitessce-data/0.0.34/main/eng-2019/eng_2019_nature.cells.csv',
           coordinationValues: {
             obsType: 'cell',
           },
@@ -71,7 +71,7 @@ const eng2019 = {
         },
         {
           fileType: 'obsSegmentations.json',
-          url: 'https://s3.amazonaws.com/vitessce-data/0.0.33/main/eng-2019/eng_2019_nature.cells.segmentations.json',
+          url: 'https://s3.amazonaws.com/vitessce-data/0.0.34/main/eng-2019/eng_2019_nature.cells.segmentations.json',
           coordinationValues: {
             obsType: 'cell',
           },

--- a/sites/html/src/umd.js
+++ b/sites/html/src/umd.js
@@ -15,7 +15,7 @@ const eng2019 = {
       files: [
         {
           fileType: 'obsEmbedding.csv',
-          url: 'https://s3.amazonaws.com/vitessce-data/0.0.33/main/eng-2019/eng_2019_nature.cells.csv',
+          url: 'https://s3.amazonaws.com/vitessce-data/0.0.34/main/eng-2019/eng_2019_nature.cells.csv',
           coordinationValues: {
             obsType: 'cell',
             embeddingType: 't-SNE',
@@ -27,7 +27,7 @@ const eng2019 = {
         },
         {
           fileType: 'obsEmbedding.csv',
-          url: 'https://s3.amazonaws.com/vitessce-data/0.0.33/main/eng-2019/eng_2019_nature.cells.csv',
+          url: 'https://s3.amazonaws.com/vitessce-data/0.0.34/main/eng-2019/eng_2019_nature.cells.csv',
           coordinationValues: {
             obsType: 'cell',
             embeddingType: 'UMAP',
@@ -39,7 +39,7 @@ const eng2019 = {
         },
         {
           fileType: 'obsLocations.csv',
-          url: 'https://s3.amazonaws.com/vitessce-data/0.0.33/main/eng-2019/eng_2019_nature.cells.csv',
+          url: 'https://s3.amazonaws.com/vitessce-data/0.0.34/main/eng-2019/eng_2019_nature.cells.csv',
           coordinationValues: {
             obsType: 'cell',
           },
@@ -50,7 +50,7 @@ const eng2019 = {
         },
         {
           fileType: 'obsSets.csv',
-          url: 'https://s3.amazonaws.com/vitessce-data/0.0.33/main/eng-2019/eng_2019_nature.cells.csv',
+          url: 'https://s3.amazonaws.com/vitessce-data/0.0.34/main/eng-2019/eng_2019_nature.cells.csv',
           coordinationValues: {
             obsType: 'cell',
           },
@@ -70,7 +70,7 @@ const eng2019 = {
         },
         {
           fileType: 'obsSegmentations.json',
-          url: 'https://s3.amazonaws.com/vitessce-data/0.0.33/main/eng-2019/eng_2019_nature.cells.segmentations.json',
+          url: 'https://s3.amazonaws.com/vitessce-data/0.0.34/main/eng-2019/eng_2019_nature.cells.segmentations.json',
           coordinationValues: {
             obsType: 'cell',
           },


### PR DESCRIPTION
#### Background
Upgrades view configs to use new data.

#### Change List
- Change view config data versions
- Use new settings as in https://github.com/vitessce/vitessce-python/pull/211
#### Checklist
 - [ ] Ensure PR works with all demos on the dev.vitessce.io homepage
 - [ ] Open (draft) PR's into [`vitessce-python`](https://github.com/vitessce/vitessce-python) and [`vitessce-r`](https://github.com/vitessce/vitessce-r) if this is a release PR
 - [ ] Documentation added or updated