### PR TITLE
Do not deep compare large arrays in BitmaskLayer props

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,7 @@
 - Removes logic for `tsconfig.json` from the meta-updater script
 - Update issue template.
 - Update documentation: fix broken links to source code, move Showcase to its own page from About page, replace Roadmap page with link to GitHub project.
+- Updated how TypedArrays are diff-ed in `BitmaskLayer` to reduce memory usage.
 
 
 ## [2.0.3](https://www.npmjs.com/package/vitessce/v/2.0.3) - 2023-02-01

--- a/packages/gl/src/BitmaskLayer.js
+++ b/packages/gl/src/BitmaskLayer.js
@@ -29,7 +29,7 @@ const defaultProps = {
   // Same as with cellColorData, we do not want to deep-compare expressionData,
   // so we set compare: false and provide a key to compare against.
   expressionData: { type: 'object', value: null, compare: false },
-  expressionDataKey: { type: 'string', value: null, compare: true },
+  expressionDataKey: { type: 'array', value: null, compare: true },
 };
 
 /**

--- a/packages/gl/src/BitmaskLayer.js
+++ b/packages/gl/src/BitmaskLayer.js
@@ -17,19 +17,20 @@ function padWithDefault(arr, defaultValue, padWidth) {
   return newArr;
 }
 
+function shallowCompare(newValue, oldValue) {
+  // Returns true if the two prop values should be considered equal.
+  // Reference: https://deck.gl/docs/developer-guide/custom-layers/prop-types#property-types-1
+  return newValue === oldValue;
+}
+
 const defaultProps = {
   hoveredCell: { type: 'number', value: null, compare: true },
   // We do not want to deep-compare cellColorData,
   // as it is potentially a TypedArray with millions of elements.
-  cellColorData: { type: 'object', value: null, compare: false },
-  // Instead, we can provide a corresponding key to compare against,
-  // in this case it is the array of selected cell sets.
-  cellColorDataKey: { type: 'array', value: null, compare: true },
+  cellColorData: { type: 'object', value: null, equal: shallowCompare },
   colormap: { type: 'string', value: GLSL_COLORMAP_DEFAULT, compare: true },
-  // Same as with cellColorData, we do not want to deep-compare expressionData,
-  // so we set compare: false and provide a key to compare against.
-  expressionData: { type: 'object', value: null, compare: false },
-  expressionDataKey: { type: 'array', value: null, compare: true },
+  // Same as with cellColorData, we do not want to deep-compare expressionData.
+  expressionData: { type: 'object', value: null, equal: shallowCompare },
 };
 
 /**
@@ -54,14 +55,14 @@ export default class BitmaskLayer extends XRLayer {
 
   updateState({ props, oldProps, changeFlags }) {
     super.updateState({ props, oldProps, changeFlags });
-    // Check the cellColorDataKey to determine whether
+    // Check the cellColorData to determine whether
     // to update the texture.
-    if (props.cellColorDataKey !== oldProps.cellColorDataKey) {
+    if (props.cellColorData !== oldProps.cellColorData) {
       this.setColorTexture();
     }
-    // Check the expressionDataKey to determine whether
+    // Check the expressionData to determine whether
     // to update the texture.
-    if (props.expressionDataKey !== oldProps.expressionDataKey) {
+    if (props.expressionData !== oldProps.expressionData) {
       const { expressionData, cellTexHeight, cellTexWidth } = this.props;
       const expressionTex = this.dataToTexture(
         expressionData,

--- a/packages/gl/src/BitmaskLayer.js
+++ b/packages/gl/src/BitmaskLayer.js
@@ -17,20 +17,17 @@ function padWithDefault(arr, defaultValue, padWidth) {
   return newArr;
 }
 
-function shallowCompare(newValue, oldValue) {
-  // Returns true if the two prop values should be considered equal.
-  // Reference: https://deck.gl/docs/developer-guide/custom-layers/prop-types#property-types-1
-  return newValue === oldValue;
-}
-
 const defaultProps = {
   hoveredCell: { type: 'number', value: null, compare: true },
   // We do not want to deep-compare cellColorData,
   // as it is potentially a TypedArray with millions of elements.
-  cellColorData: { type: 'object', value: null, equal: shallowCompare },
+  // For `compare`: "if a number is supplied, indicates the maximum depth to deep-compare,
+  // where 0 is shallow comparison and -1 is infinite depth. true is equivalent to 1."
+  // Reference: https://deck.gl/docs/developer-guide/custom-layers/prop-types#array
+  cellColorData: { type: 'object', value: null, compare: 0 },
   colormap: { type: 'string', value: GLSL_COLORMAP_DEFAULT, compare: true },
   // Same as with cellColorData, we do not want to deep-compare expressionData.
-  expressionData: { type: 'object', value: null, equal: shallowCompare },
+  expressionData: { type: 'object', value: null, compare: 0 },
 };
 
 /**

--- a/packages/gl/src/BitmaskLayer.js
+++ b/packages/gl/src/BitmaskLayer.js
@@ -19,9 +19,17 @@ function padWithDefault(arr, defaultValue, padWidth) {
 
 const defaultProps = {
   hoveredCell: { type: 'number', value: null, compare: true },
-  cellColorData: { type: 'object', value: null, compare: true },
+  // We do not want to deep-compare cellColorData,
+  // as it is potentially a TypedArray with millions of elements.
+  cellColorData: { type: 'object', value: null, compare: false },
+  // Instead, we can provide a corresponding key to compare against,
+  // in this case it is the array of selected cell sets.
+  cellColorDataKey: { type: 'array', value: null, compare: true },
   colormap: { type: 'string', value: GLSL_COLORMAP_DEFAULT, compare: true },
-  expressionData: { type: 'object', value: null, compare: true },
+  // Same as with cellColorData, we do not want to deep-compare expressionData,
+  // so we set compare: false and provide a key to compare against.
+  expressionData: { type: 'object', value: null, compare: false },
+  expressionDataKey: { type: 'string', value: null, compare: true },
 };
 
 /**
@@ -46,10 +54,14 @@ export default class BitmaskLayer extends XRLayer {
 
   updateState({ props, oldProps, changeFlags }) {
     super.updateState({ props, oldProps, changeFlags });
-    if (props.cellColorData !== oldProps.cellColorData) {
+    // Check the cellColorDataKey to determine whether
+    // to update the texture.
+    if (props.cellColorDataKey !== oldProps.cellColorDataKey) {
       this.setColorTexture();
     }
-    if (props.expressionData !== oldProps.expressionData) {
+    // Check the expressionDataKey to determine whether
+    // to update the texture.
+    if (props.expressionDataKey !== oldProps.expressionDataKey) {
       const { expressionData, cellTexHeight, cellTexWidth } = this.props;
       const expressionTex = this.dataToTexture(
         expressionData,

--- a/packages/utils/other-utils/src/interpolate-colors.js
+++ b/packages/utils/other-utils/src/interpolate-colors.js
@@ -77,35 +77,24 @@ export const interpolatePlasma = interpolateSequentialMulti(schemePlasma);
  * Get a mapping of cell IDs to cell colors based on
  * gene / cell set selection coordination state.
  * @param {object} params
- * @param {object} params.expressionMatrix { rows, cols, matrix }
- * @param {array} params.geneSelection Array of selected gene IDs.
- * @param {object} params.cellSets The cell sets tree.
- * @param {object} params.cellSetSelection Selected cell sets.
- * @param {string} params.cellColorEncoding Which to use for
- * coloring: gene expression or cell sets?
+ * @param {array[]} params.cellSetSelection Selected cell sets.
+ * @param {object[]} params.cellSetColor Array of cell set color
+ * objects, each containing a path and color [r, g, b].
+ * @param {string[]} params.obsIndex Array of cell IDs,
+ * in order to initialize all cells to the default color.
+ * @param {string} params.theme The current theme,
+ * in order to get the theme-based default color.
  * @returns {Map} Mapping from cell IDs to [r, g, b] color arrays.
  */
 export function getCellColors(params) {
   const {
-    cellColorEncoding,
-    expressionData,
-    cellSets, cellSetSelection,
+    cellSets,
+    cellSetSelection,
     cellSetColor,
     obsIndex,
     theme,
   } = params;
-  if (cellColorEncoding === 'geneSelection' && expressionData && obsIndex) {
-    // TODO: allow other color maps.
-    const geneExpColormap = interpolatePlasma;
-    const colors = new Map();
-    for (let i = 0; i < expressionData.length; i += 1) {
-      const value = expressionData[i];
-      const cellColor = geneExpColormap(value / 255);
-      colors.set(obsIndex[i], cellColor);
-    }
-    return colors;
-  }
-  if (cellColorEncoding === 'cellSetSelection' && cellSetSelection && cellSets) {
+  if (cellSetSelection && cellSets) {
     // Cell sets can potentially lack set colors since the color property
     // is not a required part of the schema.
     // The `initializeSets` function fills in any empty colors

--- a/packages/view-types/heatmap/src/HeatmapSubscriber.js
+++ b/packages/view-types/heatmap/src/HeatmapSubscriber.js
@@ -134,15 +134,12 @@ export function HeatmapSubscriber(props) {
   ), [cellSets, additionalCellSets]);
 
   const cellColors = useMemo(() => getCellColors({
-    // Only show cell set selection on heatmap labels.
-    cellColorEncoding: 'cellSetSelection',
-    geneSelection,
     cellSets: mergedCellSets,
     cellSetSelection,
     cellSetColor,
     obsIndex,
     theme,
-  }), [mergedCellSets, geneSelection, theme,
+  }), [mergedCellSets, theme,
     cellSetColor, cellSetSelection, obsIndex]);
 
   const getObsInfo = useGetObsInfo(

--- a/packages/view-types/scatterplot-embedding/src/EmbeddingScatterplotSubscriber.js
+++ b/packages/view-types/scatterplot-embedding/src/EmbeddingScatterplotSubscriber.js
@@ -174,16 +174,13 @@ export function EmbeddingScatterplotSubscriber(props) {
     setAdditionalCellSets, setCellSetColor, setCellSetSelection]);
 
   const cellColors = useMemo(() => getCellColors({
-    cellColorEncoding,
-    expressionData: expressionData && expressionData[0],
-    geneSelection,
     cellSets: mergedCellSets,
     cellSetSelection,
     cellSetColor,
     obsIndex: matrixObsIndex,
     theme,
-  }), [cellColorEncoding, geneSelection, mergedCellSets, theme,
-    cellSetSelection, cellSetColor, expressionData, matrixObsIndex]);
+  }), [mergedCellSets, theme,
+    cellSetSelection, cellSetColor, matrixObsIndex]);
 
   // cellSetPolygonCache is an array of tuples like [(key0, val0), (key1, val1), ...],
   // where the keys are cellSetSelection arrays.

--- a/packages/view-types/scatterplot-gating/src/GatingSubscriber.js
+++ b/packages/view-types/scatterplot-gating/src/GatingSubscriber.js
@@ -229,16 +229,13 @@ export function GatingSubscriber(props) {
     setAdditionalCellSets, setCellSetColor, setCellSetSelection]);
 
   const cellColors = useMemo(() => getCellColors({
-    cellColorEncoding,
-    expressionData: expressionDataColor && expressionDataColor[0],
-    geneSelection: gatingFeatureSelectionColor,
     cellSets: mergedCellSets,
     cellSetSelection,
     cellSetColor,
     obsIndex,
     theme,
-  }), [cellColorEncoding, gatingFeatureSelectionColor, mergedCellSets, theme,
-    cellSetSelection, cellSetColor, expressionDataColor, obsIndex]);
+  }), [mergedCellSets, theme,
+    cellSetSelection, cellSetColor, obsIndex]);
 
   // cellSetPolygonCache is an array of tuples like [(key0, val0), (key1, val1), ...],
   // where the keys are cellSetSelection arrays.

--- a/packages/view-types/scatterplot/src/Scatterplot.js
+++ b/packages/view-types/scatterplot/src/Scatterplot.js
@@ -343,6 +343,7 @@ class Scatterplot extends AbstractSpatialOrScatterplot {
       'obsEmbeddingIndex', 'obsEmbedding', 'cellFilter', 'cellSelection', 'cellColors',
       'cellRadius', 'cellOpacity', 'cellRadiusMode', 'geneExpressionColormap',
       'geneExpressionColormapRange', 'geneSelection', 'cellColorEncoding',
+      'getExpressionValue',
     ].some(shallowDiff)) {
       // Cells layer props changed.
       this.onUpdateCellsLayer();

--- a/packages/view-types/spatial/src/Spatial.js
+++ b/packages/view-types/spatial/src/Spatial.js
@@ -417,8 +417,6 @@ class Spatial extends AbstractSpatialOrScatterplot {
         geneExpressionColormap,
         geneExpressionColormapRange = [0.0, 1.0],
         cellColorEncoding,
-        cellColorDataKey,
-        expressionDataKey,
       } = this.props;
       return new viv.MultiscaleImageLayer({
         // `bitmask` is used by the AbstractSpatialOrScatterplot
@@ -436,7 +434,6 @@ class Spatial extends AbstractSpatialOrScatterplot {
         // has to do with the fact that we don't have it in the `defaultProps`,
         // could be wrong though.
         cellColorData: this.color.data,
-        cellColorDataKey,
         cellTexHeight: this.color.height,
         cellTexWidth: this.color.width,
         excludeBackground: true,
@@ -446,7 +443,6 @@ class Spatial extends AbstractSpatialOrScatterplot {
         isExpressionMode: cellColorEncoding === 'geneSelection',
         colormap: geneExpressionColormap,
         expressionData: this.expression.data,
-        expressionDataKey,
         // There is no onHover here,
         // see the onHover method of AbstractSpatialOrScatterplot.
       });
@@ -760,8 +756,6 @@ class Spatial extends AbstractSpatialOrScatterplot {
         'cellSelection',
         'geneExpressionColormapRange',
         'expressionData',
-        'expressionDataKey',
-        'cellColorDataKey',
         'cellColorEncoding',
         'geneExpressionColormap',
         'segmentationLayerCallbacks',

--- a/packages/view-types/spatial/src/Spatial.js
+++ b/packages/view-types/spatial/src/Spatial.js
@@ -417,6 +417,8 @@ class Spatial extends AbstractSpatialOrScatterplot {
         geneExpressionColormap,
         geneExpressionColormapRange = [0.0, 1.0],
         cellColorEncoding,
+        cellColorDataKey,
+        expressionDataKey,
       } = this.props;
       return new viv.MultiscaleImageLayer({
         // `bitmask` is used by the AbstractSpatialOrScatterplot
@@ -434,6 +436,7 @@ class Spatial extends AbstractSpatialOrScatterplot {
         // has to do with the fact that we don't have it in the `defaultProps`,
         // could be wrong though.
         cellColorData: this.color.data,
+        cellColorDataKey,
         cellTexHeight: this.color.height,
         cellTexWidth: this.color.width,
         excludeBackground: true,
@@ -443,6 +446,7 @@ class Spatial extends AbstractSpatialOrScatterplot {
         isExpressionMode: cellColorEncoding === 'geneSelection',
         colormap: geneExpressionColormap,
         expressionData: this.expression.data,
+        expressionDataKey,
         // There is no onHover here,
         // see the onHover method of AbstractSpatialOrScatterplot.
       });
@@ -754,8 +758,10 @@ class Spatial extends AbstractSpatialOrScatterplot {
         'hasSegmentations',
         'cellFilter',
         'cellSelection',
-        'cellColors',
         'geneExpressionColormapRange',
+        'expressionData',
+        'expressionDataKey',
+        'cellColorDataKey',
         'cellColorEncoding',
         'geneExpressionColormap',
         'segmentationLayerCallbacks',

--- a/packages/view-types/spatial/src/SpatialSubscriber.js
+++ b/packages/view-types/spatial/src/SpatialSubscriber.js
@@ -276,33 +276,13 @@ export function SpatialSubscriber(props) {
     setAdditionalCellSets, setCellSetColor, setCellSetSelection]);
 
   const cellColors = useMemo(() => getCellColors({
-    cellColorEncoding,
-    expressionData: expressionData && expressionData[0],
-    geneSelection,
     cellSets: mergedCellSets,
     cellSetSelection,
     cellSetColor,
     obsIndex: matrixObsIndex,
     theme,
-  }), [cellColorEncoding, geneSelection, mergedCellSets, theme,
-    cellSetColor, cellSetSelection, expressionData, matrixObsIndex]);
-
-  // The bitmask layer needs access to a array (i.e a texture) lookup of cell -> expression value
-  // where each cell id indexes into the array.
-  // Cell ids in `attrs.rows` do not necessaryily correspond to indices in that array, though,
-  // so we create a "shifted" array where this is the case.
-  const shiftedExpressionDataForBitmask = useMemo(() => {
-    if (matrixObsIndex && expressionData && obsSegmentationsType === 'bitmask') {
-      const maxId = matrixObsIndex.reduce((max, curr) => Math.max(max, Number(curr)));
-      const result = new Uint8Array(maxId + 1);
-      // eslint-disable-next-line no-plusplus
-      for (let i = 0; i < matrixObsIndex.length; i++) {
-        const id = matrixObsIndex[i];
-        result.set(expressionData[0].slice(i, i + 1), Number(id));
-      }
-      return [result];
-    } return [new Uint8Array()];
-  }, [matrixObsIndex, expressionData, obsSegmentationsType]);
+  }), [mergedCellSets, theme,
+    cellSetColor, cellSetSelection, matrixObsIndex]);
 
   const cellSelection = useMemo(() => Array.from(cellColors.keys()), [cellColors]);
 
@@ -335,6 +315,23 @@ export function SpatialSubscriber(props) {
   });
 
   const [uint8ExpressionData, expressionExtents] = useUint8FeatureSelection(expressionData);
+
+  // The bitmask layer needs access to a array (i.e a texture) lookup of cell -> expression value
+  // where each cell id indexes into the array.
+  // Cell ids in `attrs.rows` do not necessaryily correspond to indices in that array, though,
+  // so we create a "shifted" array where this is the case.
+  const shiftedExpressionDataForBitmask = useMemo(() => {
+    if (matrixObsIndex && uint8ExpressionData && obsSegmentationsType === 'bitmask') {
+      const maxId = matrixObsIndex.reduce((max, curr) => Math.max(max, Number(curr)));
+      const result = new Uint8Array(maxId + 1);
+      // eslint-disable-next-line no-plusplus
+      for (let i = 0; i < matrixObsIndex.length; i++) {
+        const id = matrixObsIndex[i];
+        result.set(uint8ExpressionData[0].slice(i, i + 1), Number(id));
+      }
+      return [result];
+    } return [new Uint8Array()];
+  }, [matrixObsIndex, uint8ExpressionData, obsSegmentationsType]);
 
   // Set up a getter function for gene expression values, to be used
   // by the DeckGL layer to obtain values for instanced attributes.
@@ -466,6 +463,8 @@ export function SpatialSubscriber(props) {
         cellColorEncoding={cellColorEncoding}
         getExpressionValue={getExpressionValue}
         theme={theme}
+        cellColorDataKey={cellSetSelection}
+        expressionDataKey={loadedFeatureSelection}
       />
       {!disableTooltip && (
         <SpatialTooltipSubscriber

--- a/packages/view-types/spatial/src/SpatialSubscriber.js
+++ b/packages/view-types/spatial/src/SpatialSubscriber.js
@@ -463,8 +463,6 @@ export function SpatialSubscriber(props) {
         cellColorEncoding={cellColorEncoding}
         getExpressionValue={getExpressionValue}
         theme={theme}
-        cellColorDataKey={cellSetSelection}
-        expressionDataKey={loadedFeatureSelection}
       />
       {!disableTooltip && (
         <SpatialTooltipSubscriber


### PR DESCRIPTION
<!-- Credit (as a starting template): https://github.com/visgl/deck.gl/blob/master/.github/pull_request_template.md -->
<!-- For feature, feature enhancement or bug fix, create an issue first and finish To Do List there -->
<!-- Anything doesn't work as expected is a bug, including code, doc and test -->
Fixes #1509 
<!-- For other PRs without open issue -->
#### Background

I closed a PR with a larger set of changes https://github.com/vitessce/vitessce/pull/1510 in favor of this one which seems to resolve the issue without the need to move logic to worker which got messy very fast.

<!-- For all the PRs -->
#### Change List
Use `compare: false` for `expressionData` and `cellColorData` props in `BitmaskLayer`. Instead, provide corresponding keys that can be compared rather than the arrays themselves.

Ideally, the arrays could just be compared shallowly (without the need for the key business), but it seems like the only options are `true`/`false`, though maybe i am missing something.

I also removed some outdated logic from the `getCellColors` function, as the mapping from expression values to colors does not use the `cellColors` `Map` variable anymore - that is performed on the GPU by using the colormap functions.

#### Checklist
 - [ ] Ensure PR works with all demos on the dev.vitessce.io homepage
 - [ ] Open (draft) PR's into [`vitessce-python`](https://github.com/vitessce/vitessce-python) and [`vitessce-r`](https://github.com/vitessce/vitessce-r) if this is a release PR
 - [ ] Documentation added or updated