### PR TITLE
Use esm.sh react

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 ### Changed
 - Converted all `rem` units to `px` to fix R/Python widget CSS bugs caused by different root style conflicts.
 - Comment out `_DiffViewConfigSchema` in the docs to fix bug.
+- Switched to using `react` via esm.sh rather than `es-react` via unpkg for the Cypress tests in `sites/html`.
 
 ## [2.0.2](https://www.npmjs.com/package/vitessce/v/2.0.2) - 2022-12-09
 

--- a/sites/html/src/es.html
+++ b/sites/html/src/es.html
@@ -17,7 +17,7 @@
       {
         "imports": {
           "react": "https://esm.sh/react@18.2.0",
-          "react-dom": "ttps://esm.sh/react-dom@18.2.0",
+          "react-dom": "https://esm.sh/react-dom@18.2.0",
           "vitessce": "http://localhost:3003/packages/main/dev/dist/index.mjs"
         }
       }

--- a/sites/html/src/es.html
+++ b/sites/html/src/es.html
@@ -16,8 +16,8 @@
     <script type="importmap">
       {
         "imports": {
-          "react": "https://unpkg.com/es-react/react.js",
-          "react-dom": "https://unpkg.com/es-react/react-dom.js",
+          "react": "https://esm.sh/react@18.2.0",
+          "react-dom": "ttps://esm.sh/react-dom@18.2.0",
           "vitessce": "http://localhost:3003/packages/main/dev/dist/index.mjs"
         }
       }

--- a/sites/html/src/es.min.html
+++ b/sites/html/src/es.min.html
@@ -17,7 +17,7 @@
       {
         "imports": {
           "react": "https://esm.sh/react@18.2.0",
-          "react-dom": "ttps://esm.sh/react-dom@18.2.0",
+          "react-dom": "https://esm.sh/react-dom@18.2.0",
           "vitessce": "http://localhost:3003/packages/main/prod/dist/index.min.mjs"
         }
       }

--- a/sites/html/src/es.min.html
+++ b/sites/html/src/es.min.html
@@ -16,8 +16,8 @@
     <script type="importmap">
       {
         "imports": {
-          "react": "https://unpkg.com/es-react/react.js",
-          "react-dom": "https://unpkg.com/es-react/react-dom.js",
+          "react": "https://esm.sh/react@18.2.0",
+          "react-dom": "ttps://esm.sh/react-dom@18.2.0",
           "vitessce": "http://localhost:3003/packages/main/prod/dist/index.min.mjs"
         }
       }


### PR DESCRIPTION

<!-- For other PRs without open issue -->
#### Background
unpkg is throwing `Internal Server Error` for `es-react` https://unpkg.com/browse/es-react@16.13.1/


<!-- For all the PRs -->
#### Change List
- Use react via `esm.sh` CDN instead
#### Checklist
 - [ ] Ensure PR works with all demos on the dev.vitessce.io homepage
 - [ ] Open (draft) PR's into [`vitessce-python`](https://github.com/vitessce/vitessce-python) and [`vitessce-r`](https://github.com/vitessce/vitessce-r) if this is a release PR
 - [ ] Documentation added or updated