### PR TITLE
Jupyter notebook style fixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 
 ### Added
 - Added a `uid` prop for `VitS` to fix Jupyter notebook style conflicts caused by multiple `Vitessce` widget instances loaded in the same `JupyterLab` session.
+- Added `!important` statements to override Jupyter Notebook (classic) style conflicts.
 
 ### Changed
 - Converted all `rem` units to `px` to fix R/Python widget CSS bugs caused by different root style conflicts.

--- a/packages/view-types/obs-sets-manager/src/styles.js
+++ b/packages/view-types/obs-sets-manager/src/styles.js
@@ -234,7 +234,8 @@ export const useStyles = makeStyles(theme => ({
   nodeMenuIcon: {
     fill: theme.palette.grayMid,
     cursor: 'pointer',
-    height: '14px',
+    // Important needed due to Jupyter Notebook conflicting styles
+    height: '14px !important',
     position: 'relative',
     verticalAlign: 'top',
     width: `${nodeHeight}px`,
@@ -260,7 +261,8 @@ export const useStyles = makeStyles(theme => ({
     /* create custom radiobutton appearance */
     width: '12px',
     height: '12px',
-    padding: '5px',
+    // Important needed due to Jupyter Notebook conflicting styles
+    padding: '5px !important',
     /* background-color only for content */
     backgroundClip: 'content-box',
     border: `2px solid ${theme.palette.primaryForegroundL10}`,


### PR DESCRIPTION
<!-- Credit (as a starting template): https://github.com/visgl/deck.gl/blob/master/.github/pull_request_template.md -->
<!-- For feature, feature enhancement or bug fix, create an issue first and finish To Do List there -->
<!-- Anything doesn't work as expected is a bug, including code, doc and test -->
Fixes the weird styles that were identified in this PR https://github.com/vitessce/vitessce-python/pull/210#pullrequestreview-1226334322
 which comes from the classic Jupyter Notebook interface using CSS that was more specific than the vitessce CSS. The important modifier should fix this.
#### Checklist
 - [ ] Ensure PR works with all demos on the dev.vitessce.io homepage
 - [ ] Open (draft) PR's into [`vitessce-python`](https://github.com/vitessce/vitessce-python) and [`vitessce-r`](https://github.com/vitessce/vitessce-r) if this is a release PR
 - [ ] Documentation added or updated