### PR TITLE
Fix cell set bugs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -51,6 +51,9 @@
 - Provide plugins as React props rather than registering them globally on `window`.
 - Use hooks in `ObsSetsManagerSubscriber` to improve controlled-component performance.
 - Revert change that removed `airbnb` eslint config.
+- Only set `additionalObsSets` in coordination space when upgrade was necessary to prevent infinite loop.
+- Fix bug causing cell set hierarchy created via `Create hierarchy` button to contain the string `undefined` (e.g., `My hierarchy 1undefined`)
+- Fix bug in `CellSetSizesPlotSubscriber` causing page to crash when no `obsSets` view is present (due to expectation of initialized `obsSetSelection` and `obsSetExpansion` coordination values).
 
 ## [2.0.3](https://www.npmjs.com/package/vitessce/v/2.0.3) - 2023-02-01
 

--- a/packages/file-types/json/src/json-loaders/ObsSetsJson.js
+++ b/packages/file-types/json/src/json-loaders/ObsSetsJson.js
@@ -22,7 +22,7 @@ export default class ObsSetsJsonLoader extends JsonLoader {
     }
     const { data: rawData, url } = payload;
     const datatype = this.fileType.endsWith('cell-sets.json') ? 'cell' : 'obs';
-    const upgradedData = tryUpgradeTreeToLatestSchema(rawData, datatype);
+    const [upgradedData] = tryUpgradeTreeToLatestSchema(rawData, datatype);
     let obsIndex = [];
     const coordinationValues = {
       obsSetSelection: [],

--- a/packages/utils/sets-utils/src/io.js
+++ b/packages/utils/sets-utils/src/io.js
@@ -21,14 +21,17 @@ import {
 // eslint-disable-next-line no-unused-vars
 export function tryUpgradeTreeToLatestSchema(currTree, datatype) {
   const zodSchema = HIERARCHICAL_SCHEMAS.schema;
+  const latestSchemaVersion = HIERARCHICAL_SCHEMAS.latestVersion;
   const parseResult = zodSchema.safeParse(currTree);
   const valid = parseResult.success;
   if (!valid) {
     const failureReason = JSON.stringify(parseResult.error.message, null, 2);
     throw new Error(`Tree validation failed: ${failureReason}`);
   }
-  // Zod will not only validate, but also will upgrade from v0.1.2 to v0.1.3.
-  return parseResult.data;
+  // Zod will not only validate, but also will upgrade from v0.1.2 to v0.1.3 via transform.
+  // We also want to return a boolean indicating whether the tree was upgraded.
+  const didUpgrade = (currTree.version !== latestSchemaVersion);
+  return [parseResult.data, didUpgrade];
 }
 
 /**
@@ -43,7 +46,7 @@ export function tryUpgradeTreeToLatestSchema(currTree, datatype) {
 export function handleImportJSON(result, datatype, theme) {
   let importData = JSON.parse(result);
   // Validate the imported file.
-  importData = tryUpgradeTreeToLatestSchema(importData, datatype);
+  [importData] = tryUpgradeTreeToLatestSchema(importData, datatype);
   return importData;
 }
 

--- a/packages/utils/sets-utils/src/io.js
+++ b/packages/utils/sets-utils/src/io.js
@@ -17,6 +17,8 @@ import {
  * @param {object} currTree A hierarchical tree object with a .version property,
  * which has already passed schema validation, but may not have the latest schema version.
  * @param {string} datatype The data type of the items in the schema.
+ * @returns {[object, boolean]} The upgraded tree object and a boolean indicating
+ * whether the tree was upgraded.
  */
 // eslint-disable-next-line no-unused-vars
 export function tryUpgradeTreeToLatestSchema(currTree, datatype) {

--- a/packages/utils/sets-utils/src/set-path-utils.js
+++ b/packages/utils/sets-utils/src/set-path-utils.js
@@ -25,28 +25,29 @@ function getPaths(node, currentPath = [], paths = []) {
  * @param {array} path An array of strings, representing a path.
  * @param {boolean} isSubset A boolean flag that indicates whether we are
  * looking for the longest subset (true) or the longest superset (false).
- * @returns The longest subset or superset of path in arrOfPaths.
+ * @returns {array} The longest subset or superset of path in arrOfPaths.
 */
 const findLongest = (arrOfPaths, path, isSubset) => {
-  let longest = null;
-  let longestLength = 0;
-
-  arrOfPaths.forEach((subArray) => {
-    const matchCount = subArray.filter((v, i) => v === path[i]).length;
-    if (
-      matchCount === (isSubset ? subArray.length : path.length)
-          && subArray.length > longestLength
-    ) {
-      longest = subArray;
-      longestLength = subArray.length;
+  if (Array.isArray(arrOfPaths)) {
+    let longest = null;
+    let longestLength = 0;
+    arrOfPaths.forEach((subArray) => {
+      const matchCount = subArray.filter((v, i) => v === path[i]).length;
+      if (
+        matchCount === (isSubset ? subArray.length : path.length)
+            && subArray.length > longestLength
+      ) {
+        longest = subArray;
+        longestLength = subArray.length;
+      }
+    });
+    if (longestLength > 0) {
+      return longest;
+    } if (isSubset) {
+      return [];
     }
-  });
-  if (longestLength > 0) {
-    return longest;
-  } if (isSubset) {
-    return [];
   }
-  return false;
+  return [];
 };
 
 /**
@@ -68,7 +69,7 @@ export function filterPathsByExpansionAndSelection(
   const paths = getPaths({ children: mergedCellSets.tree });
 
   // returns true if path is contained in allPaths, false otherwise
-  const contains = (allPaths, path) => allPaths.some(p => isEqual(p, path));
+  const contains = (allPaths, path) => allPaths?.some(p => isEqual(p, path));
 
   return paths.filter((clusterPath) => {
     // clusterPath is a parent of some selected cell set and is expanded. We should discard it.

--- a/packages/view-types/obs-sets-manager/src/ObsSetsManagerSubscriber.js
+++ b/packages/view-types/obs-sets-manager/src/ObsSetsManagerSubscriber.js
@@ -119,13 +119,18 @@ export function ObsSetsManagerSubscriber(props) {
   useEffect(() => {
     if (additionalCellSets) {
       let upgradedCellSets;
+      let didUpgrade;
       try {
-        upgradedCellSets = tryUpgradeTreeToLatestSchema(additionalCellSets, SETS_DATATYPE_OBS);
+        [upgradedCellSets, didUpgrade] = tryUpgradeTreeToLatestSchema(
+          additionalCellSets, SETS_DATATYPE_OBS,
+        );
       } catch (e) {
         setWarning(e.message);
         return;
       }
-      setAdditionalCellSets(upgradedCellSets);
+      if (didUpgrade) {
+        setAdditionalCellSets(upgradedCellSets);
+      }
     }
   }, [additionalCellSets, setAdditionalCellSets, setWarning]);
 
@@ -488,7 +493,7 @@ export function ObsSetsManagerSubscriber(props) {
 
   // The user wants to create a new level zero node.
   const onCreateLevelZeroNode = useCallback(() => {
-    const nextName = getNextNumberedNodeName(additionalCellSets?.tree, 'My hierarchy ');
+    const nextName = getNextNumberedNodeName(additionalCellSets?.tree, 'My hierarchy ', '');
     setAdditionalCellSets({
       ...(additionalCellSets || treeInitialize(SETS_DATATYPE_OBS)),
       tree: [

--- a/packages/view-types/statistical-plots/src/CellSetSizesPlotSubscriber.js
+++ b/packages/view-types/statistical-plots/src/CellSetSizesPlotSubscriber.js
@@ -77,33 +77,35 @@ export function CellSetSizesPlotSubscriber(props) {
   );
 
   const data = useMemo(() => {
-    let newHierarchy = currentHierarchy;
+    if (cellSetSelection && cellSetExpansion && cellSetColor && mergedCellSets && cellSets) {
+      let newHierarchy = currentHierarchy;
 
-    if (cellSetSelection) {
-      const changedHierarchy = findChangedHierarchy(prevCellSetSelection, cellSetSelection);
-      setPrevCellSetSelection(cellSetSelection);
+      if (cellSetSelection) {
+        const changedHierarchy = findChangedHierarchy(prevCellSetSelection, cellSetSelection);
+        setPrevCellSetSelection(cellSetSelection);
 
-      if (changedHierarchy) {
-        setCurrentHierarchy(changedHierarchy);
-        newHierarchy = changedHierarchy;
+        if (changedHierarchy) {
+          setCurrentHierarchy(changedHierarchy);
+          newHierarchy = changedHierarchy;
+        }
       }
-    }
 
-    const cellSetPaths = filterPathsByExpansionAndSelection(
-      mergedCellSets,
-      newHierarchy,
-      cellSetExpansion,
-      cellSetSelection,
-    );
-
-    if (mergedCellSets && cellSets && cellSetSelection && cellSetColor) {
-      return treeToSetSizesBySetNames(
+      const cellSetPaths = filterPathsByExpansionAndSelection(
         mergedCellSets,
-        cellSetPaths,
+        newHierarchy,
+        cellSetExpansion,
         cellSetSelection,
-        cellSetColor,
-        theme,
       );
+
+      if (mergedCellSets && cellSets && cellSetSelection && cellSetColor) {
+        return treeToSetSizesBySetNames(
+          mergedCellSets,
+          cellSetPaths,
+          cellSetSelection,
+          cellSetColor,
+          theme,
+        );
+      }
     }
     return [];
   }, [


### PR DESCRIPTION
<!-- Credit (as a starting template): https://github.com/visgl/deck.gl/blob/master/.github/pull_request_template.md -->
<!-- For feature, feature enhancement or bug fix, create an issue first and finish To Do List there -->
<!-- Anything doesn't work as expected is a bug, including code, doc and test -->
Fixes bug reported by @ivababukova  on [slack](https://hms-dbmi.slack.com/archives/GG50HSQ4E/p1685094853061079) plus two others
<!-- For other PRs without open issue -->
#### Background

<!-- For all the PRs -->
#### Change List
- Only set `additionalObsSets` in coordination space when upgrade was necessary to prevent infinite loop.
  - Introduced in https://github.com/vitessce/vitessce/pull/1529 / https://github.com/vitessce/vitessce/pull/1441
- Fix bug causing cell set hierarchy created via `Create hierarchy` button to contain the string `undefined` (e.g., `My hierarchy 1undefined`)
- Fix bug in `CellSetSizesPlotSubscriber` causing page to crash when no `obsSets` view is present (due to expectation of initialized `obsSetSelection` and `obsSetExpansion` coordination values).

#### Checklist
 - [ ] Ensure PR works with all demos on the dev.vitessce.io homepage
 - [ ] Open (draft) PR's into [`vitessce-python`](https://github.com/vitessce/vitessce-python) and [`vitessce-r`](https://github.com/vitessce/vitessce-r) if this is a release PR
 - [ ] Documentation added or updated