### PR TITLE
Show paths in current hierarchy when cellSetExpanded is not defined

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -87,6 +87,7 @@
 - Modified component `FeatureList` so that if sort is not equal to `alphabetical`, then sorting of data is skipped and the order of feature listis the same as original.
 - Fixed equality check when creating default model matrices for `sizes`
 - Split useEffect into useMemo + useEffect in SpatialSubscriber to fix infinite loop for `neumann-2020` demo on the docs site.
+- Fixed a bug in `CellSetSizesPlotSubscriber` plot causing rending of empty `CellSetSizesPlot` when there is no `obsSets` view (due to expectation of initialised `cellSetExpanded` coordination value).
 
 ## [2.0.3](https://www.npmjs.com/package/vitessce/v/2.0.3) - 2023-02-01
 

--- a/packages/utils/sets-utils/src/set-path-utils.js
+++ b/packages/utils/sets-utils/src/set-path-utils.js
@@ -93,7 +93,10 @@ export function filterPathsByExpansionAndSelection(
   const paths = getPaths({ children: mergedCellSets.tree });
 
   // returns true if path is contained in allPaths, false otherwise
-  const contains = (allPaths, path) => allPaths?.some(p => isEqual(p, path));
+  const contains = (allPaths, path) => {
+    if (allPaths === null) return false;
+    return allPaths?.some(p => isEqual(p, path));
+  };
 
   return paths.filter((clusterPath) => {
     // clusterPath is a parent of some selected cell set and is expanded. We should discard it.
@@ -108,13 +111,15 @@ export function filterPathsByExpansionAndSelection(
         return false;
       }
 
-      // the clusterPath is too deep in the tree. We should discard it.
-      if (cellSetExpansion.length === 0 && clusterPath.length > 2) return false;
+      if (cellSetExpansion) {
+        // the clusterPath is too deep in the tree. We should discard it.
+        if (cellSetExpansion.length === 0 && clusterPath.length > 2) return false;
 
-      const longestSubset = findLongestPath(cellSetExpansion, clusterPath, true);
-      // another case of the clusterPath being deep in the tree. We should discard it.
-      if (cellSetExpansion.length > 0 && longestSubset.length + 1 < clusterPath.length) {
-        return false;
+        const longestSubset = findLongestPath(cellSetExpansion, clusterPath, true);
+        // another case of the clusterPath being deep in the tree. We should discard it.
+        if (cellSetExpansion.length > 0 && longestSubset.length + 1 < clusterPath.length) {
+          return false;
+        }
       }
     }
     return clusterPath[0] === hierarchy[0];

--- a/packages/utils/sets-utils/src/set-path-utils.js
+++ b/packages/utils/sets-utils/src/set-path-utils.js
@@ -93,10 +93,7 @@ export function filterPathsByExpansionAndSelection(
   const paths = getPaths({ children: mergedCellSets.tree });
 
   // returns true if path is contained in allPaths, false otherwise
-  const contains = (allPaths, path) => {
-    if (allPaths === null) return false;
-    return allPaths?.some(p => isEqual(p, path));
-  };
+  const contains = (allPaths, path) => allPaths?.some(p => isEqual(p, path));
 
   return paths.filter((clusterPath) => {
     // clusterPath is a parent of some selected cell set and is expanded. We should discard it.

--- a/packages/utils/sets-utils/src/set-path-utils.test.js
+++ b/packages/utils/sets-utils/src/set-path-utils.test.js
@@ -230,4 +230,28 @@ describe('Tests for filterPathsByExpansionAndSelection', () => {
       ['Cell Type Annotations', 'Immune'],
     ]);
   });
+
+  it('Uses paths in cellSetSelection when cellSetExpansion is null', () => {
+    const hierarchy = ['Louvain Clustering'];
+    const cellSetExpansion = null;
+    const cellSetSelection = [
+      ['Louvain Clustering', 'Cluster 1'],
+      ['Louvain Clustering', 'Cluster 2'],
+      ['Louvain Clustering', 'Cluster 3'],
+      ['Louvain Clustering', 'Cluster 4'],
+    ];
+
+    const cellSetPaths = filterPathsByExpansionAndSelection(
+      tree,
+      hierarchy,
+      cellSetExpansion,
+      cellSetSelection,
+    );
+    expect(cellSetPaths).toEqual([
+      ['Louvain Clustering', 'Cluster 1'],
+      ['Louvain Clustering', 'Cluster 2'],
+      ['Louvain Clustering', 'Cluster 3'],
+      ['Louvain Clustering', 'Cluster 4'],
+    ]);
+  });
 });

--- a/packages/view-types/statistical-plots/src/CellSetSizesPlotSubscriber.js
+++ b/packages/view-types/statistical-plots/src/CellSetSizesPlotSubscriber.js
@@ -77,7 +77,7 @@ export function CellSetSizesPlotSubscriber(props) {
   );
 
   const data = useMemo(() => {
-    if (cellSetSelection && cellSetExpansion && cellSetColor && mergedCellSets && cellSets) {
+    if (cellSetSelection && cellSetColor && mergedCellSets && cellSets) {
       let newHierarchy = currentHierarchy;
 
       if (cellSetSelection) {


### PR DESCRIPTION
Fixes #1558 

#### Background
When there is no `obsSets` view, the `obsSetSizes` bar plot does not render anything anymore. This is because we compute the paths to show in the `CellSetSizesPlotSubscriber` only if `cellSetExpanded` is not null. `cellSetExpanded` is null when there is no `obsSets` view.

#### Change List
- Made `CellSetSizesPlotSubscriber` compute the bars to show even when `cellSetExpanded`.
- Changed the `filterPathsByExpansionAndSelection` function to not rely on `cellSetExpanded` always being defined.

TODOs:
- [x] Check what happens when other parameters of function `filterPathsByExpansionAndSelection` are null. See if we should handle this or not.
- [x] Remove random components from view config and check if the bar plot still works.

#### Checklist
 - [ ] Ensure PR works with all demos on the dev.vitessce.io homepage
 - [ ] Open (draft) PR's into [`vitessce-python`](https://github.com/vitessce/vitessce-python) and [`vitessce-r`](https://github.com/vitessce/vitessce-r) if this is a release PR
 - [ ] Documentation added or updated