### PR TITLE
Regenerate View Config store on `configKey` change

### DIFF
--- a/.changeset/few-actors-act.md
+++ b/.changeset/few-actors-act.md
@@ -1,0 +1,5 @@
+---
+"@vitessce/vit-s": minor
+---
+
+Regenerate View Config store on configKey change

--- a/packages/vit-s/src/VitS.js
+++ b/packages/vit-s/src/VitS.js
@@ -105,7 +105,7 @@ export function VitS(props) {
     jointFileTypes,
     coordinationTypes,
     viewTypes,
-  ), [viewTypes, fileTypes, jointFileTypes, coordinationTypes]);
+  ), [viewTypes, fileTypes, jointFileTypes, coordinationTypes, configKey]);
 
   // Process the view config and memoize the result:
   // - Validate.
@@ -202,7 +202,7 @@ export function VitS(props) {
     <StylesProvider generateClassName={generateClassName}>
       <ThemeProvider theme={muiTheme[theme]}>
         <QueryClientProvider client={queryClient}>
-          <ViewConfigProvider createStore={createViewConfigStoreClosure}>
+          <ViewConfigProvider key={configKey} createStore={createViewConfigStoreClosure}>
             <AuxiliaryProvider createStore={createAuxiliaryStore}>
               <VitessceGrid
                 success={success}

--- a/packages/vit-s/src/VitS.js
+++ b/packages/vit-s/src/VitS.js
@@ -105,7 +105,7 @@ export function VitS(props) {
     jointFileTypes,
     coordinationTypes,
     viewTypes,
-  ), [viewTypes, fileTypes, jointFileTypes, coordinationTypes, configKey]);
+  ), [viewTypes, fileTypes, jointFileTypes, coordinationTypes]);
 
   // Process the view config and memoize the result:
   // - Validate.


### PR DESCRIPTION
Fixes #1616 
#### Background
- There is an issue on the HuBMAP data portal where switching between different view configs for the visualization causes a black screen to be displayed
- After doing some digging, I found that the image layers were not being properly reinitialized when the config key/the callback used to generate the store changed; no image loading requests were taking place, and the Spatial layer display was `null`.
- In order to force the store to be recreated when the provided config is changed, the `configKey` can be provided to the `ViewConfigProvider` component as a `key`; when the `key` changes, [React unmounts and remounts the provider, which regenerates the store and ensures that](https://react.dev/learn/preserving-and-resetting-state#option-2-resetting-state-with-a-key) initialization is successful.
#### Change List
- Trigger full regeneration of the VIewConfig store when the provided ViewConfig is changed
#### Checklist
 - [x] Ensure PR works with all demos on the dev.vitessce.io homepage