### PR TITLE
Fix for safari bug resulting in bad scatterplot initialization

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -87,6 +87,7 @@
 - Modified component `FeatureList` so that if sort is not equal to `alphabetical`, then sorting of data is skipped and the order of feature listis the same as original.
 - Fixed equality check when creating default model matrices for `sizes`
 - Split useEffect into useMemo + useEffect in SpatialSubscriber to fix infinite loop for `neumann-2020` demo on the docs site.
+- Delay computing the initial view state longer in EmbeddingScatterplotSubscriber to ensure the view width/height is finished animating.
 
 ## [2.0.3](https://www.npmjs.com/package/vitessce/v/2.0.3) - 2023-02-01
 

--- a/packages/view-types/scatterplot-embedding/src/EmbeddingScatterplotSubscriber.js
+++ b/packages/view-types/scatterplot-embedding/src/EmbeddingScatterplotSubscriber.js
@@ -230,7 +230,14 @@ export function EmbeddingScatterplotSubscriber(props) {
   // compute the cell radius scale based on the
   // extents of the cell coordinates on the x/y axes.
   useEffect(() => {
-    if (xRange && yRange) {
+    // We do not really need isReady here, since the above useMemo that
+    // computes xRange and yRange will only run after obsEmbedding has loaded anyway.
+    // However, we include it here to ensure this effect waits as long as possible to run;
+    // For some reason, otherwise, in some cases this effect will run before the react-grid-layout
+    // initialization animation has finished,
+    // prior to `height` and `width` reaching their ultimate values, resulting in
+    // an initial viewState for that small view size, which looks bad.
+    if (xRange && yRange && isReady) {
       const pointSizeDevicePixels = getPointSizeDevicePixels(
         window.devicePixelRatio, zoom, xRange, yRange, width, height,
       );
@@ -259,7 +266,7 @@ export function EmbeddingScatterplotSubscriber(props) {
       }
     }
   // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [xRange, yRange, xExtent, yExtent, numCells,
+  }, [xRange, yRange, isReady, xExtent, yExtent, numCells,
     width, height, zoom, averageFillDensity]);
 
   const getObsInfo = useGetObsInfo(


### PR DESCRIPTION
<!-- Credit (as a starting template): https://github.com/visgl/deck.gl/blob/master/.github/pull_request_template.md -->
<!-- For feature, feature enhancement or bug fix, create an issue first and finish To Do List there -->
<!-- Anything doesn't work as expected is a bug, including code, doc and test -->
Fixes safari-related issue found during testing of #1548 

I could reproduce with the localhost demo, but not consistently. Slowing down my computer by opening in multiple safari windows seemed to help reproduce the bug.  I think it has to do with the react-grid-layout animation not being finished, resulting in the `width` and `height` used in the initialization calculation being too low because the views are still animating larger.

<!-- For other PRs without open issue -->
#### Background

I think this fixes the bug you found @ilan-gold - it is not an ideal way to fix it but more of a hack.

I think the ideal fix would be to implement a way to retrieve "initial" coordination values from the view config, possibly leveraging the new `config.uid` property for hinting about initialization vs. interactions. Then we could always re-compute things based on those initial values later more easily (e.g., when `width` and `height` change). I will add a new issue for that

<!-- For all the PRs -->
#### Change List
- Delay computing the initial view state longer in EmbeddingScatterplotSubscriber to ensure the view width/height is finished animating.
#### Checklist
 - [ ] Ensure PR works with all demos on the dev.vitessce.io homepage
 - [ ] Open (draft) PR's into [`vitessce-python`](https://github.com/vitessce/vitessce-python) and [`vitessce-r`](https://github.com/vitessce/vitessce-r) if this is a release PR
 - [ ] Documentation added or updated