### PR TITLE
#1608 Add handling to filter duplicate names from download options

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 ### Added
 
 ### Changed
+- Fix duplicate URLs appearing in download dropdown by filtering based on names.
 
 ## [3.0.1](https://www.npmjs.com/package/vitessce/v/3.0.1) - 2023-06-30
 

--- a/packages/vit-s/src/hooks.js
+++ b/packages/vit-s/src/hooks.js
@@ -150,7 +150,10 @@ export function useReady(statusValues) {
  */
 export function useUrls(urls) {
   const mergedUrls = useMemo(
-    () => urls.filter(a => Array.isArray(a)).flat(),
+    () => urls.filter(a => Array.isArray(a)).flat().filter((url, index, array) => {
+      const firstIndex = array.findIndex(u => u.name === url.name);
+      return index === firstIndex;
+    }),
     // eslint-disable-next-line react-hooks/exhaustive-deps
     urls,
   );


### PR DESCRIPTION
<!-- Credit (as a starting template): https://github.com/visgl/deck.gl/blob/master/.github/pull_request_template.md -->
<!-- For feature, feature enhancement or bug fix, create an issue first and finish To Do List there -->
<!-- Anything doesn't work as expected is a bug, including code, doc and test -->
Fixes #1608
<!-- For other PRs without open issue -->
#### Background
<!-- For all the PRs -->
The helpdesk received a ticket where a user was confused about duplicate download link entries were appearing for various datasets in HuBMAP:

![image](https://github.com/vitessce/vitessce/assets/19957804/451f9498-d80d-40e9-b6eb-f249b9cdca32)

I reproduced this in the vitessce demo site here:

http://vitessce.io/#?edit=false&url=https%3A%2F%2Fportal.hubmapconsortium.org%2Fbrowse%2Fdataset%2F69d9c52bc9edb625b496cecb623ec081.vitessce.json

![image](https://github.com/vitessce/vitessce/assets/19957804/3882ed21-64bb-4c25-9f94-1df56b421439)

I traced the calculation and confirmed this was happening due to two lists having the same entries. Due to objects not working with `SameValue` comparison, `Set` didn't work for deduplication, so I performed the comparison by making sure the index of each URL in the array matched the return of the `findIndex` for a URL with the same `name` parameter (which filters out any instances of URL's with the same name after the first).

After the fix/with the changes to URL's from release 3.0.1:

![image](https://github.com/vitessce/vitessce/assets/19957804/eeb94339-3a75-4049-9bea-491e3feed77b)


#### Change List
- Added another filter function to the flattened URL list to ensure only the first entry of a URL is added
#### Checklist
 - [x] Ensure PR works with all demos on the dev.vitessce.io homepage
 - [ ] Open (draft) PR's into [`vitessce-python`](https://github.com/vitessce/vitessce-python) and [`vitessce-r`](https://github.com/vitessce/vitessce-r) if this is a release PR
 - [ ] Documentation added or updated