### PR TITLE
(fix): equality check for `sizes`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -85,6 +85,7 @@
 - Adjusted the `onHeatmapClick` function in `HeatmapSubscriber.js` to distinguish between clicks on the heatmap and clicks on the cell set bar and take according actions.
 - Added a prop `sort` in `FeatureListSubscriber`, with default value equal to `alphabetical`.
 - Modified component `FeatureList` so that if sort is not equal to `alphabetical`, then sorting of data is skipped and the order of feature listis the same as original.
+- Fixed equality check when creating default model matrices for `sizes`
 
 ## [2.0.3](https://www.npmjs.com/package/vitessce/v/2.0.3) - 2023-02-01
 

--- a/packages/utils/spatial-utils/src/spatial.js
+++ b/packages/utils/spatial-utils/src/spatial.js
@@ -117,7 +117,8 @@ function getMetaWithTransformMatrices(imageMeta, imageLoaders) {
     }
     // Find the ratio of the sizes to get the scaling factor.
     const scale = sizes.map((i, k) => divide(i, minPhysicalSize[k]));
-    if (sizes[0] !== sizes[1]) {
+    // sizes are special objects with own equals method - see `unit` in declaration
+    if (!sizes[0].equals(sizes[1])) {
       // Handle scaling in the Y direction for non-square pixels
       scale[1] = divide(sizes[1], sizes[0]);
     }


### PR DESCRIPTION
#### Background
![image](https://github.com/vitessce/vitessce/assets/43999641/2ef65cf9-3356-4192-b891-a7f13dedad4c)
From #1484, the returned object from `unit` i.e., `sizes[0]` is a special `Units` object with its own equality method.  If we don't use this, we will always assume that height and width are different when they aren't.  We need to `equals` in order to actually compare the values: https://mathjs.org/docs/datatypes/units.html

#### Change List
- Use `equals` instead of `==` for comparing `Units`
#### Checklist
 - [ ] Ensure PR works with all demos on the dev.vitessce.io homepage
 - [ ] Open (draft) PR's into [`vitessce-python`](https://github.com/vitessce/vitessce-python) and [`vitessce-r`](https://github.com/vitessce/vitessce-r) if this is a release PR
 - [ ] Documentation added or updated