### PR TITLE
Fix Go to Definition support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 ### Added
 
 ### Changed
+- Fixes Go to Definition support in vscode (see https://github.com/microsoft/TypeScript/issues/49003#issuecomment-1164659854).
 
 ## [2.0.3](https://www.npmjs.com/package/vitessce/v/2.0.3) - 2023-02-01
 

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -15,7 +15,9 @@
     "esModuleInterop": false,
     "resolveJsonModule": true,
     "isolatedModules": true,
-    "incremental": true
+    "incremental": true,
+    "declaration": true,
+    "declarationMap": true
   },
   "references": [
     { "path": "examples/configs" },


### PR DESCRIPTION

#### Background

With the TS Project References enabled, this extra flag is required in order to use the Go To Definition (command+click) in vscode. Otherwise when you command+click, vscode will take you to the generated code within `dist-tsc/` rather than `src/` where you want to go.

Related to https://github.com/microsoft/TypeScript/issues/49003#issuecomment-1164655018 and https://github.com/microsoft/TypeScript/issues/6209

#### Checklist
 - [ ] Ensure PR works with all demos on the dev.vitessce.io homepage
 - [ ] Open (draft) PR's into [`vitessce-python`](https://github.com/vitessce/vitessce-python) and [`vitessce-r`](https://github.com/vitessce/vitessce-r) if this is a release PR
 - [ ] Documentation added or updated