### PR TITLE
Use loglevel

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Changed
 - Fix hot module reloading by refactoring JS files that export React components (the component needs to be the only export for HMR to work). Add react-refresh eslint plugin to check for this moving forward.
 - Fixes Go to Definition support in vscode (see https://github.com/microsoft/TypeScript/issues/49003#issuecomment-1164659854).
+- Use `loglevel` package for logging to enable configuration of logging threshold.
 
 
 ## [2.0.3](https://www.npmjs.com/package/vitessce/v/2.0.3) - 2023-02-01

--- a/packages/constants/package.json
+++ b/packages/constants/package.json
@@ -20,6 +20,7 @@
     "bundle": "pnpm exec vite build -c ../../scripts/vite.config.js"
   },
   "dependencies": {
-    "@vitessce/constants-internal": "workspace:*"
+    "@vitessce/constants-internal": "workspace:*",
+    "loglevel": "^1.8.1"
   }
 }

--- a/packages/constants/src/constants-merged.js
+++ b/packages/constants/src/constants-merged.js
@@ -9,6 +9,7 @@ import {
   FileType as FileTypeCurr,
   CoordinationType as CoordinationTypeCurr,
 } from '@vitessce/constants-internal';
+import log from 'loglevel';
 import {
   ViewType as ViewTypeOld,
   DataType as DataTypeOld,
@@ -21,7 +22,7 @@ function makeConstantWithDeprecationMessage(currObj, oldObj) {
     get(obj, prop) {
       const oldKeys = Object.keys(oldObj);
       if (oldKeys.includes(prop)) {
-        console.warn(`Notice about the constant mapping ${prop}: '${oldObj[prop][0]}':\n${oldObj[prop][1]}`);
+        log.warn(`Notice about the constant mapping ${prop}: '${oldObj[prop][0]}':\n${oldObj[prop][1]}`);
         return oldObj[prop];
       }
       return obj[prop];

--- a/packages/file-types/json/package.json
+++ b/packages/file-types/json/package.json
@@ -30,6 +30,7 @@
     "ajv": "^6.10.0",
     "d3-array": "^2.4.0",
     "lodash": "^4.17.21",
+    "loglevel": "^1.8.1",
     "zarr": "0.5.1"
   },
   "devDependencies": {

--- a/packages/file-types/json/src/raster-json-loaders/RasterJsonAsImageLoader.js
+++ b/packages/file-types/json/src/raster-json-loaders/RasterJsonAsImageLoader.js
@@ -1,4 +1,5 @@
 import { AbstractLoaderError, LoaderResult } from '@vitessce/vit-s';
+import log from 'loglevel';
 import RasterLoader from './RasterJsonLoader';
 
 export default class RasterJsonAsImageLoader extends RasterLoader {
@@ -22,7 +23,7 @@ export default class RasterJsonAsImageLoader extends RasterLoader {
     });
 
     if (!coordinationValues?.spatialImageLayer) {
-      console.warn('Could not initialize coordinationValues.spatialImageLayer in RasterJsonAsImageLoader. This may be an indicator that the image could not be loaded.');
+      log.warn('Could not initialize coordinationValues.spatialImageLayer in RasterJsonAsImageLoader. This may be an indicator that the image could not be loaded.');
     }
 
     return new LoaderResult(

--- a/packages/file-types/json/src/raster-json-loaders/RasterJsonAsObsSegmentationsLoader.js
+++ b/packages/file-types/json/src/raster-json-loaders/RasterJsonAsObsSegmentationsLoader.js
@@ -1,4 +1,5 @@
 import { AbstractLoaderError, LoaderResult } from '@vitessce/vit-s';
+import log from 'loglevel';
 import RasterLoader from './RasterJsonLoader';
 
 export default class RasterJsonAsObsSegmentationsLoader extends RasterLoader {
@@ -22,7 +23,7 @@ export default class RasterJsonAsObsSegmentationsLoader extends RasterLoader {
     });
 
     if (!coordinationValues?.spatialImageLayer) {
-      console.warn('Could not initialize coordinationValues.spatialImageLayer in RasterJsonAsObsSegmentationsLoader. This may be an indicator that the image could not be loaded.');
+      log.warn('Could not initialize coordinationValues.spatialImageLayer in RasterJsonAsObsSegmentationsLoader. This may be an indicator that the image could not be loaded.');
     }
 
     return new LoaderResult(

--- a/packages/file-types/zarr/package.json
+++ b/packages/file-types/zarr/package.json
@@ -29,6 +29,7 @@
     "@vitessce/vit-s": "workspace:*",
     "d3-array": "^2.4.0",
     "lodash": "^4.17.21",
+    "loglevel": "^1.8.1",
     "zarr": "0.5.1"
   }
 }

--- a/packages/file-types/zarr/src/ome-loaders/OmeZarrLoader.js
+++ b/packages/file-types/zarr/src/ome-loaders/OmeZarrLoader.js
@@ -1,3 +1,4 @@
+import log from 'loglevel';
 import { viv } from '@vitessce/gl';
 import { initializeRasterLayersAndChannels } from '@vitessce/spatial-utils';
 import { AbstractLoaderError, LoaderResult, AbstractTwoStepLoader } from '@vitessce/vit-s';
@@ -24,7 +25,7 @@ export default class OmeZarrLoader extends AbstractTwoStepLoader {
     const { omero } = metadata;
 
     if (!omero) {
-      console.error('Path for image not valid');
+      log.error('Path for image not valid');
       return Promise.reject(payload);
     }
 

--- a/packages/utils/export-utils/package.json
+++ b/packages/utils/export-utils/package.json
@@ -22,6 +22,7 @@
   },
   "dependencies": {
     "bowser": "^2.11.0",
-    "lz-string": "^1.4.4"
+    "lz-string": "^1.4.4",
+    "loglevel": "^1.8.1"
   }
 }

--- a/packages/utils/export-utils/src/export-utils.js
+++ b/packages/utils/export-utils/src/export-utils.js
@@ -1,3 +1,4 @@
+import log from 'loglevel';
 import Bowser from 'bowser';
 import { compressToEncodedURIComponent, decompressFromEncodedURIComponent } from 'lz-string';
 
@@ -49,7 +50,7 @@ export function encodeConfInUrl({
       .filter(entry => entry[1] > newParams.length)
       .map(entry => entry[0]);
     const message = `Configuration is ${compressedConf.length} characters; max URL for ${browser} is ${maxLength}: it will work on ${willWorkOn.join(', ') || 'no browser'}.`;
-    console.error(message);
+    log.error(message);
     onOverMaximumUrlLength({ message, willWorkOn });
   }
   return newParams;

--- a/packages/utils/other-utils/package.json
+++ b/packages/utils/other-utils/package.json
@@ -24,6 +24,7 @@
     "@vitessce/sets-utils": "workspace:*",
     "bowser": "^2.11.0",
     "lodash": "^4.17.21",
+    "loglevel": "^1.8.1",
     "lz-string": "^1.4.4"
   }
 }

--- a/packages/utils/other-utils/src/components.js
+++ b/packages/utils/other-utils/src/components.js
@@ -1,3 +1,5 @@
+import log from 'loglevel';
+
 // Originally in src/components/utils.js
 export const DEFAULT_DARK_COLOR = [50, 50, 50];
 export const DEFAULT_LIGHT_COLOR = [200, 200, 200];
@@ -46,27 +48,27 @@ export const COLORMAP_OPTIONS = [
 export const DEFAULT_GL_OPTIONS = { webgl2: true };
 
 export function createDefaultUpdateStatus(componentName) {
-  return message => console.warn(`${componentName} updateStatus: ${message}`);
+  return message => log.warn(`${componentName} updateStatus: ${message}`);
 }
 
 export function createDefaultUpdateCellsSelection(componentName) {
-  return cellsSelection => console.warn(`${componentName} updateCellsSelection: ${cellsSelection}`);
+  return cellsSelection => log.warn(`${componentName} updateCellsSelection: ${cellsSelection}`);
 }
 
 export function createDefaultUpdateCellsHover(componentName) {
-  return hoverInfo => console.warn(`${componentName} updateCellsHover: ${hoverInfo.cellId}`);
+  return hoverInfo => log.warn(`${componentName} updateCellsHover: ${hoverInfo.cellId}`);
 }
 
 export function createDefaultUpdateGenesHover(componentName) {
-  return hoverInfo => console.warn(`${componentName} updateGenesHover: ${hoverInfo.geneId}`);
+  return hoverInfo => log.warn(`${componentName} updateGenesHover: ${hoverInfo.geneId}`);
 }
 
 export function createDefaultUpdateTracksHover(componentName) {
-  return hoverInfo => console.warn(`${componentName} updateTracksHover: ${hoverInfo}`);
+  return hoverInfo => log.warn(`${componentName} updateTracksHover: ${hoverInfo}`);
 }
 
 export function createDefaultUpdateViewInfo(componentName) {
-  return viewInfo => console.warn(`${componentName} updateViewInfo: ${viewInfo}`);
+  return viewInfo => log.warn(`${componentName} updateViewInfo: ${viewInfo}`);
 }
 
 export function createDefaultClearPleaseWait() {

--- a/packages/view-types/spatial/package.json
+++ b/packages/view-types/spatial/package.json
@@ -36,7 +36,8 @@
     "math.gl": "^3.5.6",
     "mathjs": "^9.2.0",
     "plur": "^5.1.0",
-    "short-number": "^1.0.6"
+    "short-number": "^1.0.6",
+    "loglevel": "^1.8.1"
   },
   "devDependencies": {
     "react": "^18.0.0",

--- a/packages/view-types/spatial/src/SpatialSubscriber.js
+++ b/packages/view-types/spatial/src/SpatialSubscriber.js
@@ -1,4 +1,5 @@
 import React, { useEffect, useMemo, useCallback } from 'react';
+import log from 'loglevel';
 import {
   TitleInfo,
   useDeckCanvasSize, useReady, useUrls,
@@ -385,7 +386,7 @@ export function SpatialSubscriber(props) {
       && cellsLayer && !obsSegmentations && !obsSegmentationsIndex
       && obsCentroids && obsCentroidsIndex
     ) {
-      console.warn('Rendering cell segmentation diamonds for backwards compatibility.');
+      log.warn('Rendering cell segmentation diamonds for backwards compatibility.');
     }
   }, [hasSegmentationsData, cellsLayer, obsSegmentations, obsSegmentationsIndex,
     obsCentroids, obsCentroidsIndex,

--- a/packages/vit-s/package.json
+++ b/packages/vit-s/package.json
@@ -31,6 +31,7 @@
     "internmap": "^2.0.3",
     "jss-plugin-global": "^10.9.2",
     "lodash": "^4.17.21",
+    "loglevel": "^1.8.1",
     "react-grid-layout-with-lodash": "^1.3.5",
     "uuid": "^3.3.2",
     "zustand": "^3.5.10"

--- a/packages/vit-s/src/CallbackPublisher.js
+++ b/packages/vit-s/src/CallbackPublisher.js
@@ -1,4 +1,5 @@
 import { useEffect } from 'react';
+import log from 'loglevel';
 import { SCHEMA_HANDLERS, LATEST_VERSION } from './view-config-versions';
 import { useViewConfigStoreApi, useLoaders, useWarning } from './state/hooks';
 
@@ -13,7 +14,7 @@ function validateViewConfig(viewConfig) {
       throw new Error(`Config validation failed: ${failureReason}`);
     }
   } catch (e) {
-    console.error(e);
+    log.error(e);
   }
   // Do nothing if successful.
 }

--- a/packages/vit-s/src/VitS.js
+++ b/packages/vit-s/src/VitS.js
@@ -1,5 +1,6 @@
 /* eslint-disable camelcase */
 import React, { useEffect, useMemo } from 'react';
+import log from 'loglevel';
 import {
   ThemeProvider,
   StylesProvider,
@@ -26,10 +27,12 @@ import {
 } from './view-config-utils';
 
 function logConfig(config, name) {
-  console.groupCollapsed(`🚄 Vitessce (${META_VERSION.version}) ${name}`);
-  console.info(`data:,${JSON.stringify(config)}`);
-  console.info(JSON.stringify(config, null, 2));
-  console.groupEnd();
+  if (log.getLevel() <= log.levels.INFO) {
+    console.groupCollapsed(`🚄 Vitessce (${META_VERSION.version}) ${name}`);
+    console.info(`data:,${JSON.stringify(config)}`);
+    console.info(JSON.stringify(config, null, 2));
+    console.groupEnd();
+  }
 }
 
 /**

--- a/packages/vit-s/src/data-hook-utils.js
+++ b/packages/vit-s/src/data-hook-utils.js
@@ -1,5 +1,6 @@
 import { useState, useEffect } from 'react';
 import equal from 'fast-deep-equal';
+import log from 'loglevel';
 import { capitalize } from '@vitessce/utils';
 import { STATUS } from '@vitessce/constants-internal';
 import { useMatchingLoader, useMatchingLoaders, useSetWarning } from './state/hooks';
@@ -16,8 +17,8 @@ import { getDefaultCoordinationValues } from './plugins';
  */
 export function warn(error, setWarning) {
   setWarning(error.message);
-  console.warn(error.message);
-  console.error(error.stack);
+  log.warn(error.message);
+  log.error(error.stack);
   if (error instanceof AbstractLoaderError) {
     error.warnInConsole();
   }

--- a/packages/vit-s/src/errors/DataSourceFetchError.js
+++ b/packages/vit-s/src/errors/DataSourceFetchError.js
@@ -1,3 +1,4 @@
+import log from 'loglevel';
 import AbstractLoaderError from './AbstractLoaderError';
 
 export default class DataSourceFetchError extends AbstractLoaderError {
@@ -10,6 +11,6 @@ export default class DataSourceFetchError extends AbstractLoaderError {
 
   warnInConsole() {
     const { source, url, headers } = this;
-    console.warn(`${source} failed to fetch from ${url} with headers ${headers}`);
+    log.warn(`${source} failed to fetch from ${url} with headers ${headers}`);
   }
 }

--- a/packages/vit-s/src/errors/DatasetNotFoundError.js
+++ b/packages/vit-s/src/errors/DatasetNotFoundError.js
@@ -1,3 +1,4 @@
+import log from 'loglevel';
 import AbstractLoaderError from './AbstractLoaderError';
 
 export default class DatasetNotFoundError extends AbstractLoaderError {
@@ -13,11 +14,11 @@ export default class DatasetNotFoundError extends AbstractLoaderError {
       datasetUid,
     } = this;
     if (datasetUid) {
-      console.warn(
+      log.warn(
         `Unable to find dataset for ${datasetUid}`,
       );
     } else {
-      console.warn('No dataset uid specified.');
+      log.warn('No dataset uid specified.');
     }
   }
 }

--- a/packages/vit-s/src/errors/LoaderNotFoundError.js
+++ b/packages/vit-s/src/errors/LoaderNotFoundError.js
@@ -1,3 +1,4 @@
+import log from 'loglevel';
 import AbstractLoaderError from './AbstractLoaderError';
 
 export default class LoaderNotFoundError extends AbstractLoaderError {
@@ -15,7 +16,7 @@ export default class LoaderNotFoundError extends AbstractLoaderError {
     const {
       loaders, viewCoordinationValues,
     } = this;
-    console.warn(
+    log.warn(
       // eslint-disable-next-line prefer-template
       `Expected to match on { ${Object.entries(viewCoordinationValues).map(([k, v]) => k + ': ' + v).join(', ')} }`,
       loaders,

--- a/packages/vit-s/src/errors/LoaderValidationError.js
+++ b/packages/vit-s/src/errors/LoaderValidationError.js
@@ -1,3 +1,4 @@
+import log from 'loglevel';
 import AbstractLoaderError from './AbstractLoaderError';
 
 export default class LoaderValidationError extends AbstractLoaderError {
@@ -15,7 +16,7 @@ export default class LoaderValidationError extends AbstractLoaderError {
     const {
       datasetType, datasetUrl, reason,
     } = this;
-    console.warn(
+    log.warn(
       `${datasetType} from ${datasetUrl}: validation failed`,
       JSON.stringify(reason, null, 2),
     );

--- a/packages/vit-s/src/errors/OptionsValidationError.js
+++ b/packages/vit-s/src/errors/OptionsValidationError.js
@@ -1,3 +1,4 @@
+import log from 'loglevel';
 import AbstractLoaderError from './AbstractLoaderError';
 
 export default class OptionsValidationError extends AbstractLoaderError {
@@ -15,7 +16,7 @@ export default class OptionsValidationError extends AbstractLoaderError {
     const {
       options, reason,
     } = this;
-    console.warn(
+    log.warn(
       'Received options\n',
       JSON.stringify(options, null, 2),
       'JSON schema validation failure reason\n',

--- a/packages/vit-s/src/file-options-schemas.js
+++ b/packages/vit-s/src/file-options-schemas.js
@@ -1,10 +1,11 @@
 import Ajv from 'ajv';
+import log from 'loglevel';
 
 export function validateOptions(optionsSchema, options) {
   const validate = new Ajv().compile(optionsSchema);
   const valid = validate(options || null);
   if (!valid) {
-    console.warn(JSON.stringify(validate.errors, null, 2));
+    log.warn(JSON.stringify(validate.errors, null, 2));
     throw new Error(`File definition options failed schema validation (${optionsSchema.title})`);
   }
   return true;

--- a/packages/vit-s/src/state/hooks.js
+++ b/packages/vit-s/src/state/hooks.js
@@ -1,5 +1,6 @@
 /* eslint-disable react-refresh/only-export-components */
 import { useRef, useCallback, useMemo } from 'react';
+import log from 'loglevel';
 import create from 'zustand';
 import createContext from 'zustand/context';
 import shallow from 'zustand/shallow';
@@ -291,7 +292,7 @@ export function useComplexCoordination(
           } else if (parameterScopeGlobal) {
             value = parameterSpace[parameterScopeGlobal];
           } else {
-            console.error(`coordination scope for ${parameter} was not found.`);
+            log.error(`coordination scope for ${parameter} was not found.`);
           }
           return [parameter, value];
         }
@@ -320,7 +321,7 @@ export function useComplexCoordination(
           value,
         });
       } else {
-        console.error(`coordination scope for ${parameter} was not found.`);
+        log.error(`coordination scope for ${parameter} was not found.`);
       }
       return [setterName, setterFunc];
     }));

--- a/packages/vit-s/src/view-config-upgraders.js
+++ b/packages/vit-s/src/view-config-upgraders.js
@@ -1,4 +1,5 @@
 /* eslint-disable camelcase */
+import log from 'loglevel';
 import uuidv4 from 'uuid/v4';
 import cloneDeep from 'lodash/cloneDeep';
 import { getNextScope, capitalize } from '@vitessce/utils';
@@ -580,7 +581,7 @@ export function upgradeFrom1_0_14(config) {
     // Iterate over each old prop key.
     Object.entries(propAnalogies).forEach(([oldProp, newType]) => {
       if (viewDef.props?.[oldProp]) {
-        console.warn(`Warning: the '${oldProp}' prop on the ${viewDef.component} view is deprecated. Please use the '${newType}' coordination type instead.`);
+        log.warn(`Warning: the '${oldProp}' prop on the ${viewDef.component} view is deprecated. Please use the '${newType}' coordination type instead.`);
       }
     });
   });

--- a/packages/vit-s/src/vitessce-grid-utils.js
+++ b/packages/vit-s/src/vitessce-grid-utils.js
@@ -1,6 +1,7 @@
 import {
   useState, useEffect, useRef,
 } from 'react';
+import log from 'loglevel';
 import { InternMap } from 'internmap';
 import isEqual from 'lodash/isEqual';
 import pick from 'lodash/pick';
@@ -103,7 +104,7 @@ function withDefaults(coordinationValues, dataType, fileType, datasetUid) {
   };
   if (!isEqual(coordinationValues, coordinationValuesWithDefaults)) {
     // eslint-disable-next-line max-len
-    console.warn(`Using coordination value defaults for file type ${fileType} in dataset ${datasetUid}\nBefore: ${JSON.stringify(coordinationValues)}\nAfter: ${JSON.stringify(coordinationValuesWithDefaults)}`);
+    log.warn(`Using coordination value defaults for file type ${fileType} in dataset ${datasetUid}\nBefore: ${JSON.stringify(coordinationValues)}\nAfter: ${JSON.stringify(coordinationValuesWithDefaults)}`);
   }
   return coordinationValuesWithDefaults;
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -99,8 +99,10 @@ importers:
   packages/constants:
     specifiers:
       '@vitessce/constants-internal': workspace:*
+      loglevel: ^1.8.1
     dependencies:
       '@vitessce/constants-internal': link:../constants-internal
+      loglevel: 1.8.1
 
   packages/constants-internal:
     specifiers:
@@ -135,6 +137,7 @@ importers:
       ajv: ^6.10.0
       d3-array: ^2.4.0
       lodash: ^4.17.21
+      loglevel: ^1.8.1
       zarr: 0.5.1
     dependencies:
       '@vitessce/constants-internal': link:../../constants-internal
@@ -146,6 +149,7 @@ importers:
       ajv: 6.12.6
       d3-array: 2.12.1
       lodash: 4.17.21
+      loglevel: 1.8.1
       zarr: 0.5.1
 
   packages/file-types/zarr:
@@ -158,6 +162,7 @@ importers:
       '@vitessce/vit-s': workspace:*
       d3-array: ^2.4.0
       lodash: ^4.17.21
+      loglevel: ^1.8.1
       zarr: 0.5.1
     dependencies:
       '@vitessce/constants-internal': link:../../constants-internal
@@ -168,6 +173,7 @@ importers:
       '@vitessce/vit-s': link:../../vit-s
       d3-array: 2.12.1
       lodash: 4.17.21
+      loglevel: 1.8.1
       zarr: 0.5.1
 
   packages/gl:
@@ -401,9 +407,11 @@ importers:
   packages/utils/export-utils:
     specifiers:
       bowser: ^2.11.0
+      loglevel: ^1.8.1
       lz-string: ^1.4.4
     dependencies:
       bowser: 2.11.0
+      loglevel: 1.8.1
       lz-string: 1.4.4
 
   packages/utils/other-utils:
@@ -411,11 +419,13 @@ importers:
       '@vitessce/sets-utils': workspace:*
       bowser: ^2.11.0
       lodash: ^4.17.21
+      loglevel: ^1.8.1
       lz-string: ^1.4.4
     dependencies:
       '@vitessce/sets-utils': link:../sets-utils
       bowser: 2.11.0
       lodash: 4.17.21
+      loglevel: 1.8.1
       lz-string: 1.4.4
 
   packages/utils/sets-utils:
@@ -762,6 +772,7 @@ importers:
       '@vitessce/vit-s': workspace:*
       d3-array: ^2.4.0
       lodash: ^4.17.21
+      loglevel: ^1.8.1
       math.gl: ^3.5.6
       mathjs: ^9.2.0
       plur: ^5.1.0
@@ -782,6 +793,7 @@ importers:
       '@vitessce/vit-s': link:../../vit-s
       d3-array: 2.12.1
       lodash: 4.17.21
+      loglevel: 1.8.1
       math.gl: 3.6.3
       mathjs: 9.5.2
       plur: 5.1.0
@@ -849,6 +861,7 @@ importers:
       internmap: ^2.0.3
       jss-plugin-global: ^10.9.2
       lodash: ^4.17.21
+      loglevel: ^1.8.1
       react: ^18.0.0
       react-grid-layout-with-lodash: ^1.3.5
       uuid: ^3.3.2
@@ -866,6 +879,7 @@ importers:
       internmap: 2.0.3
       jss-plugin-global: 10.9.2
       lodash: 4.17.21
+      loglevel: 1.8.1
       react-grid-layout-with-lodash: 1.3.5_biqbaboplfbrettd7655fr4n2y
       uuid: 3.4.0
       zustand: 3.7.2_react@18.2.0
@@ -896,6 +910,7 @@ importers:
       '@vitessce/example-configs': workspace:*
       '@vitessce/example-plugins': workspace:*
       cypress: ^10.10.0
+      loglevel: ^1.8.1
       react: ^18.0.0
       react-dom: ^18.0.0
       sass: ^1.55.0
@@ -905,6 +920,7 @@ importers:
       '@vitessce/constants-internal': link:../../packages/constants-internal
       '@vitessce/example-configs': link:../../examples/configs
       '@vitessce/example-plugins': link:../../examples/plugins
+      loglevel: 1.8.1
       react: 18.2.0
       react-dom: 18.2.0_react@18.2.0
       vitessce: link:../../packages/main/prod
@@ -14270,6 +14286,11 @@ packages:
       slice-ansi: 4.0.0
       wrap-ansi: 6.2.0
     dev: true
+
+  /loglevel/1.8.1:
+    resolution: {integrity: sha512-tCRIJM51SHjAayKwC+QAg8hT8vg6z7GSgLJKGvzuPb1Wc+hLzqtuVLxp6/HzSPOozuK+8ErAhy7U/sVzw8Dgfg==}
+    engines: {node: '>= 0.6.0'}
+    dev: false
 
   /long/3.2.0:
     resolution: {integrity: sha512-ZYvPPOMqUwPoDsbJaR10iQJYnMuZhRTvHYl62ErLIEX7RgFlziSBUUvrt3OVfc47QlHHpzPZYP17g3Fv7oeJkg==}

--- a/sites/demo/package.json
+++ b/sites/demo/package.json
@@ -15,6 +15,7 @@
     "@vitessce/example-plugins": "workspace:*",
     "react": "^18.0.0",
     "react-dom": "^18.0.0",
+    "loglevel": "^1.8.1",
     "vitessce": "workspace:*"
   },
   "devDependencies": {

--- a/sites/demo/src/index.jsx
+++ b/sites/demo/src/index.jsx
@@ -1,6 +1,9 @@
 import React from 'react';
 import { createRoot } from 'react-dom/client';
+import log from 'loglevel';
 import { VitessceDemo } from './vitessce-demo';
+
+log.setLevel(log.levels.WARN);
 
 const container = document.getElementById('root');
 const root = createRoot(container);


### PR DESCRIPTION
<!-- Credit (as a starting template): https://github.com/visgl/deck.gl/blob/master/.github/pull_request_template.md -->
<!-- For feature, feature enhancement or bug fix, create an issue first and finish To Do List there -->
<!-- Anything doesn't work as expected is a bug, including code, doc and test -->
Fixes #1433 

Only thing i am not sure about is how to set the log level from the console like [DeckGL allows](https://deck.gl/docs/developer-guide/debugging#deckgl-logging). It would probably require setting a global on `window` which kind of goes against #1401. Also kind of related to https://github.com/vitessce/vitessce/issues/1436 if such a global would allow accessing the current/original config(s) for any Vitessce components on the page

TODO
- Add info about usage of `loglevel` to README or Docs for both internal developers (not to contribute PRs containing `console` calls but rather to use `loglevel`) and consumers of the `vitessce` package (with example of how to set the log level in the consumer app)

#### Checklist
 - [ ] Ensure PR works with all demos on the dev.vitessce.io homepage
 - [ ] Open (draft) PR's into [`vitessce-python`](https://github.com/vitessce/vitessce-python) and [`vitessce-r`](https://github.com/vitessce/vitessce-r) if this is a release PR
 - [ ] Documentation added or updated