### PR TITLE
NickAkhmetov/HMP-296 Stringify config object for use as configKey if no UID is present

### DIFF
--- a/.changeset/weak-numbers-agree.md
+++ b/.changeset/weak-numbers-agree.md
@@ -1,0 +1,5 @@
+---
+"@vitessce/vit-s": patch
+---
+
+Stringify passed config object to use as key when uid is missing

--- a/packages/vit-s/src/VitS.js
+++ b/packages/vit-s/src/VitS.js
@@ -98,7 +98,14 @@ export function VitS(props) {
   // If config.uid exists, then use it for hook dependencies to detect changes
   // (controlled component case). If not, then use the config object itself
   // and assume the un-controlled component case.
-  const configKey = config?.uid || config;
+  const configKey = useMemo(() => {
+    if (config?.uid) {
+      return config.uid;
+    }
+    // Stringify the config object so it can be used as a key
+    // Otherwise, the key will be [object Object]
+    return JSON.stringify(config);
+  }, [config]);
 
   const pluginSpecificConfigSchema = useMemo(() => buildConfigSchema(
     fileTypes,


### PR DESCRIPTION
#### Background

This PR builds on the change in #1617. 

When the `uid` is missing from the config, the config object itself is used as a configKey. This works as expected in most circumstances, but fails when using the `configKey` as a React element `key`. i.e. due to the config object's `.toString` being `[object Object]`, no change in the key is detected. Stringifying the config and using the resulting string as a key works as expected.

#### Change List
- Stringify passed config object to use as key when uid is missing
#### Checklist
 - [x] Ensure PR works with all demos on the dev.vitessce.io homepage
 - [ ] Open (draft) PR's into [`vitessce-python`](https://github.com/vitessce/vitessce-python) and [`vitessce-r`](https://github.com/vitessce/vitessce-r) if this is a release PR
 - [ ] Documentation added or updated