### PR TITLE
Fix bug with originalViewState

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -75,6 +75,7 @@
 - Modified `HeatmapOptions`, `SpatialOptions` and `ScatterplotOptions` components - added a checkbox for making the tooltip not visible.
 - Added a `tooltipsVisible` to the coordination scope for `Heatmap`, `Spatial` and `Scatterplot` coordination types. Its default value is true. Modified the components to hide the tooltip if `tooltipVsisible` is false.
 - Removed `disableTooltip` from `props`.
+- Fix bug that may cause `originalViewState.target` to not be an array as expected.
 
 ## [2.0.3](https://www.npmjs.com/package/vitessce/v/2.0.3) - 2023-02-01
 

--- a/packages/view-types/scatterplot-embedding/src/EmbeddingScatterplotSubscriber.js
+++ b/packages/view-types/scatterplot-embedding/src/EmbeddingScatterplotSubscriber.js
@@ -160,7 +160,7 @@ export function EmbeddingScatterplotSubscriber(props) {
   const [dynamicCellRadius, setDynamicCellRadius] = useState(cellRadiusFixed);
   const [dynamicCellOpacity, setDynamicCellOpacity] = useState(cellOpacityFixed);
 
-  const [originalViewState, setOriginalViewState] = useState({});
+  const [originalViewState, setOriginalViewState] = useState(null);
 
   const mergedCellSets = useMemo(() => mergeObsSets(
     cellSets, additionalCellSets,
@@ -242,6 +242,8 @@ export function EmbeddingScatterplotSubscriber(props) {
       setDynamicCellOpacity(nextCellOpacityScale);
 
       if (typeof targetX !== 'number' || typeof targetY !== 'number') {
+        // The view config did not define an initial viewState so
+        // we calculate one based on the data and set it.
         const newTargetX = xExtent[0] + xRange / 2;
         const newTargetY = yExtent[0] + yRange / 2;
         const newZoom = Math.log2(Math.min(width / xRange, height / yRange));
@@ -250,6 +252,10 @@ export function EmbeddingScatterplotSubscriber(props) {
         setTargetY(-newTargetY);
         setZoom(newZoom);
         setOriginalViewState({ target: [newTargetX, -newTargetY, 0], zoom: newZoom });
+      } else if (!originalViewState) {
+        // originalViewState has not yet been set and
+        // the view config defined an initial viewState.
+        setOriginalViewState({ target: [targetX, -targetY, 0], zoom });
       }
     }
   // eslint-disable-next-line react-hooks/exhaustive-deps

--- a/packages/view-types/scatterplot-embedding/src/EmbeddingScatterplotSubscriber.js
+++ b/packages/view-types/scatterplot-embedding/src/EmbeddingScatterplotSubscriber.js
@@ -255,7 +255,7 @@ export function EmbeddingScatterplotSubscriber(props) {
       } else if (!originalViewState) {
         // originalViewState has not yet been set and
         // the view config defined an initial viewState.
-        setOriginalViewState({ target: [targetX, -targetY, 0], zoom });
+        setOriginalViewState({ target: [targetX, targetY, 0], zoom });
       }
     }
   // eslint-disable-next-line react-hooks/exhaustive-deps

--- a/packages/view-types/scatterplot/src/Scatterplot.js
+++ b/packages/view-types/scatterplot/src/Scatterplot.js
@@ -371,7 +371,9 @@ class Scatterplot extends AbstractSpatialOrScatterplot {
 
   recenter() {
     const { originalViewState, setViewState } = this.props;
-    setViewState(originalViewState);
+    if (Array.isArray(originalViewState?.target) && typeof originalViewState?.zoom === 'number') {
+      setViewState(originalViewState);
+    }
   }
 
   // render() is implemented in the abstract parent class.

--- a/packages/view-types/spatial/src/Spatial.js
+++ b/packages/view-types/spatial/src/Spatial.js
@@ -703,7 +703,9 @@ class Spatial extends AbstractSpatialOrScatterplot {
 
   recenter() {
     const { originalViewState, setViewState } = this.props;
-    setViewState(originalViewState);
+    if (Array.isArray(originalViewState?.target) && typeof originalViewState?.zoom === 'number') {
+      setViewState(originalViewState);
+    }
   }
 
   /**


### PR DESCRIPTION
<!-- For other PRs without open issue -->
#### Background

When testing https://github.com/vitessce/vitessce/pull/1542 with the `satija-2020` demo  I noticed that clicking the recenter button caused a crash - it seems like because the view config defines initial values for the embedding target and zoom, causing originalViewState to not be set as expected. 
<!-- For all the PRs -->
#### Change List
- Set originalViewState in all cases, including when it is not automatically computed
- Add extra checks in the recenter function
#### Checklist
 - [ ] Ensure PR works with all demos on the dev.vitessce.io homepage
 - [ ] Open (draft) PR's into [`vitessce-python`](https://github.com/vitessce/vitessce-python) and [`vitessce-r`](https://github.com/vitessce/vitessce-r) if this is a release PR
 - [ ] Documentation added or updated