### PR TITLE
Fix heatmap click bug when featureLabels are used

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -55,6 +55,8 @@
 - Only set `additionalObsSets` in coordination space when upgrade was necessary to prevent infinite loop.
 - Fix bug causing cell set hierarchy created via `Create hierarchy` button to contain the string `undefined` (e.g., `My hierarchy 1undefined`)
 - Fix bug in `CellSetSizesPlotSubscriber` causing page to crash when no `obsSets` view is present (due to expectation of initialized `obsSetSelection` and `obsSetExpansion` coordination values).
+- Fix bug causing incorrect gene selection upon heatmap click when `featureLabels` are used (such as in the case of gene aliases used in the HuBMAP data portal view configs).
+
 
 ## [2.0.3](https://www.npmjs.com/package/vitessce/v/2.0.3) - 2023-02-01
 

--- a/packages/view-types/heatmap/src/Heatmap.js
+++ b/packages/view-types/heatmap/src/Heatmap.js
@@ -121,6 +121,7 @@ const Heatmap = forwardRef((props, deckRef) => {
     hideObservationLabels = false,
     hideVariableLabels = false,
     onHeatmapClick,
+    featureIndex,
   } = props;
 
   const viewState = {
@@ -762,7 +763,13 @@ const Heatmap = forwardRef((props, deckRef) => {
       : axisTopLabels[colI]);
 
     const obsId = expression.rows[obsI];
-    const varId = expression.cols[varI];
+
+    // We need to use featureIndex here,
+    // because expression.cols may be mapped to
+    // use featureLabels (if those were available in the dataset).
+    // Highlights and selections are assumed to be in terms of
+    // obsIndex/featureIndex (as opposed to obsLabels/featureLabels).
+    const varId = featureIndex[varI];
 
     if (setComponentHover) {
       setComponentHover();

--- a/packages/view-types/heatmap/src/HeatmapSubscriber.js
+++ b/packages/view-types/heatmap/src/HeatmapSubscriber.js
@@ -148,10 +148,11 @@ export function HeatmapSubscriber(props) {
 
   const getFeatureInfo = useCallback((featureId) => {
     if (featureId) {
-      return { [`${capitalize(variablesLabel)} ID`]: featureId };
+      const featureLabel = featureLabelsMap?.get(featureId) || featureId;
+      return { [`${capitalize(variablesLabel)} ID`]: featureLabel };
     }
     return null;
-  }, [variablesLabel]);
+  }, [variablesLabel, featureLabelsMap]);
 
   const expressionMatrix = useMemo(() => {
     if (obsIndex && featureIndex && uint8ObsFeatureMatrix) {
@@ -225,6 +226,7 @@ export function HeatmapSubscriber(props) {
         setIsRendering={setIsRendering}
         setCellHighlight={setCellHighlight}
         setGeneHighlight={setGeneHighlight}
+        featureIndex={featureIndex}
         setTrackHighlight={setTrackHighlight}
         setComponentHover={() => {
           setComponentHover(uuid);


### PR DESCRIPTION
Discovered while testing the release PR v3.0.0 with portal-ui

<!-- For other PRs without open issue -->
#### Background

Highlights and selections of obs/features are assumed to be in terms of obsIndex/featureIndex values. 

I did not catch this when reviewing the heatmap click implementation in #1479 but discovered while testing with portal configs like https://portal.hubmapconsortium.org/browse/dataset/6b5d4d3a6af69a3bb82c4768cd24396c.vitessce.json that if featureLabels were present, those were being used for the featureHighlight value, causing the incorrect gene to be selected.


<!-- For all the PRs -->
#### Change List
-
#### Checklist
 - [ ] Ensure PR works with all demos on the dev.vitessce.io homepage
 - [ ] Open (draft) PR's into [`vitessce-python`](https://github.com/vitessce/vitessce-python) and [`vitessce-r`](https://github.com/vitessce/vitessce-r) if this is a release PR
 - [ ] Documentation added or updated