### PR TITLE
Fix zustand store initialization and add hook for initial coordination values

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@
 - Added a dropdown in `FeatureList` that allows the user to:
   - select between `alphabetical` and `original` ordering for the feature list.
   - show two columns in the feature list if the feature has a second identifier associated.
+- Add `useInitialCoordination` hook to get the values of the coordination space from the initial config, which can be used for viewState reset buttons.
+- Use `config` object reference as hook dependency when no `config.uid` is present (to support both controlled and un-controlled component cases).
+- Initialize Zustand store using closure over `createViewConfigStore` function, rather than via `useEffect`.
 
 ### Changed
 - Fix Material UI import statement.

--- a/packages/view-types/scatterplot-embedding/src/EmbeddingScatterplotSubscriber.js
+++ b/packages/view-types/scatterplot-embedding/src/EmbeddingScatterplotSubscriber.js
@@ -21,6 +21,7 @@ import {
   useLoaders,
   useSetComponentHover,
   useSetComponentViewInfo,
+  useInitialCoordination,
 } from '@vitessce/vit-s';
 import { setObsSelection, mergeObsSets, getCellSetPolygons } from '@vitessce/sets-utils';
 import { getCellColors, commaNumber } from '@vitessce/utils';
@@ -111,6 +112,14 @@ export function EmbeddingScatterplotSubscriber(props) {
     setFeatureValueColormapRange: setGeneExpressionColormapRange,
     setTooltipsVisible,
   }] = useCoordination(COMPONENT_COORDINATION_TYPES[ViewType.SCATTERPLOT], coordinationScopes);
+
+  const {
+    embeddingZoom: initialZoom,
+    embeddingTargetX: initialTargetX,
+    embeddingTargetY: initialTargetY,
+  } = useInitialCoordination(
+    COMPONENT_COORDINATION_TYPES[ViewType.SCATTERPLOT], coordinationScopes,
+  );
 
   const observationsLabel = observationsLabelOverride || obsType;
 
@@ -230,44 +239,41 @@ export function EmbeddingScatterplotSubscriber(props) {
   // compute the cell radius scale based on the
   // extents of the cell coordinates on the x/y axes.
   useEffect(() => {
-    // We do not really need isReady here, since the above useMemo that
-    // computes xRange and yRange will only run after obsEmbedding has loaded anyway.
-    // However, we include it here to ensure this effect waits as long as possible to run;
-    // For some reason, otherwise, in some cases this effect will run before the react-grid-layout
-    // initialization animation has finished,
-    // prior to `height` and `width` reaching their ultimate values, resulting in
-    // an initial viewState for that small view size, which looks bad.
-    if (xRange && yRange && isReady) {
+    if (xRange && yRange) {
       const pointSizeDevicePixels = getPointSizeDevicePixels(
-        window.devicePixelRatio, zoom, xRange, yRange, width, height,
+        window.devicePixelRatio, initialZoom, xRange, yRange, width, height,
       );
       setDynamicCellRadius(pointSizeDevicePixels);
 
       const nextCellOpacityScale = getPointOpacity(
-        zoom, xRange, yRange, width, height, numCells, averageFillDensity,
+        initialZoom, xRange, yRange, width, height, numCells, averageFillDensity,
       );
       setDynamicCellOpacity(nextCellOpacityScale);
 
-      if (typeof targetX !== 'number' || typeof targetY !== 'number') {
+      if (typeof initialTargetX !== 'number' || typeof initialTargetY !== 'number') {
         // The view config did not define an initial viewState so
         // we calculate one based on the data and set it.
         const newTargetX = xExtent[0] + xRange / 2;
         const newTargetY = yExtent[0] + yRange / 2;
         const newZoom = Math.log2(Math.min(width / xRange, height / yRange));
-        setTargetX(newTargetX);
-        // Graphics rendering has the y-axis going south so we need to multiply by negative one.
-        setTargetY(-newTargetY);
-        setZoom(newZoom);
+        const notYetInitialized = (typeof targetX !== 'number' || typeof targetY !== 'number');
+        const stillDefaultInitialized = (targetX === newTargetX && targetY === -newTargetY);
+        if (notYetInitialized || stillDefaultInitialized) {
+          setTargetX(newTargetX);
+          // Graphics rendering has the y-axis going south so we need to multiply by negative one.
+          setTargetY(-newTargetY);
+          setZoom(newZoom);
+        }
         setOriginalViewState({ target: [newTargetX, -newTargetY, 0], zoom: newZoom });
       } else if (!originalViewState) {
         // originalViewState has not yet been set and
         // the view config defined an initial viewState.
-        setOriginalViewState({ target: [targetX, targetY, 0], zoom });
+        setOriginalViewState({ target: [initialTargetX, initialTargetY, 0], zoom: initialZoom });
       }
     }
   // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [xRange, yRange, isReady, xExtent, yExtent, numCells,
-    width, height, zoom, averageFillDensity]);
+  }, [xRange, yRange, xExtent, yExtent, numCells,
+    width, height, initialZoom, initialTargetX, initialTargetY, averageFillDensity]);
 
   const getObsInfo = useGetObsInfo(
     observationsLabel, obsLabelsTypes, obsLabelsData, obsSetsMembership,

--- a/packages/view-types/spatial/src/SpatialSubscriber.js
+++ b/packages/view-types/spatial/src/SpatialSubscriber.js
@@ -15,6 +15,7 @@ import {
   useUint8FeatureSelection,
   useExpressionValueGetter,
   useGetObsInfo,
+  useInitialCoordination,
   useCoordination,
   useLoaders,
   useSetComponentHover,
@@ -113,6 +114,15 @@ export function SpatialSubscriber(props) {
     setFeatureValueColormapRange: setGeneExpressionColormapRange,
     setTooltipsVisible,
   }] = useCoordination(COMPONENT_COORDINATION_TYPES[ViewType.SPATIAL], coordinationScopes);
+
+  const {
+    spatialZoom: initialZoom,
+    spatialTargetX: initialTargetX,
+    spatialTargetY: initialTargetY,
+    spatialTargetZ: initialTargetZ,
+  } = useInitialCoordination(
+    COMPONENT_COORDINATION_TYPES[ViewType.SPATIAL], coordinationScopes,
+  );
 
   const observationsLabel = observationsLabelOverride || obsType;
 
@@ -239,14 +249,13 @@ export function SpatialSubscriber(props) {
   const moleculesCount = obsLocationsFeatureIndex?.length || 0;
   const locationsCount = obsLocationsIndex?.length || 0;
 
-  const [originalViewState, setOriginalViewState] = useState(
-    { target: [targetX, targetY, targetZ], zoom },
-  );
+  const [originalViewState, setOriginalViewState] = useState(null);
 
   // Compute initial viewState values to use if targetX and targetY are not
   // defined in the initial configuration.
   const {
-    initialTargetX, initialTargetY, initialTargetZ, initialZoom,
+    initialTargetX: defaultTargetX, initialTargetY: defaultTargetY,
+    initialTargetZ: defaultTargetZ, initialZoom: defaultZoom,
   } = useMemo(() => getInitialSpatialTargets({
     width,
     height,
@@ -259,33 +268,41 @@ export function SpatialSubscriber(props) {
     use3d,
     modelMatrices: meta.map(({ metadata }) => metadata?.transform?.matrix),
   }),
-  // Deliberate dependency omissions: width/height - technically then
-  // these initial values will be "wrong" after resizing, but it shouldn't be far enough
-  // off to be noticeable.
   // Deliberate dependency omissions: imageLayerLoaders and meta - using `image` as
   // an indirect dependency instead.
   // eslint-disable-next-line react-hooks/exhaustive-deps
-  [image, use3d, hasImageData, obsCentroids, obsSegmentations, obsSegmentationsType]);
+  [image, use3d, hasImageData, obsCentroids, obsSegmentations, obsSegmentationsType,
+    width, height,
+  ]);
 
   useEffect(() => {
     // If it has not already been set, set the initial view state using
     // the auto-computed values from the useMemo above.
-    if (
-      (typeof targetX !== 'number' || typeof targetY !== 'number')
-    ) {
-      setTargetX(initialTargetX);
-      setTargetY(initialTargetY);
-      setTargetZ(initialTargetZ);
-      setZoom(initialZoom);
-      // Save these values to originalViewState so that we can reset to them later.
+    if (typeof initialTargetX !== 'number' || typeof initialTargetY !== 'number') {
+      const notYetInitialized = (typeof targetX !== 'number' || typeof targetY !== 'number');
+      const stillDefaultInitialized = (targetX === defaultTargetX && targetY === defaultTargetY);
+      if (notYetInitialized || stillDefaultInitialized) {
+        setTargetX(defaultTargetX);
+        setTargetY(defaultTargetY);
+        setTargetZ(defaultTargetZ);
+        setZoom(defaultZoom);
+      }
       setOriginalViewState(
-        { target: [initialTargetX, initialTargetY, initialTargetZ], zoom: initialZoom },
+        { target: [defaultTargetX, defaultTargetY, defaultTargetZ], zoom: defaultZoom },
       );
+    } else if (!originalViewState) {
+      // originalViewState has not yet been set and
+      // the view config defined an initial viewState.
+      setOriginalViewState({
+        target: [initialTargetX, initialTargetY, initialTargetZ], zoom: initialZoom,
+      });
     }
     // Deliberate dependency omissions: targetX, targetY
     // since we do not this to re-run on every single zoom/pan interaction.
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [initialTargetX, initialTargetY, initialTargetZ, initialZoom]);
+  }, [defaultTargetX, defaultTargetY, defaultTargetZ, defaultZoom,
+    initialTargetX, initialTargetY, initialTargetZ, initialZoom,
+  ]);
 
   const mergedCellSets = useMemo(() => mergeObsSets(
     cellSets, additionalCellSets,

--- a/packages/vit-s/src/VitessceGrid.js
+++ b/packages/vit-s/src/VitessceGrid.js
@@ -5,11 +5,8 @@ import React, {
 import clsx from 'clsx';
 import { VITESSCE_CONTAINER } from './classNames.js';
 import { VitessceGridLayout } from './vitessce-grid-layout/index.js';
-import { useRowHeight, createLoaders } from './vitessce-grid-utils.js';
+import { useRowHeight } from './vitessce-grid-utils.js';
 import {
-  useViewConfigStoreApi,
-  useSetViewConfig,
-  useSetLoaders,
   useEmitGridResize,
   useRemoveComponent,
   useChangeLayout,
@@ -33,8 +30,6 @@ const margin = 5;
  * @param {number} props.height Total height for grid. Optional.
  * @param {function} props.onWarn A callback for warning messages. Optional.
  * @param {PluginViewType[]} props.viewTypes
- * @param {PluginFileType[]} props.fileTypes
- * @param {PluginCoordinationType[]} props.coordinationTypes
  */
 export default function VitessceGrid(props) {
   const {
@@ -44,8 +39,6 @@ export default function VitessceGrid(props) {
     height,
     isBounded,
     viewTypes,
-    fileTypes,
-    coordinationTypes,
   } = props;
 
   const [rowHeight, containerRef] = useRowHeight(config, initialRowHeight, height, margin, padding);
@@ -61,9 +54,6 @@ export default function VitessceGrid(props) {
     onResize();
   }, [rowHeight, onResize]);
 
-  const viewConfigStoreApi = useViewConfigStoreApi();
-  const setViewConfig = useSetViewConfig(viewConfigStoreApi);
-  const setLoaders = useSetLoaders();
   const removeComponent = useRemoveComponent();
   const changeLayout = useChangeLayout();
   const layout = useLayout();
@@ -73,23 +63,6 @@ export default function VitessceGrid(props) {
       changeLayout(newComponentProps);
     }
   }, [changeLayout, componentWidth]);
-
-  // Update the view config and loaders in the global state.
-  useEffect(() => {
-    if (config) {
-      setViewConfig(config);
-      const loaders = createLoaders(
-        config.datasets,
-        config.description,
-        fileTypes,
-        coordinationTypes,
-      );
-      setLoaders(loaders);
-    } else {
-      // No config found, so clear the loaders.
-      setLoaders({});
-    }
-  }, [config, setViewConfig, setLoaders, fileTypes, coordinationTypes]);
 
   return (
     <div

--- a/packages/vit-s/src/index.js
+++ b/packages/vit-s/src/index.js
@@ -17,6 +17,7 @@ export {
   useGridItemSize,
 } from './hooks.js';
 export {
+  useInitialCoordination,
   useCoordination,
   useComplexCoordination,
   useMultiCoordinationValues,


### PR DESCRIPTION
Fixes #1486 
Fixes #1577 

Related to #1571 

<!-- For other PRs without open issue -->
#### Background
<!-- For all the PRs -->
#### Change List
- Add `useInitialCoordination` hook to get the values of the coordination space from the initial config, which can be used for viewState reset buttons.
- Use `config` object reference as hook dependency when no `config.uid` is present (to support both controlled and un-controlled component cases).
- Initialize Zustand store using closure over `createViewConfigStore` function, rather than via `useEffect`.
#### Checklist
 - [ ] Ensure PR works with all demos on the dev.vitessce.io homepage
 - [ ] Open (draft) PR's into [`vitessce-python`](https://github.com/vitessce/vitessce-python) and [`vitessce-r`](https://github.com/vitessce/vitessce-r) if this is a release PR
 - [ ] Documentation added or updated