### PR TITLE
Remove Showcase from About page

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -651,6 +651,7 @@
 - Use a random `uuid` when upgrading `v0.1.0` view configs to `v1.0.0` to enable the data hook `dataset` dependency to detect dataset updates resulting from passing new view configs.
 - Fixed bug in `Status` component in which `cellHighlight` and `geneHighlight` were incorrectly expected to be objects.
 - Fix `Spatial` initialization bug.
+- Remove Showcase section from `About` page now that we have a standalone Showcase documentation page.
 
 ## [0.2.5](https://www.npmjs.com/package/vitessce/v/0.2.5) - 2020-08-31
 

--- a/sites/docs/docs/about.md
+++ b/sites/docs/docs/about.md
@@ -6,18 +6,6 @@ slug: /about
 
 Vitessce is developed by the [Gehlenborg Lab](http://gehlenborglab.org/research/projects/vitessce/) at Harvard Medical School.
 
-## Showcase
-
-Vitessce is being used in the following projects:
-
-* [HuBMAP Data Portal](https://portal.hubmapconsortium.org/)
-* [BaysorAnalysis](https://github.com/kharchenkolab/BaysorAnalysis/tree/68f568d1c056708d474aeea3f28bbe083ccb6e4c#visualization-of-the-results)
-* [Azimuth](https://azimuth.hubmapconsortium.org/references/human_pbmc/)
-* [KPMP Kidney Tissue Atlas Spatial Viewer](https://atlas.kpmp.org/spatial-viewer/)
-* [cBioPortal](https://www.thehyve.nl/articles/single-cell-data-visualisation-in-cbioportal)
-* [scimap_phenotyping](https://github.com/ohsu-comp-bio/scimap_phenotyping/tree/2d0e63)
-* [Cellenics](https://github.com/hms-dbmi-cellenics/ui/blob/394a115/src/components/data-exploration/heatmap/HeatmapPlot.jsx#L30)
-
 ## Contributors
 
 <ul><li><a href="https://github.com/keller-mark">Mark Keller</a></li><li><a href="https://github.com/mccalluc">Chuck McCallum</a></li><li><a href="https://github.com/ilan-gold">Ilan Gold</a></li><li><a href="https://github.com/manzt">Trevor Manz</a></li><li><a href="https://github.com/thomaslchan">Tos Chan</a></li><li><a href="https://github.com/sehilyi">Sehi Lyi</a></li><li><a href="https://github.com/jkmarx">Jennifer Marx</a></li><li><a href="https://github.com/pkharchenko">Peter Kharchenko</a></li><li><a href="https://github.com/ngehlenborg">Nils Gehlenborg</a></li></ul>


### PR DESCRIPTION
In a previous PR, I moved the Showcase to a standalone page in the documentation but forgot to remove that section from the About page.

(Change that I originally made in https://github.com/vitessce/vitessce/pull/1519 but have reverted there to make an independent PR since it was unrelated)

#### Checklist
 - [ ] Ensure PR works with all demos on the dev.vitessce.io homepage
 - [ ] Open (draft) PR's into [`vitessce-python`](https://github.com/vitessce/vitessce-python) and [`vitessce-r`](https://github.com/vitessce/vitessce-r) if this is a release PR
 - [ ] Documentation added or updated