### PR TITLE
Incremental update towards break-up-spatial-layers to support multi-`image.ome-tiff` and `image.ome-zarr`

### DIFF
--- a/examples/configs/src/view-configs/spraggins.js
+++ b/examples/configs/src/view-configs/spraggins.js
@@ -1,45 +1,188 @@
-import { urlPrefix } from '../utils';
-
 const vanderbiltDescription = 'High bit depth (uint16) multiplex immunofluorescence images of the kidney by the BIOmolecular Multimodal Imaging Center (BIOMIC) at Vanderbilt University';
-const vanderbiltBase = {
-  description: vanderbiltDescription,
-  layers: [
+const spragginsRasterJsonOptions = {
+  schemaVersion: '0.0.2',
+  renderLayers: [
+    'Spraggins MxIF',
+    'Spraggins IMS',
+  ],
+  images: [
     {
-      name: 'raster',
-      type: 'RASTER',
-      fileType: 'raster.json',
-      url: `${urlPrefix}/spraggins/spraggins.raster.json`,
+      name: 'Spraggins IMS',
+      // TODO: update to use OME-NGFF or OME-TIFF rather than Bioformats-Zarr.
+      url: 'https://vitessce-data.storage.googleapis.com/0.0.31/master_release/spraggins/spraggins.ims.zarr',
+      type: 'zarr',
+      metadata: {
+        dimensions: [
+          {
+            field: 'mz',
+            type: 'ordinal',
+            values: [
+              '675.5366',
+              '703.5722',
+              '721.4766',
+              '725.5562',
+              '729.5892',
+              '731.606',
+              '734.5692',
+              '737.4524',
+              '739.4651',
+              '741.5302',
+              '745.4766',
+              '747.4938',
+              '749.5093',
+              '753.5892',
+              '756.5534',
+              '758.5706',
+              '772.5225',
+              '772.5506',
+              '776.5928',
+              '780.5528',
+              '782.5697',
+              '784.5841',
+              '786.6012',
+              '787.6707',
+              '790.5157',
+              '796.5259',
+              '798.54',
+              '804.5528',
+              '806.5683',
+              '808.5838',
+              '809.6518',
+              '810.6',
+              '811.6699',
+              '813.6847',
+              '815.699',
+              '820.5262',
+              '822.5394',
+              '824.5559',
+              '825.6241',
+              '828.5495',
+              '830.5666',
+              '832.5816',
+              '833.649',
+              '835.6666',
+              '837.6798',
+              '848.5577',
+              '851.6374',
+            ],
+          },
+          {
+            field: 'y',
+            type: 'quantitative',
+            values: null,
+          },
+          {
+            field: 'x',
+            type: 'quantitative',
+            values: null,
+          },
+        ],
+        isPyramid: false,
+        transform: {
+          scale: 20.0,
+          translate: {
+            y: 12020,
+            x: 19020,
+          },
+        },
+      },
+    },
+    {
+      name: 'Spraggins MxIF',
+      // TODO: update to use OME-NGFF or OME-TIFF rather than Bioformats-Zarr.
+      url: 'https://vitessce-data.storage.googleapis.com/0.0.31/master_release/spraggins/spraggins.mxif.zarr',
+      type: 'zarr',
+      metadata: {
+        dimensions: [
+          {
+            field: 'channel',
+            type: 'nominal',
+            values: [
+              'DAPI - Hoechst (nuclei)',
+              'FITC - Laminin (basement membrane)',
+              'Cy3 - Synaptopodin (glomerular)',
+              'Cy5 - THP (thick limb)',
+            ],
+          },
+          {
+            field: 'y',
+            type: 'quantitative',
+            values: null,
+          },
+          {
+            field: 'x',
+            type: 'quantitative',
+            values: null,
+          },
+        ],
+        isPyramid: true,
+        transform: {
+          translate: {
+            y: 0,
+            x: 0,
+          },
+          scale: 1,
+        },
+      },
     },
   ],
 };
 
 export const spraggins2020 = {
-  ...vanderbiltBase,
-  version: '0.1.0',
+  version: '1.0.1',
   name: 'Spraggins',
-  public: true,
-  staticLayout: [
+  description: vanderbiltDescription,
+  datasets: [
+    {
+      uid: 'A',
+      name: 'Spraggins',
+      files: [
+        {
+          type: 'raster',
+          fileType: 'raster.json',
+          options: spragginsRasterJsonOptions,
+        },
+      ],
+    },
+  ],
+  coordinationSpace: {
+    spatialZoom: {
+      A: -6.5,
+    },
+    spatialTargetX: {
+      A: 20000,
+    },
+    spatialTargetY: {
+      A: 20000,
+    },
+  },
+  layout: [
     {
       component: 'spatial',
-      props: {
-        view: {
-          zoom: -6.5,
-          target: [20000, 20000, 0],
-        },
+      coordinationScopes: {
+        spatialZoom: 'A',
+        spatialTargetX: 'A',
+        spatialTargetY: 'A',
       },
       x: 0,
       y: 0,
       w: 9,
-      h: 2,
+      h: 12,
     },
     {
       component: 'layerController',
+      coordinationScopes: {
+        spatialZoom: 'A',
+        spatialTargetX: 'A',
+        spatialTargetY: 'A',
+      },
       x: 9,
       y: 0,
       w: 3,
-      h: 2,
+      h: 12,
     },
   ],
+  initStrategy: 'auto',
 };
 
 export const neumann2020 = {

--- a/packages/file-types/json/src/json-loaders/JsonLoader.js
+++ b/packages/file-types/json/src/json-loaders/JsonLoader.js
@@ -29,8 +29,12 @@ export default class JsonLoader extends AbstractTwoStepLoader {
 
   load() {
     const {
-      url, type, fileType,
+      url, type, fileType, options,
     } = this;
+    if (fileType === 'raster.json') {
+      // Special case for raster.json.
+      return Promise.resolve(options);
+    }
     if (this.data) {
       return this.data;
     }

--- a/packages/file-types/json/src/raster-json-loaders/RasterJsonLoader.js
+++ b/packages/file-types/json/src/raster-json-loaders/RasterJsonLoader.js
@@ -74,11 +74,6 @@ async function initLoader(imageData) {
 
 export default class RasterLoader extends JsonLoader {
   constructor(dataSource, params) {
-    const { url, options } = params;
-    if (!url && options) {
-      // eslint-disable-next-line no-param-reassign
-      dataSource.url = URL.createObjectURL(new Blob([JSON.stringify(options)]));
-    }
     super(dataSource, params);
     this.schema = rasterSchema;
   }

--- a/packages/file-types/ome-tiff/src/OmeTiffLoader.js
+++ b/packages/file-types/ome-tiff/src/OmeTiffLoader.js
@@ -21,8 +21,10 @@ export default class OmeTiffLoader extends AbstractTwoStepLoader {
   }
 
   async load() {
-    const { url, requestInit } = this;
+    const { url, requestInit, coordinationValues } = this;
     const { coordinateTransformations: coordinateTransformationsFromOptions } = this.options || {};
+
+    console.log(coordinationValues);
 
     // Get image name and URL tuples.
     const urls = [
@@ -87,13 +89,14 @@ export default class OmeTiffLoader extends AbstractTwoStepLoader {
         imagesWithLoaderCreators,
         renderLayers,
         usePhysicalSizeScaling,
+        coordinationValues.image,
       );
     }
 
     return this.autoImageCache.then((autoImages) => {
       const [autoImageLayers, imageLayerLoaders, imageLayerMeta] = autoImages;
 
-      const coordinationValues = {
+      const coordinationValuesForView = {
         spatialImageLayer: autoImageLayers,
       };
       return new LoaderResult(
@@ -102,7 +105,7 @@ export default class OmeTiffLoader extends AbstractTwoStepLoader {
           featureIndex: channels,
         },
         urls,
-        coordinationValues,
+        coordinationValuesForView,
       );
     });
   }

--- a/packages/schemas/src/previous-base-schemas.ts
+++ b/packages/schemas/src/previous-base-schemas.ts
@@ -256,7 +256,12 @@ export const configSchema1_0_16 = configSchema1_0_13.extend({
   ),
 });
 
-export const latestConfigSchema = configSchema1_0_16;
+// Only coordination type or behavioral changes.
+export const configSchema1_0_17 = configSchema1_0_16.extend({
+  version: z.literal('1.0.17'),
+});
+
+export const latestConfigSchema = configSchema1_0_17;
 
 export type AnyVersionConfig =
   z.infer<typeof configSchema0_1_0> |
@@ -276,6 +281,7 @@ export type AnyVersionConfig =
   z.infer<typeof configSchema1_0_13> |
   z.infer<typeof configSchema1_0_14> |
   z.infer<typeof configSchema1_0_15> |
-  z.infer<typeof configSchema1_0_16>;
+  z.infer<typeof configSchema1_0_16> |
+  z.infer<typeof configSchema1_0_17>;
 
 export type UpgradeFunction = (config: any) => AnyVersionConfig;

--- a/packages/schemas/src/schema-builders.ts
+++ b/packages/schemas/src/schema-builders.ts
@@ -65,7 +65,7 @@ export function buildConfigSchema<
 
   // TODO: make this less redundant with latestSchema from ./previous-base-schemas
   return z.object({
-    version: z.literal('1.0.16')
+    version: z.literal('1.0.17')
       .describe('The schema version for the view config.'),
     uid: z.string().optional(),
     name: z.string(),

--- a/packages/schemas/src/view-config-upgraders.ts
+++ b/packages/schemas/src/view-config-upgraders.ts
@@ -747,7 +747,6 @@ export function upgradeFrom1_0_16(
   config: z.infer<typeof configSchema1_0_16>,
 ): z.infer<typeof configSchema1_0_17> {
   const newConfig = cloneDeep(config);
-
   const { datasets, layout, coordinationSpace = {} } = newConfig;
 
   const imageScopes: string[] = [];

--- a/packages/schemas/src/view-config-upgraders.ts
+++ b/packages/schemas/src/view-config-upgraders.ts
@@ -22,6 +22,7 @@ import {
   configSchema1_0_14,
   configSchema1_0_15,
   configSchema1_0_16,
+  configSchema1_0_17,
 } from './previous-base-schemas';
 import { componentCoordinationScopes, componentCoordinationScopesBy } from './shared';
 
@@ -736,4 +737,23 @@ export function upgradeFrom1_0_15(
     layout: newLayout,
     version: '1.0.16',
   };
+}
+
+// Added in version 1.0.17:
+// - Use multi-level coordination to
+// break up spatial layer coordination values
+// (from arrays and nested objects to primitives).
+export function upgradeFrom1_0_16(
+  config: z.infer<typeof configSchema1_0_16>,
+): z.infer<typeof configSchema1_0_17> {
+  const newConfig = cloneDeep(config);
+
+  
+
+  return {
+    ...newConfig,
+    layout: newLayout,
+    coordinationSpace: newCoordinationSpace,
+    version: '1.0.17',
+  }
 }

--- a/packages/schemas/src/view-config-utils.test.fixtures.ts
+++ b/packages/schemas/src/view-config-utils.test.fixtures.ts
@@ -1358,8 +1358,8 @@ export const nestedSpatialLayers: z.infer<typeof configSchema1_0_16> = {
   initStrategy: 'auto',
 };
 
-export const nestedSpatialLayersWithImageCoordinationValue: z.infer<typeof configSchema1_0_16> = {
-  version: '1.0.16',
+export const nestedSpatialLayersWithImageCoordinationValue: z.infer<typeof configSchema1_0_17> = {
+  version: '1.0.17',
   name: 'Spatial layers fixture',
   datasets: [
     {

--- a/packages/schemas/src/view-config-utils.test.fixtures.ts
+++ b/packages/schemas/src/view-config-utils.test.fixtures.ts
@@ -6,7 +6,8 @@ import {
   configSchema1_0_1,
   configSchema1_0_15,
   configSchema1_0_16,
-} from "./previous-base-schemas";
+  configSchema1_0_17,
+} from './previous-base-schemas';
 
 /* eslint-disable camelcase */
 export const legacyViewConfig0_1_0: z.infer<typeof configSchema0_1_0> = {
@@ -898,4 +899,860 @@ export const explicitPerDatasetCoordinations: z.infer<typeof configSchema1_0_16>
       y: 2,
     },
   ],
+};
+
+// TODO: another example with a segmentation bitmask
+export const nestedSpatialLayers: z.infer<typeof configSchema1_0_16> = {
+  version: '1.0.16',
+  name: 'Spatial layers fixture',
+  datasets: [
+    {
+      uid: 'A',
+      name: 'My dataset',
+      files: [
+        {
+          fileType: 'image.raster.json',
+          options: {
+            schemaVersion: '0.0.2',
+            images: [
+              {
+                name: 'PAS',
+                type: 'ome-tiff',
+                url: 'https://assets.hubmapconsortium.org/f4188a148e4c759092d19369d310883b/ometiff-pyramids/processedMicroscopy/VAN0006-LK-2-85-PAS_images/VAN0006-LK-2-85-PAS_registered.ome.tif?token=',
+              },
+              {
+                name: 'AF',
+                type: 'ome-tiff',
+                url: 'https://assets.hubmapconsortium.org/2130d5f91ce61d7157a42c0497b06de8/ometiff-pyramids/processedMicroscopy/VAN0006-LK-2-85-AF_preIMS_images/VAN0006-LK-2-85-AF_preIMS_registered.ome.tif?token=',
+              },
+              {
+                name: 'IMS PosMode',
+                type: 'ome-tiff',
+                url: 'https://assets.hubmapconsortium.org/be503a021ed910c0918842e318e6efa2/ometiff-pyramids/ometiffs/VAN0006-LK-2-85-IMS_PosMode_multilayer.ome.tif?token=',
+              },
+              {
+                name: 'IMS NegMode',
+                type: 'ome-tiff',
+                url: 'https://assets.hubmapconsortium.org/ca886a630b2038997a4cfbbf4abfd283/ometiff-pyramids/ometiffs/VAN0006-LK-2-85-IMS_NegMode_multilayer.ome.tif?token=',
+              },
+            ],
+            usePhysicalSizeScaling: true,
+            renderLayers: [
+              'PAS',
+              'AF',
+              'IMS PosMode',
+              'IMS NegMode',
+            ],
+          },
+        },
+      ],
+    },
+  ],
+  coordinationSpace: {
+    dataset: {
+      A: 'A',
+    },
+    obsType: {
+      A: 'cell',
+    },
+    featureType: {
+      A: 'gene',
+    },
+    featureValueType: {
+      A: 'expression',
+    },
+    obsLabelsType: {
+      A: null,
+    },
+    spatialZoom: {
+      A: -4.4211074257069285,
+    },
+    spatialRotation: {
+      A: 0,
+    },
+    spatialTargetX: {
+      A: 11092.812174766119,
+    },
+    spatialTargetY: {
+      A: 15196.071341244067,
+    },
+    spatialTargetZ: {
+      A: null,
+    },
+    spatialRotationX: {
+      A: 0,
+    },
+    spatialRotationY: {
+      A: null,
+    },
+    spatialRotationZ: {
+      A: null,
+    },
+    spatialRotationOrbit: {
+      A: 0,
+    },
+    spatialOrbitAxis: {
+      A: null,
+    },
+    spatialAxisFixed: {
+      A: false,
+    },
+    obsFilter: {
+      A: null,
+    },
+    obsHighlight: {
+      A: null,
+    },
+    obsSetSelection: {
+      A: null,
+    },
+    obsSetHighlight: {
+      A: null,
+    },
+    obsSetColor: {
+      A: null,
+    },
+    featureHighlight: {
+      A: null,
+    },
+    featureSelection: {
+      A: null,
+    },
+    featureValueColormap: {
+      A: 'plasma',
+    },
+    featureValueColormapRange: {
+      A: [
+        0,
+        1,
+      ],
+    },
+    obsColorEncoding: {
+      A: 'cellSetSelection',
+    },
+    spatialImageLayer: {
+      A: [
+        {
+          type: 'raster',
+          index: 0,
+          visible: true,
+          colormap: null,
+          opacity: 1,
+          domainType: 'Min/Max',
+          transparentColor: null,
+          renderingMode: 'Additive',
+          use3d: false,
+          channels: [
+            {
+              selection: {
+                c: 0,
+                z: 0,
+                t: 0,
+              },
+              color: [
+                255,
+                0,
+                0,
+              ],
+              visible: true,
+              slider: [
+                0,
+                255,
+              ],
+            },
+            {
+              selection: {
+                c: 1,
+                z: 0,
+                t: 0,
+              },
+              color: [
+                0,
+                255,
+                0,
+              ],
+              visible: true,
+              slider: [
+                0,
+                255,
+              ],
+            },
+            {
+              selection: {
+                c: 2,
+                z: 0,
+                t: 0,
+              },
+              color: [
+                0,
+                0,
+                255,
+              ],
+              visible: true,
+              slider: [
+                0,
+                255,
+              ],
+            },
+          ],
+        },
+        {
+          type: 'raster',
+          index: 1,
+          visible: true,
+          colormap: null,
+          opacity: 1,
+          domainType: 'Min/Max',
+          transparentColor: [
+            0,
+            0,
+            0,
+          ],
+          renderingMode: 'Additive',
+          use3d: false,
+          channels: [
+            {
+              selection: {
+                c: 0,
+                z: 0,
+                t: 0,
+              },
+              color: [
+                0,
+                0,
+                255,
+              ],
+              visible: true,
+              slider: [
+                1024,
+                23753,
+              ],
+            },
+            {
+              selection: {
+                c: 1,
+                z: 0,
+                t: 0,
+              },
+              color: [
+                0,
+                255,
+                0,
+              ],
+              visible: true,
+              slider: [
+                373,
+                9848,
+              ],
+            },
+            {
+              selection: {
+                c: 2,
+                z: 0,
+                t: 0,
+              },
+              color: [
+                255,
+                0,
+                255,
+              ],
+              visible: true,
+              slider: [
+                326,
+                14084,
+              ],
+            },
+          ],
+        },
+        {
+          type: 'raster',
+          index: 2,
+          visible: true,
+          colormap: null,
+          opacity: 1,
+          domainType: 'Min/Max',
+          transparentColor: [
+            0,
+            0,
+            0,
+          ],
+          renderingMode: 'Additive',
+          use3d: false,
+          channels: [
+            {
+              selection: {
+                c: 0,
+                z: 0,
+                t: 0,
+              },
+              color: [
+                0,
+                0,
+                255,
+              ],
+              visible: true,
+              slider: [
+                0.7109375,
+                2817.15283203125,
+              ],
+            },
+            {
+              selection: {
+                c: 1,
+                z: 0,
+                t: 0,
+              },
+              color: [
+                0,
+                255,
+                0,
+              ],
+              visible: true,
+              slider: [
+                7.094120025634766,
+                50509.515625,
+              ],
+            },
+            {
+              selection: {
+                c: 2,
+                z: 0,
+                t: 0,
+              },
+              color: [
+                255,
+                0,
+                255,
+              ],
+              visible: true,
+              slider: [
+                0.5399665832519531,
+                1078.9984130859375,
+              ],
+            },
+            {
+              selection: {
+                c: 3,
+                z: 0,
+                t: 0,
+              },
+              color: [
+                255,
+                255,
+                0,
+              ],
+              visible: true,
+              slider: [
+                0.28322410583496094,
+                1108.6363525390625,
+              ],
+            },
+          ],
+          modelMatrix: [
+            20,
+            0,
+            0,
+            0,
+            0,
+            20,
+            0,
+            0,
+            0,
+            0,
+            1,
+            0,
+            0,
+            0,
+            0,
+            1,
+          ],
+        },
+        {
+          type: 'raster',
+          index: 3,
+          visible: true,
+          colormap: null,
+          opacity: 1,
+          domainType: 'Min/Max',
+          transparentColor: [
+            0,
+            0,
+            0,
+          ],
+          renderingMode: 'Additive',
+          use3d: false,
+          channels: [
+            {
+              selection: {
+                c: 0,
+                z: 0,
+                t: 0,
+              },
+              color: [
+                0,
+                0,
+                255,
+              ],
+              visible: true,
+              slider: [
+                1.335814118385315,
+                1839.003662109375,
+              ],
+            },
+            {
+              selection: {
+                c: 1,
+                z: 0,
+                t: 0,
+              },
+              color: [
+                0,
+                255,
+                0,
+              ],
+              visible: true,
+              slider: [
+                4.591888427734375,
+                5142.390625,
+              ],
+            },
+            {
+              selection: {
+                c: 2,
+                z: 0,
+                t: 0,
+              },
+              color: [
+                255,
+                0,
+                255,
+              ],
+              visible: true,
+              slider: [
+                0.2421875,
+                314.395751953125,
+              ],
+            },
+            {
+              selection: {
+                c: 3,
+                z: 0,
+                t: 0,
+              },
+              color: [
+                255,
+                255,
+                0,
+              ],
+              visible: true,
+              slider: [
+                0.4366779327392578,
+                390.0624084472656,
+              ],
+            },
+          ],
+          modelMatrix: [
+            20,
+            0,
+            0,
+            0,
+            0,
+            20,
+            0,
+            0,
+            0,
+            0,
+            1,
+            0,
+            0,
+            0,
+            0,
+            1,
+          ],
+        },
+      ],
+    },
+    spatialSegmentationLayer: {
+      A: [],
+    },
+    spatialPointLayer: {
+      A: null,
+    },
+    spatialNeighborhoodLayer: {
+      A: null,
+    },
+    additionalObsSets: {
+      A: null,
+    },
+    moleculeHighlight: {
+      A: null,
+    },
+  },
+  layout: [
+    {
+      component: 'spatial',
+      coordinationScopes: {
+        dataset: 'A',
+        obsType: 'A',
+        featureType: 'A',
+        featureValueType: 'A',
+        obsLabelsType: 'A',
+        spatialZoom: 'A',
+        spatialRotation: 'A',
+        spatialTargetX: 'A',
+        spatialTargetY: 'A',
+        spatialTargetZ: 'A',
+        spatialRotationX: 'A',
+        spatialRotationY: 'A',
+        spatialRotationZ: 'A',
+        spatialRotationOrbit: 'A',
+        spatialOrbitAxis: 'A',
+        spatialAxisFixed: 'A',
+        obsFilter: 'A',
+        obsHighlight: 'A',
+        obsSetSelection: 'A',
+        obsSetHighlight: 'A',
+        obsSetColor: 'A',
+        featureHighlight: 'A',
+        featureSelection: 'A',
+        featureValueColormap: 'A',
+        featureValueColormapRange: 'A',
+        obsColorEncoding: 'A',
+        spatialImageLayer: 'A',
+        spatialSegmentationLayer: 'A',
+        spatialPointLayer: 'A',
+        spatialNeighborhoodLayer: 'A',
+        additionalObsSets: 'A',
+        moleculeHighlight: 'A',
+      },
+      x: 0,
+      y: 0,
+      w: 9,
+      h: 12,
+      uid: 'A',
+    },
+    {
+      component: 'layerController',
+      coordinationScopes: {
+        dataset: 'A',
+        obsType: 'A',
+        featureType: 'A',
+        featureValueType: 'A',
+        spatialZoom: 'A',
+        spatialTargetX: 'A',
+        spatialTargetY: 'A',
+        spatialTargetZ: 'A',
+        spatialRotationX: 'A',
+        spatialRotationY: 'A',
+        spatialRotationZ: 'A',
+        spatialRotationOrbit: 'A',
+        spatialOrbitAxis: 'A',
+        spatialImageLayer: 'A',
+        spatialSegmentationLayer: 'A',
+        spatialPointLayer: 'A',
+        spatialNeighborhoodLayer: 'A',
+      },
+      x: 9,
+      y: 0,
+      w: 3,
+      h: 12,
+      props: {
+        globalDisable3d: true,
+        disableChannelsIfRgbDetected: true,
+      },
+      uid: 'B',
+    },
+  ],
+  initStrategy: 'auto',
+};
+
+export const multiLevelSpatialLayers: z.infer<typeof configSchema1_0_17> = {
+  version: '1.0.17',
+  name: 'Spatial layers fixture',
+  datasets: [
+    {
+      uid: 'A',
+      name: 'My dataset',
+      files: [
+        {
+          fileType: 'image.ome-tiff',
+          url: 'https://assets.hubmapconsortium.org/f4188a148e4c759092d19369d310883b/ometiff-pyramids/processedMicroscopy/VAN0006-LK-2-85-PAS_images/VAN0006-LK-2-85-PAS_registered.ome.tif?token=',
+          coordinationValues: {
+            image: 'PAS',
+          },
+        },
+        {
+          fileType: 'image.ome-tiff',
+          url: 'https://assets.hubmapconsortium.org/2130d5f91ce61d7157a42c0497b06de8/ometiff-pyramids/processedMicroscopy/VAN0006-LK-2-85-AF_preIMS_images/VAN0006-LK-2-85-AF_preIMS_registered.ome.tif?token=',
+          coordinationValues: {
+            image: 'AF',
+          },
+        },
+        {
+          fileType: 'image.ome-tiff',
+          url: 'https://assets.hubmapconsortium.org/be503a021ed910c0918842e318e6efa2/ometiff-pyramids/ometiffs/VAN0006-LK-2-85-IMS_PosMode_multilayer.ome.tif?token=',
+          coordinationValues: {
+            image: 'IMS PosMode',
+          },
+        },
+        {
+          fileType: 'image.ome-tiff',
+          url: 'https://assets.hubmapconsortium.org/ca886a630b2038997a4cfbbf4abfd283/ometiff-pyramids/ometiffs/VAN0006-LK-2-85-IMS_NegMode_multilayer.ome.tif?token=',
+          coordinationValues: {
+            image: 'IMS NegMode',
+          },
+        },
+        // TODO: example with obsSegmentations.ome-tiff (bitmask)
+        // TODO: example with obsSegmentations.json (polygons)
+      ],
+    },
+  ],
+  coordinationSpace: {
+    dataset: { A: 'A' },
+    spatialImageLayer: {
+      A: '__dummy__', B: '__dummy__', C: '__dummy__', D: '__dummy__',
+    },
+    image: {
+      A: 'PAS', B: 'AF', C: 'IMS PosMode', D: 'IMS NegMode',
+    },
+    spatialLayerVisible: {
+      A: true, B: true, C: true, D: true,
+    },
+    spatialLayerOpacity: {
+      A: 1, B: 1, C: 1, D: 1,
+    },
+    spatialImageChannel: {
+      // PAS: RGB
+      A: '__dummy__',
+      B: '__dummy__',
+      C: '__dummy__',
+      // AF: 3 channels
+      D: '__dummy__',
+      E: '__dummy__',
+      F: '__dummy__',
+      // IMS PosMode: 4 channels
+      G: '__dummy__',
+      H: '__dummy__',
+      I: '__dummy__',
+      J: '__dummy__',
+      // IMS: NegMode: 4 channels
+      K: '__dummy__',
+      L: '__dummy__',
+      M: '__dummy__',
+      N: '__dummy__',
+    },
+    spatialTargetC: {
+      // Previously in spatialImageLayer[].channels[].selection.(c|C|color|...):
+      // eslint-disable-next-line object-property-newline
+      A: 0, B: 1, C: 2,
+      // eslint-disable-next-line object-property-newline
+      D: 0, E: 1, F: 2,
+      // eslint-disable-next-line object-property-newline
+      G: 0, H: 1, I: 2, J: 3,
+      // eslint-disable-next-line object-property-newline
+      K: 0, L: 1, M: 2, N: 3,
+    },
+    spatialChannelVisible: {
+      // Previously in spatialImageLayer[].channels[].selection.(c|C|color|...):
+      // eslint-disable-next-line object-property-newline
+      A: true, B: true, C: true,
+      // eslint-disable-next-line object-property-newline
+      D: true, E: true, F: true,
+      // eslint-disable-next-line object-property-newline
+      G: true, H: true, I: true, J: true,
+      // eslint-disable-next-line object-property-newline
+      K: true, L: true, M: true, N: true,
+    },
+    spatialChannelColor: {
+      // Previously in spatialImageLayer[].channels[].color:
+      // RGB
+      A: [255, 0, 0],
+      B: [0, 255, 0],
+      C: [0, 0, 255],
+      // AF
+      D: [0, 0, 255],
+      E: [0, 255, 0],
+      F: [255, 0, 255],
+      // IMS PosMode
+      G: [0, 0, 255],
+      H: [0, 255, 0],
+      I: [255, 0, 255],
+      J: [255, 255, 0],
+      // IMS NegMode
+      K: [0, 0, 255],
+      L: [0, 255, 0],
+      M: [255, 0, 255],
+      N: [255, 255, 0],
+    },
+    spatialChannelColormap: {
+      // Previously in spatialImageLayer[].colormap:
+      A: null,
+      B: null,
+      C: null,
+      D: null,
+    },
+    spatialWindowSliderMode: {
+      // Previously in spatialImageLayer[].domainType:
+      A: 'extent', // Converted from 'Min/Max'
+      B: 'extent', // Converted from 'Min/Max'
+      C: 'extent', // Converted from 'Min/Max'
+      D: 'extent', // Converted from 'Min/Max'
+    },
+    spatialTransparentColor: {
+      // Previously in spatialImageLayer[].transparentColor:
+      A: null,
+      B: [0, 0, 0],
+      C: [0, 0, 0],
+      D: [0, 0, 0],
+    },
+    spatialChannelWindowRange: {
+      // Previously in spatialImageLayer[].channels[].slider
+      // PAS
+      A: [0, 255],
+      B: [0, 255],
+      C: [0, 255],
+      // AF
+      D: [1024, 23753],
+      E: [373, 9848],
+      F: [326, 14084],
+      // IMS PosMode
+      G: [0.7109375, 2817.15283203125],
+      H: [7.094120025634766, 50509.515625],
+      I: [0.5399665832519531, 1078.9984130859375],
+      J: [0.28322410583496094, 1108.6363525390625],
+      // IMS NegMode
+      K: [1.335814118385315, 1839.003662109375],
+      L: [4.591888427734375, 5142.390625],
+      M: [0.2421875, 314.395751953125],
+      N: [0.4366779327392578, 390.0624084472656],
+    },
+    spatialModelMatrix: {
+      // Previously in spatialImageLayer[].modelMatrix
+      // IMS PosMode
+      A: [
+        20,
+        0,
+        0,
+        0,
+        0,
+        20,
+        0,
+        0,
+        0,
+        0,
+        1,
+        0,
+        0,
+        0,
+        0,
+        1,
+      ],
+      // IMS NegMode
+      B: [
+        20,
+        0,
+        0,
+        0,
+        0,
+        20,
+        0,
+        0,
+        0,
+        0,
+        1,
+        0,
+        0,
+        0,
+        0,
+        1,
+      ],
+    },
+    metaCoordinationScopes: {
+      A: {
+        spatialImageLayer: ['A', 'B', 'C', 'D'],
+        // TODO: example with spatialSemgentationLayer (as bitmask)
+        // TODO: example with spatialSemgentationLayer (as polygon)
+        // TODO: example with spatialPointLayer
+      },
+    },
+    metaCoordinationScopesBy: {
+      A: {
+        spatialImageLayer: {
+          image: {
+            A: 'A', B: 'B', C: 'C', D: 'D',
+          },
+          spatialLayerVisible: {
+            A: 'A', B: 'B', C: 'C', D: 'D',
+          },
+          spatialLayerOpacity: {
+            A: 'A', B: 'B', C: 'C', D: 'D',
+          },
+          spatialWindowSliderMode: {
+            A: 'A', B: 'B', C: 'C', D: 'D',
+          },
+          spatialTransparentColor: {
+            A: 'A', B: 'B', C: 'C', D: 'D',
+          },
+          spatialImageChannel: {
+            A: ['A', 'B', 'C'],
+            B: ['D', 'E', 'F'],
+            C: ['G', 'H', 'I', 'J'],
+            D: ['K', 'L', 'M', 'N'],
+          },
+        },
+        spatialImageChannel: {
+          spatialTargetC: {
+            A: 'A', B: 'B', C: 'C',
+            D: 'D', E: 'E', F: 'F',
+            G: 'G', H: 'H', I: 'I', J: 'J',
+            K: 'K', L: 'L', M: 'M', N: 'N',
+          },
+          spatialChannelColor: {
+            A: 'A', B: 'B', C: 'C',
+            D: 'D', E: 'E', F: 'F',
+            G: 'G', H: 'H', I: 'I', J: 'J',
+            K: 'K', L: 'L', M: 'M', N: 'N',
+          },
+          spatialChannelColormap: {
+            A: 'A', B: 'A', C: 'A',
+            D: 'B', E: 'B', F: 'B',
+            G: 'C', H: 'C', I: 'C', J: 'C',
+            K: 'D', L: 'D', M: 'D', N: 'D',
+          },
+          spatialChannelVisible: {
+            A: 'A', B: 'A', C: 'A',
+            D: 'B', E: 'B', F: 'B',
+            G: 'C', H: 'C', I: 'C', J: 'C',
+            K: 'D', L: 'D', M: 'D', N: 'D',
+          },
+          spatialChannelWindowRange: {
+            A: 'A', B: 'A', C: 'A',
+            D: 'B', E: 'B', F: 'B',
+            G: 'C', H: 'C', I: 'C', J: 'C',
+            K: 'D', L: 'D', M: 'D', N: 'D',
+          },
+        },
+      },
+    },
+  },
+  layout: [{
+    component: 'spatial',
+    coordinationScopes: {
+      dataset: 'A',
+      metaCoordinationScopes: ['A'],
+      metaCoordinationScopesBy: ['A'],
+    },
+    // eslint-disable-next-line object-property-newline
+    x: 0, y: 0, w: 1, h: 1,
+  }, {
+    component: 'layerController',
+    coordinationScopes: {
+      dataset: 'A',
+      metaCoordinationScopes: ['A'],
+      metaCoordinationScopesBy: ['A'],
+    },
+    // eslint-disable-next-line object-property-newline
+    x: 0, y: 0, w: 1, h: 1,
+  }],
+  initStrategy: 'auto',
 };

--- a/packages/schemas/src/view-config-utils.test.fixtures.ts
+++ b/packages/schemas/src/view-config-utils.test.fixtures.ts
@@ -1358,11 +1358,12 @@ export const nestedSpatialLayers: z.infer<typeof configSchema1_0_16> = {
   initStrategy: 'auto',
 };
 
-export const multiLevelSpatialLayers: z.infer<typeof configSchema1_0_17> = {
-  version: '1.0.17',
+export const nestedSpatialLayersWithImageCoordinationValue: z.infer<typeof configSchema1_0_16> = {
+  version: '1.0.16',
   name: 'Spatial layers fixture',
   datasets: [
     {
+      // TODO: example with multiple datasets
       uid: 'A',
       name: 'My dataset',
       files: [
@@ -1400,7 +1401,9 @@ export const multiLevelSpatialLayers: z.infer<typeof configSchema1_0_17> = {
     },
   ],
   coordinationSpace: {
-    dataset: { A: 'A' },
+    dataset: {
+      A: 'A',
+    },
     spatialZoom: {
       A: -4.4211074257069285,
     },
@@ -1410,300 +1413,399 @@ export const multiLevelSpatialLayers: z.infer<typeof configSchema1_0_17> = {
     spatialTargetY: {
       A: 15196.071341244067,
     },
-    spatialImageLayer: {
-      A: '__dummy__', B: '__dummy__', C: '__dummy__', D: '__dummy__',
-    },
-    image: {
-      A: 'PAS', B: 'AF', C: 'IMS PosMode', D: 'IMS NegMode',
-    },
-    spatialLayerVisible: {
-      A: true, B: true, C: true, D: true,
-    },
-    spatialLayerOpacity: {
-      A: 1, B: 1, C: 1, D: 1,
-    },
-    spatialImageChannel: {
-      // PAS: RGB
-      A: '__dummy__',
-      B: '__dummy__',
-      C: '__dummy__',
-      // AF: 3 channels
-      D: '__dummy__',
-      E: '__dummy__',
-      F: '__dummy__',
-      // IMS PosMode: 4 channels
-      G: '__dummy__',
-      H: '__dummy__',
-      I: '__dummy__',
-      J: '__dummy__',
-      // IMS: NegMode: 4 channels
-      K: '__dummy__',
-      L: '__dummy__',
-      M: '__dummy__',
-      N: '__dummy__',
-    },
-    spatialTargetC: {
-      // Previously in spatialImageLayer[].channels[].selection.(c|C|color|...):
-      // eslint-disable-next-line object-property-newline
-      A: 0, B: 1, C: 2,
-      // eslint-disable-next-line object-property-newline
-      D: 0, E: 1, F: 2,
-      // eslint-disable-next-line object-property-newline
-      G: 0, H: 1, I: 2, J: 3,
-      // eslint-disable-next-line object-property-newline
-      K: 0, L: 1, M: 2, N: 3,
-    },
     spatialTargetZ: {
-      // Previously in spatialImageLayer[].channels[].selection.(z|Z|...):
-      A: 0, B: 1, C: 2, D: 0,
-    },
-    spatialTargetT: {
-      // Previously in spatialImageLayer[].channels[].selection.(t|T|temporal|...):
-      A: 0, B: 1, C: 2, D: 0,
-    },
-    spatialChannelVisible: {
-      // Previously in spatialImageLayer[].channels[].selection.(c|C|color|...):
-      // eslint-disable-next-line object-property-newline
-      A: true, B: true, C: true,
-      // eslint-disable-next-line object-property-newline
-      D: true, E: true, F: true,
-      // eslint-disable-next-line object-property-newline
-      G: true, H: true, I: true, J: true,
-      // eslint-disable-next-line object-property-newline
-      K: true, L: true, M: true, N: true,
-    },
-    spatialChannelColor: {
-      // Previously in spatialImageLayer[].channels[].color:
-      // RGB
-      A: [255, 0, 0],
-      B: [0, 255, 0],
-      C: [0, 0, 255],
-      // AF
-      D: [0, 0, 255],
-      E: [0, 255, 0],
-      F: [255, 0, 255],
-      // IMS PosMode
-      G: [0, 0, 255],
-      H: [0, 255, 0],
-      I: [255, 0, 255],
-      J: [255, 255, 0],
-      // IMS NegMode
-      K: [0, 0, 255],
-      L: [0, 255, 0],
-      M: [255, 0, 255],
-      N: [255, 255, 0],
-    },
-    spatialChannelColormap: {
-      // Previously in spatialImageLayer[].colormap:
       A: null,
-      B: null,
-      C: null,
-      D: null,
     },
-    spatialWindowSliderMode: {
-      // Previously in spatialImageLayer[].domainType:
-      A: 'Min/Max',
-      B: 'Min/Max',
-      C: 'Min/Max',
-      D: 'Min/Max',
-    },
-    spatialTransparentColor: {
-      // Previously in spatialImageLayer[].transparentColor:
-      A: null,
-      B: [0, 0, 0],
-      C: [0, 0, 0],
-      D: [0, 0, 0],
-    },
-    spatialRenderingMode: {
-      // Previously in spatialImageLayer[].use3d:
-      A: '2D',
-      B: '2D',
-      C: '2D',
-      D: '2D',
-    },
-    spatialImageVolumeRenderingMethod: {
-      // Previously in spatialImageLayer[].renderingMode:
-      A: 'Additive',
-      B: 'Additive',
-      C: 'Additive',
-      D: 'Additive',
-    },
-    spatialChannelWindowRange: {
-      // Previously in spatialImageLayer[].channels[].slider
-      // PAS
-      A: [0, 255],
-      B: [0, 255],
-      C: [0, 255],
-      // AF
-      D: [1024, 23753],
-      E: [373, 9848],
-      F: [326, 14084],
-      // IMS PosMode
-      G: [0.7109375, 2817.15283203125],
-      H: [7.094120025634766, 50509.515625],
-      I: [0.5399665832519531, 1078.9984130859375],
-      J: [0.28322410583496094, 1108.6363525390625],
-      // IMS NegMode
-      K: [1.335814118385315, 1839.003662109375],
-      L: [4.591888427734375, 5142.390625],
-      M: [0.2421875, 314.395751953125],
-      N: [0.4366779327392578, 390.0624084472656],
-    },
-    spatialModelMatrix: {
-      // Previously in spatialImageLayer[].modelMatrix
-      // IMS PosMode
+    spatialImageLayer: {
       A: [
-        20,
-        0,
-        0,
-        0,
-        0,
-        20,
-        0,
-        0,
-        0,
-        0,
-        1,
-        0,
-        0,
-        0,
-        0,
-        1,
-      ],
-      // IMS NegMode
-      B: [
-        20,
-        0,
-        0,
-        0,
-        0,
-        20,
-        0,
-        0,
-        0,
-        0,
-        1,
-        0,
-        0,
-        0,
-        0,
-        1,
+        {
+          type: 'raster',
+          image: 'PAS',
+          visible: true,
+          colormap: null,
+          opacity: 1,
+          domainType: 'Min/Max',
+          transparentColor: null,
+          renderingMode: 'Additive',
+          use3d: false,
+          channels: [
+            {
+              selection: {
+                c: 0,
+                z: 0,
+                t: 0,
+              },
+              color: [
+                255,
+                0,
+                0,
+              ],
+              visible: true,
+              slider: [
+                0,
+                255,
+              ],
+            },
+            {
+              selection: {
+                c: 1,
+                z: 0,
+                t: 0,
+              },
+              color: [
+                0,
+                255,
+                0,
+              ],
+              visible: true,
+              slider: [
+                0,
+                255,
+              ],
+            },
+            {
+              selection: {
+                c: 2,
+                z: 0,
+                t: 0,
+              },
+              color: [
+                0,
+                0,
+                255,
+              ],
+              visible: true,
+              slider: [
+                0,
+                255,
+              ],
+            },
+          ],
+        },
+        {
+          type: 'raster',
+          image: 'AF',
+          visible: true,
+          colormap: null,
+          opacity: 1,
+          domainType: 'Min/Max',
+          transparentColor: [
+            0,
+            0,
+            0,
+          ],
+          renderingMode: 'Additive',
+          use3d: false,
+          channels: [
+            {
+              selection: {
+                c: 0,
+                z: 0,
+                t: 0,
+              },
+              color: [
+                0,
+                0,
+                255,
+              ],
+              visible: true,
+              slider: [
+                1024,
+                23753,
+              ],
+            },
+            {
+              selection: {
+                c: 1,
+                z: 0,
+                t: 0,
+              },
+              color: [
+                0,
+                255,
+                0,
+              ],
+              visible: true,
+              slider: [
+                373,
+                9848,
+              ],
+            },
+            {
+              selection: {
+                c: 2,
+                z: 0,
+                t: 0,
+              },
+              color: [
+                255,
+                0,
+                255,
+              ],
+              visible: true,
+              slider: [
+                326,
+                14084,
+              ],
+            },
+          ],
+        },
+        {
+          type: 'raster',
+          image: 'IMS PosMode',
+          visible: true,
+          colormap: null,
+          opacity: 1,
+          domainType: 'Min/Max',
+          transparentColor: [
+            0,
+            0,
+            0,
+          ],
+          renderingMode: 'Additive',
+          use3d: false,
+          channels: [
+            {
+              selection: {
+                c: 0,
+                z: 0,
+                t: 0,
+              },
+              color: [
+                0,
+                0,
+                255,
+              ],
+              visible: true,
+              slider: [
+                0.7109375,
+                2817.15283203125,
+              ],
+            },
+            {
+              selection: {
+                c: 1,
+                z: 0,
+                t: 0,
+              },
+              color: [
+                0,
+                255,
+                0,
+              ],
+              visible: true,
+              slider: [
+                7.094120025634766,
+                50509.515625,
+              ],
+            },
+            {
+              selection: {
+                c: 2,
+                z: 0,
+                t: 0,
+              },
+              color: [
+                255,
+                0,
+                255,
+              ],
+              visible: true,
+              slider: [
+                0.5399665832519531,
+                1078.9984130859375,
+              ],
+            },
+            {
+              selection: {
+                c: 3,
+                z: 0,
+                t: 0,
+              },
+              color: [
+                255,
+                255,
+                0,
+              ],
+              visible: true,
+              slider: [
+                0.28322410583496094,
+                1108.6363525390625,
+              ],
+            },
+          ],
+          modelMatrix: [
+            20,
+            0,
+            0,
+            0,
+            0,
+            20,
+            0,
+            0,
+            0,
+            0,
+            1,
+            0,
+            0,
+            0,
+            0,
+            1,
+          ],
+        },
+        {
+          type: 'raster',
+          image: 'IMS NegMode',
+          visible: true,
+          colormap: null,
+          opacity: 1,
+          domainType: 'Min/Max',
+          transparentColor: [
+            0,
+            0,
+            0,
+          ],
+          renderingMode: 'Additive',
+          use3d: false,
+          channels: [
+            {
+              selection: {
+                c: 0,
+                z: 0,
+                t: 0,
+              },
+              color: [
+                0,
+                0,
+                255,
+              ],
+              visible: true,
+              slider: [
+                1.335814118385315,
+                1839.003662109375,
+              ],
+            },
+            {
+              selection: {
+                c: 1,
+                z: 0,
+                t: 0,
+              },
+              color: [
+                0,
+                255,
+                0,
+              ],
+              visible: true,
+              slider: [
+                4.591888427734375,
+                5142.390625,
+              ],
+            },
+            {
+              selection: {
+                c: 2,
+                z: 0,
+                t: 0,
+              },
+              color: [
+                255,
+                0,
+                255,
+              ],
+              visible: true,
+              slider: [
+                0.2421875,
+                314.395751953125,
+              ],
+            },
+            {
+              selection: {
+                c: 3,
+                z: 0,
+                t: 0,
+              },
+              color: [
+                255,
+                255,
+                0,
+              ],
+              visible: true,
+              slider: [
+                0.4366779327392578,
+                390.0624084472656,
+              ],
+            },
+          ],
+          modelMatrix: [
+            20,
+            0,
+            0,
+            0,
+            0,
+            20,
+            0,
+            0,
+            0,
+            0,
+            1,
+            0,
+            0,
+            0,
+            0,
+            1,
+          ],
+        },
       ],
     },
-    metaCoordinationScopes: {
-      A: {
-        spatialImageLayer: ['A', 'B', 'C', 'D'],
-        // TODO: example with spatialSemgentationLayer (as bitmask)
-        // TODO: example with spatialSemgentationLayer (as polygon)
-        // TODO: example with spatialPointLayer
-      },
+    spatialSegmentationLayer: {
+      A: [],
     },
-    metaCoordinationScopesBy: {
-      A: {
-        spatialImageLayer: {
-          image: {
-            A: 'A', B: 'B', C: 'C', D: 'D',
-          },
-          spatialLayerVisible: {
-            A: 'A', B: 'B', C: 'C', D: 'D',
-          },
-          spatialLayerOpacity: {
-            A: 'A', B: 'B', C: 'C', D: 'D',
-          },
-          spatialWindowSliderMode: {
-            A: 'A', B: 'B', C: 'C', D: 'D',
-          },
-          spatialTransparentColor: {
-            A: 'A', B: 'B', C: 'C', D: 'D',
-          },
-          spatialRenderingMode: {
-            A: 'A', B: 'B', C: 'C', D: 'D',
-          },
-          spatialImageVolumeRenderingMethod: {
-            A: 'A', B: 'B', C: 'C', D: 'D',
-          },
-          spatialImageChannel: {
-            A: ['A', 'B', 'C'],
-            B: ['D', 'E', 'F'],
-            C: ['G', 'H', 'I', 'J'],
-            D: ['K', 'L', 'M', 'N'],
-          },
-        },
-        spatialImageChannel: {
-          spatialTargetC: {
-            A: 'A', B: 'B', C: 'C',
-            D: 'D', E: 'E', F: 'F',
-            G: 'G', H: 'H', I: 'I', J: 'J',
-            K: 'K', L: 'L', M: 'M', N: 'N',
-          },
-          spatialChannelColor: {
-            A: 'A', B: 'B', C: 'C',
-            D: 'D', E: 'E', F: 'F',
-            G: 'G', H: 'H', I: 'I', J: 'J',
-            K: 'K', L: 'L', M: 'M', N: 'N',
-          },
-          spatialChannelColormap: {
-            A: 'A', B: 'A', C: 'A',
-            D: 'B', E: 'B', F: 'B',
-            G: 'C', H: 'C', I: 'C', J: 'C',
-            K: 'D', L: 'D', M: 'D', N: 'D',
-          },
-          spatialTargetZ: {
-            A: 'A', B: 'A', C: 'A',
-            D: 'B', E: 'B', F: 'B',
-            G: 'C', H: 'C', I: 'C', J: 'C',
-            K: 'D', L: 'D', M: 'D', N: 'D',
-          },
-          spatialTargetT: {
-            A: 'A', B: 'A', C: 'A',
-            D: 'B', E: 'B', F: 'B',
-            G: 'C', H: 'C', I: 'C', J: 'C',
-            K: 'D', L: 'D', M: 'D', N: 'D',
-          },
-          spatialChannelVisible: {
-            A: 'A', B: 'A', C: 'A',
-            D: 'B', E: 'B', F: 'B',
-            G: 'C', H: 'C', I: 'C', J: 'C',
-            K: 'D', L: 'D', M: 'D', N: 'D',
-          },
-          spatialChannelWindowRange: {
-            A: 'A', B: 'A', C: 'A',
-            D: 'B', E: 'B', F: 'B',
-            G: 'C', H: 'C', I: 'C', J: 'C',
-            K: 'D', L: 'D', M: 'D', N: 'D',
-          },
-        },
-      },
+    spatialPointLayer: {
+      A: null,
     },
   },
-  layout: [{
-    component: 'spatial',
-    coordinationScopes: {
-      dataset: 'A',
-      metaCoordinationScopes: ['A'],
-      metaCoordinationScopesBy: ['A'],
+  layout: [
+    {
+      component: 'spatial',
+      coordinationScopes: {
+        dataset: 'A',
+        spatialZoom: 'A',
+        spatialTargetX: 'A',
+        spatialTargetY: 'A',
+        spatialTargetZ: 'A',
+        spatialImageLayer: 'A',
+        spatialSegmentationLayer: 'A',
+        spatialPointLayer: 'A',
+      },
+      x: 0,
+      y: 0,
+      w: 9,
+      h: 12,
+      uid: 'A',
     },
-    x: 0,
-    y: 0,
-    w: 9,
-    h: 12,
-    uid: 'A',
-  }, {
-    component: 'layerController',
-    coordinationScopes: {
-      dataset: 'A',
-      metaCoordinationScopes: ['A'],
-      metaCoordinationScopesBy: ['A'],
+    {
+      component: 'layerController',
+      coordinationScopes: {
+        dataset: 'A',
+        spatialZoom: 'A',
+        spatialTargetX: 'A',
+        spatialTargetY: 'A',
+        spatialTargetZ: 'A',
+        spatialImageLayer: 'A',
+        spatialSegmentationLayer: 'A',
+        spatialPointLayer: 'A',
+      },
+      x: 9,
+      y: 0,
+      w: 3,
+      h: 12,
+      props: {
+        globalDisable3d: true,
+        disableChannelsIfRgbDetected: true,
+      },
+      uid: 'B',
     },
-    x: 9,
-    y: 0,
-    w: 3,
-    h: 12,
-    props: {
-      globalDisable3d: true,
-      disableChannelsIfRgbDetected: true,
-    },
-    uid: 'B',
-  }],
+  ],
   initStrategy: 'auto',
 };

--- a/packages/schemas/src/view-config-utils.test.fixtures.ts
+++ b/packages/schemas/src/view-config-utils.test.fixtures.ts
@@ -952,23 +952,8 @@ export const nestedSpatialLayers: z.infer<typeof configSchema1_0_16> = {
     dataset: {
       A: 'A',
     },
-    obsType: {
-      A: 'cell',
-    },
-    featureType: {
-      A: 'gene',
-    },
-    featureValueType: {
-      A: 'expression',
-    },
-    obsLabelsType: {
-      A: null,
-    },
     spatialZoom: {
       A: -4.4211074257069285,
-    },
-    spatialRotation: {
-      A: 0,
     },
     spatialTargetX: {
       A: 11092.812174766119,
@@ -978,57 +963,6 @@ export const nestedSpatialLayers: z.infer<typeof configSchema1_0_16> = {
     },
     spatialTargetZ: {
       A: null,
-    },
-    spatialRotationX: {
-      A: 0,
-    },
-    spatialRotationY: {
-      A: null,
-    },
-    spatialRotationZ: {
-      A: null,
-    },
-    spatialRotationOrbit: {
-      A: 0,
-    },
-    spatialOrbitAxis: {
-      A: null,
-    },
-    spatialAxisFixed: {
-      A: false,
-    },
-    obsFilter: {
-      A: null,
-    },
-    obsHighlight: {
-      A: null,
-    },
-    obsSetSelection: {
-      A: null,
-    },
-    obsSetHighlight: {
-      A: null,
-    },
-    obsSetColor: {
-      A: null,
-    },
-    featureHighlight: {
-      A: null,
-    },
-    featureSelection: {
-      A: null,
-    },
-    featureValueColormap: {
-      A: 'plasma',
-    },
-    featureValueColormapRange: {
-      A: [
-        0,
-        1,
-      ],
-    },
-    obsColorEncoding: {
-      A: 'cellSetSelection',
     },
     spatialImageLayer: {
       A: [
@@ -1378,52 +1312,19 @@ export const nestedSpatialLayers: z.infer<typeof configSchema1_0_16> = {
     spatialPointLayer: {
       A: null,
     },
-    spatialNeighborhoodLayer: {
-      A: null,
-    },
-    additionalObsSets: {
-      A: null,
-    },
-    moleculeHighlight: {
-      A: null,
-    },
   },
   layout: [
     {
       component: 'spatial',
       coordinationScopes: {
         dataset: 'A',
-        obsType: 'A',
-        featureType: 'A',
-        featureValueType: 'A',
-        obsLabelsType: 'A',
         spatialZoom: 'A',
-        spatialRotation: 'A',
         spatialTargetX: 'A',
         spatialTargetY: 'A',
         spatialTargetZ: 'A',
-        spatialRotationX: 'A',
-        spatialRotationY: 'A',
-        spatialRotationZ: 'A',
-        spatialRotationOrbit: 'A',
-        spatialOrbitAxis: 'A',
-        spatialAxisFixed: 'A',
-        obsFilter: 'A',
-        obsHighlight: 'A',
-        obsSetSelection: 'A',
-        obsSetHighlight: 'A',
-        obsSetColor: 'A',
-        featureHighlight: 'A',
-        featureSelection: 'A',
-        featureValueColormap: 'A',
-        featureValueColormapRange: 'A',
-        obsColorEncoding: 'A',
         spatialImageLayer: 'A',
         spatialSegmentationLayer: 'A',
         spatialPointLayer: 'A',
-        spatialNeighborhoodLayer: 'A',
-        additionalObsSets: 'A',
-        moleculeHighlight: 'A',
       },
       x: 0,
       y: 0,
@@ -1435,22 +1336,13 @@ export const nestedSpatialLayers: z.infer<typeof configSchema1_0_16> = {
       component: 'layerController',
       coordinationScopes: {
         dataset: 'A',
-        obsType: 'A',
-        featureType: 'A',
-        featureValueType: 'A',
         spatialZoom: 'A',
         spatialTargetX: 'A',
         spatialTargetY: 'A',
         spatialTargetZ: 'A',
-        spatialRotationX: 'A',
-        spatialRotationY: 'A',
-        spatialRotationZ: 'A',
-        spatialRotationOrbit: 'A',
-        spatialOrbitAxis: 'A',
         spatialImageLayer: 'A',
         spatialSegmentationLayer: 'A',
         spatialPointLayer: 'A',
-        spatialNeighborhoodLayer: 'A',
       },
       x: 9,
       y: 0,
@@ -1509,6 +1401,15 @@ export const multiLevelSpatialLayers: z.infer<typeof configSchema1_0_17> = {
   ],
   coordinationSpace: {
     dataset: { A: 'A' },
+    spatialZoom: {
+      A: -4.4211074257069285,
+    },
+    spatialTargetX: {
+      A: 11092.812174766119,
+    },
+    spatialTargetY: {
+      A: 15196.071341244067,
+    },
     spatialImageLayer: {
       A: '__dummy__', B: '__dummy__', C: '__dummy__', D: '__dummy__',
     },
@@ -1552,6 +1453,14 @@ export const multiLevelSpatialLayers: z.infer<typeof configSchema1_0_17> = {
       // eslint-disable-next-line object-property-newline
       K: 0, L: 1, M: 2, N: 3,
     },
+    spatialTargetZ: {
+      // Previously in spatialImageLayer[].channels[].selection.(z|Z|...):
+      A: 0, B: 1, C: 2, D: 0,
+    },
+    spatialTargetT: {
+      // Previously in spatialImageLayer[].channels[].selection.(t|T|temporal|...):
+      A: 0, B: 1, C: 2, D: 0,
+    },
     spatialChannelVisible: {
       // Previously in spatialImageLayer[].channels[].selection.(c|C|color|...):
       // eslint-disable-next-line object-property-newline
@@ -1593,10 +1502,10 @@ export const multiLevelSpatialLayers: z.infer<typeof configSchema1_0_17> = {
     },
     spatialWindowSliderMode: {
       // Previously in spatialImageLayer[].domainType:
-      A: 'extent', // Converted from 'Min/Max'
-      B: 'extent', // Converted from 'Min/Max'
-      C: 'extent', // Converted from 'Min/Max'
-      D: 'extent', // Converted from 'Min/Max'
+      A: 'Min/Max',
+      B: 'Min/Max',
+      C: 'Min/Max',
+      D: 'Min/Max',
     },
     spatialTransparentColor: {
       // Previously in spatialImageLayer[].transparentColor:
@@ -1604,6 +1513,20 @@ export const multiLevelSpatialLayers: z.infer<typeof configSchema1_0_17> = {
       B: [0, 0, 0],
       C: [0, 0, 0],
       D: [0, 0, 0],
+    },
+    spatialRenderingMode: {
+      // Previously in spatialImageLayer[].use3d:
+      A: '2D',
+      B: '2D',
+      C: '2D',
+      D: '2D',
+    },
+    spatialImageVolumeRenderingMethod: {
+      // Previously in spatialImageLayer[].renderingMode:
+      A: 'Additive',
+      B: 'Additive',
+      C: 'Additive',
+      D: 'Additive',
     },
     spatialChannelWindowRange: {
       // Previously in spatialImageLayer[].channels[].slider
@@ -1693,6 +1616,12 @@ export const multiLevelSpatialLayers: z.infer<typeof configSchema1_0_17> = {
           spatialTransparentColor: {
             A: 'A', B: 'B', C: 'C', D: 'D',
           },
+          spatialRenderingMode: {
+            A: 'A', B: 'B', C: 'C', D: 'D',
+          },
+          spatialImageVolumeRenderingMethod: {
+            A: 'A', B: 'B', C: 'C', D: 'D',
+          },
           spatialImageChannel: {
             A: ['A', 'B', 'C'],
             B: ['D', 'E', 'F'],
@@ -1714,6 +1643,18 @@ export const multiLevelSpatialLayers: z.infer<typeof configSchema1_0_17> = {
             K: 'K', L: 'L', M: 'M', N: 'N',
           },
           spatialChannelColormap: {
+            A: 'A', B: 'A', C: 'A',
+            D: 'B', E: 'B', F: 'B',
+            G: 'C', H: 'C', I: 'C', J: 'C',
+            K: 'D', L: 'D', M: 'D', N: 'D',
+          },
+          spatialTargetZ: {
+            A: 'A', B: 'A', C: 'A',
+            D: 'B', E: 'B', F: 'B',
+            G: 'C', H: 'C', I: 'C', J: 'C',
+            K: 'D', L: 'D', M: 'D', N: 'D',
+          },
+          spatialTargetT: {
             A: 'A', B: 'A', C: 'A',
             D: 'B', E: 'B', F: 'B',
             G: 'C', H: 'C', I: 'C', J: 'C',
@@ -1742,8 +1683,11 @@ export const multiLevelSpatialLayers: z.infer<typeof configSchema1_0_17> = {
       metaCoordinationScopes: ['A'],
       metaCoordinationScopesBy: ['A'],
     },
-    // eslint-disable-next-line object-property-newline
-    x: 0, y: 0, w: 1, h: 1,
+    x: 0,
+    y: 0,
+    w: 9,
+    h: 12,
+    uid: 'A',
   }, {
     component: 'layerController',
     coordinationScopes: {
@@ -1751,8 +1695,15 @@ export const multiLevelSpatialLayers: z.infer<typeof configSchema1_0_17> = {
       metaCoordinationScopes: ['A'],
       metaCoordinationScopesBy: ['A'],
     },
-    // eslint-disable-next-line object-property-newline
-    x: 0, y: 0, w: 1, h: 1,
+    x: 9,
+    y: 0,
+    w: 3,
+    h: 12,
+    props: {
+      globalDisable3d: true,
+      disableChannelsIfRgbDetected: true,
+    },
+    uid: 'B',
   }],
   initStrategy: 'auto',
 };

--- a/packages/schemas/src/view-config-utils.test.ts
+++ b/packages/schemas/src/view-config-utils.test.ts
@@ -19,6 +19,7 @@ import {
 import {
   upgradeAndParse,
 } from './view-config-versions';
+import { latestConfigSchema } from './previous-base-schemas';
 
 describe('src/app/view-config-utils.js', () => {
   describe('upgrade', () => {
@@ -40,7 +41,8 @@ describe('src/app/view-config-utils.js', () => {
     });
     it('upgrades more than once', () => {
       const latestConfig = upgradeAndParse(legacyViewConfig1_0_0);
-      expect(latestConfig.version).toEqual('1.0.16');
+      // eslint-disable-next-line no-underscore-dangle
+      expect(latestConfig.version).toEqual(latestConfigSchema.shape.version._def.value);
     });
   });
 });

--- a/packages/schemas/src/view-config-utils.test.ts
+++ b/packages/schemas/src/view-config-utils.test.ts
@@ -14,7 +14,7 @@ import {
   implicitPerDatasetCoordinations,
   explicitPerDatasetCoordinations,
   nestedSpatialLayers,
-  multiLevelSpatialLayers,
+  nestedSpatialLayersWithImageCoordinationValue,
 } from './view-config-utils.test.fixtures';
 import {
   upgradeAndParse,
@@ -36,7 +36,7 @@ describe('src/app/view-config-utils.js', () => {
     });
     it('upgrade view config from v1.0.16 to v1.0.17', () => {
       expect(upgradeFrom1_0_16(nestedSpatialLayers))
-        .toEqual(multiLevelSpatialLayers);
+        .toEqual(nestedSpatialLayersWithImageCoordinationValue);
     });
     it('upgrades more than once', () => {
       const latestConfig = upgradeAndParse(legacyViewConfig1_0_0);

--- a/packages/schemas/src/view-config-utils.test.ts
+++ b/packages/schemas/src/view-config-utils.test.ts
@@ -4,6 +4,7 @@ import {
   upgradeFrom0_1_0,
   upgradeFrom1_0_0,
   upgradeFrom1_0_15,
+  upgradeFrom1_0_16,
 } from './view-config-upgraders';
 import {
   legacyViewConfig0_1_0,
@@ -12,6 +13,8 @@ import {
   upgradedLegacyViewConfig1_0_0,
   implicitPerDatasetCoordinations,
   explicitPerDatasetCoordinations,
+  nestedSpatialLayers,
+  multiLevelSpatialLayers,
 } from './view-config-utils.test.fixtures';
 import {
   upgradeAndParse,
@@ -30,6 +33,10 @@ describe('src/app/view-config-utils.js', () => {
     it('upgrade view config from v1.0.9 to v1.0.16', () => {
       expect(upgradeFrom1_0_15(implicitPerDatasetCoordinations))
         .toEqual(explicitPerDatasetCoordinations);
+    });
+    it('upgrade view config from v1.0.16 to v1.0.17', () => {
+      expect(upgradeFrom1_0_16(nestedSpatialLayers))
+        .toEqual(multiLevelSpatialLayers);
     });
     it('upgrades more than once', () => {
       const latestConfig = upgradeAndParse(legacyViewConfig1_0_0);

--- a/packages/schemas/src/view-config-versions.ts
+++ b/packages/schemas/src/view-config-versions.ts
@@ -25,6 +25,7 @@ import {
   AnyVersionConfig,
   UpgradeFunction,
   latestConfigSchema,
+  configSchema1_0_16,
 } from './previous-base-schemas';
 import {
   upgradeFrom0_1_0,
@@ -44,6 +45,7 @@ import {
   upgradeFrom1_0_13,
   upgradeFrom1_0_14,
   upgradeFrom1_0_15,
+  upgradeFrom1_0_16,
 } from './view-config-upgraders';
 
 const SCHEMA_HANDLERS: [string, z.ZodTypeAny, UpgradeFunction][] = [
@@ -64,6 +66,7 @@ const SCHEMA_HANDLERS: [string, z.ZodTypeAny, UpgradeFunction][] = [
   ['1.0.13', configSchema1_0_13, upgradeFrom1_0_13],
   ['1.0.14', configSchema1_0_14, upgradeFrom1_0_14],
   ['1.0.15', configSchema1_0_15, upgradeFrom1_0_15],
+  ['1.0.16', configSchema1_0_16, upgradeFrom1_0_16],
 ];
 
 export const VERSIONED_CONFIG_SCHEMAS: Record<string, z.ZodTypeAny> = {

--- a/packages/utils/spatial-utils/src/spatial.js
+++ b/packages/utils/spatial-utils/src/spatial.js
@@ -254,6 +254,7 @@ export async function initializeRasterLayersAndChannels(
   rasterLayers,
   rasterRenderLayers,
   usePhysicalSizeScaling,
+  imageCoordinationValue,
 ) {
   const nextImageLoaders = [];
   let nextImageMetaAndLayers = [];
@@ -281,7 +282,7 @@ export async function initializeRasterLayersAndChannels(
       .then(channels => Promise.resolve({
         type: nextImageMetaAndLayers[layerIndex]?.metadata?.isBitmask ? 'bitmask' : 'raster',
         // TODO: switch to using `image` property instead of `index` property.
-        index: layerIndex,
+        image: imageCoordinationValue,
         ...DEFAULT_RASTER_LAYER_PROPS,
         channels: channels.map((channel, j) => ({
           ...channel,
@@ -304,7 +305,7 @@ export async function initializeRasterLayersAndChannels(
         .then(channels => Promise.resolve({
           type: nextImageMetaAndLayers[layerIndex]?.metadata?.isBitmask ? 'bitmask' : 'raster',
           // TODO: switch to using `image` property instead of `index` property.
-          index: layerIndex,
+          image: imageCoordinationValue,
           ...DEFAULT_RASTER_LAYER_PROPS,
           channels: channels.map((channel, j) => ({
             ...channel,

--- a/packages/utils/spatial-utils/src/spatial.js
+++ b/packages/utils/spatial-utils/src/spatial.js
@@ -280,6 +280,7 @@ export async function initializeRasterLayersAndChannels(
     const autoImageLayerDefPromise = initializeLayerChannels(loader)
       .then(channels => Promise.resolve({
         type: nextImageMetaAndLayers[layerIndex]?.metadata?.isBitmask ? 'bitmask' : 'raster',
+        // TODO: switch to using `image` property instead of `index` property.
         index: layerIndex,
         ...DEFAULT_RASTER_LAYER_PROPS,
         channels: channels.map((channel, j) => ({
@@ -302,6 +303,7 @@ export async function initializeRasterLayersAndChannels(
         // eslint-disable-next-line no-loop-func
         .then(channels => Promise.resolve({
           type: nextImageMetaAndLayers[layerIndex]?.metadata?.isBitmask ? 'bitmask' : 'raster',
+          // TODO: switch to using `image` property instead of `index` property.
           index: layerIndex,
           ...DEFAULT_RASTER_LAYER_PROPS,
           channels: channels.map((channel, j) => ({

--- a/packages/view-types/spatial/src/Spatial.js
+++ b/packages/view-types/spatial/src/Spatial.js
@@ -368,11 +368,13 @@ class Spatial extends AbstractSpatialOrScatterplot {
     // Reference: https://github.com/hms-dbmi/viv/blob/ad86d0f/src/layers/MultiscaleImageLayer/MultiscaleImageLayer.js#L127
     let selections;
     const nextLoaderSelection = layerDef.channels.map(c => c.selection);
+    // TODO: switch to using `image` property instead of `index` property.
     const prevLoaderSelection = this.layerLoaderSelections[layerDef.index];
     if (isEqual(prevLoaderSelection, nextLoaderSelection)) {
       selections = prevLoaderSelection;
     } else {
       selections = nextLoaderSelection;
+      // TODO: switch to using `image` property instead of `index` property.
       this.layerLoaderSelections[layerDef.index] = nextLoaderSelection;
     }
     const useTransparentColor = (!layerDef.visible
@@ -421,6 +423,7 @@ class Spatial extends AbstractSpatialOrScatterplot {
       return new viv.MultiscaleImageLayer({
         // `bitmask` is used by the AbstractSpatialOrScatterplot
         // https://github.com/vitessce/vitessce/pull/927/files#diff-9cab35a2ca0c5b6d9754b177810d25079a30ca91efa062d5795181360bc3ff2cR111
+        // TODO: switch to using `image` property instead of `index` property.
         id: `bitmask-layer-${layerDef.index}-${i}`,
         channelsVisible: layerProps.visibilities,
         opacity: layerProps.opacity,
@@ -459,6 +462,7 @@ class Spatial extends AbstractSpatialOrScatterplot {
     }
     return new Layer({
       loader: layerLoader,
+      // TODO: switch to using `image` property instead of `index` property.
       id: `${layerDef.use3d ? 'volume' : 'image'}-layer-${layerDef.index}-${i}`,
       colors: layerProps.colors,
       contrastLimits: layerProps.sliders,
@@ -501,6 +505,7 @@ class Spatial extends AbstractSpatialOrScatterplot {
       .filter(layer => (use3d ? layer.use3d === use3d : true))
       .map((layer, i) => this.createRasterLayer(
         { ...layer, callback: imageLayerCallbacks[use3d ? use3dIndex : i] },
+        // TODO: switch to using `image` property instead of `index` property.
         imageLayerLoaders[layer.index],
         i,
       ));
@@ -521,6 +526,7 @@ class Spatial extends AbstractSpatialOrScatterplot {
         .filter(layer => (use3d ? layer.use3d === use3d : true))
         .map((layer, i) => this.createRasterLayer(
           { ...layer, callback: segmentationLayerCallbacks[use3d ? use3dIndex : i] },
+          // TODO: switch to using `image` property instead of `index` property.
           loaders[layer.index],
           i,
         ));


### PR DESCRIPTION
<!-- Credit (as a starting template): https://github.com/visgl/deck.gl/blob/master/.github/pull_request_template.md -->
<!-- For feature, feature enhancement or bug fix, create an issue first and finish To Do List there -->
<!-- Anything doesn't work as expected is a bug, including code, doc and test -->
Fixes #
<!-- For other PRs without open issue -->
#### Background
<!-- For all the PRs -->
#### Change List
-

TODO:
- test with http://localhost:3000/?dataset=neumann-2020
- determine how initialization should happen
#### Checklist
 - [ ] Ensure PR works with all demos on the dev.vitessce.io homepage
 - [ ] Open (draft) PR's into [`vitessce-python`](https://github.com/vitessce/vitessce-python) and [`vitessce-r`](https://github.com/vitessce/vitessce-r) if this is a release PR
 - [ ] Documentation added or updated