### PR TITLE
Accessibility fixes

### DIFF
--- a/packages/view-types/layer-controller/src/BitmaskChannelController.js
+++ b/packages/view-types/layer-controller/src/BitmaskChannelController.js
@@ -54,7 +54,7 @@ function BitmaskChannelController({
         <IconButton
           onClick={handleChannelRemove}
           style={{ padding: '6px 6px 6px 0px' }}
-          getAriaLabel={() => 'Remove channel'}
+          aria-label="Remove channel"
         >
           <RemoveCircleIcon />
         </IconButton>

--- a/packages/view-types/layer-controller/src/ChannelOptions.js
+++ b/packages/view-types/layer-controller/src/ChannelOptions.js
@@ -44,16 +44,16 @@ function ChannelOptions({ handlePropertyChange, handleChannelRemove, handleIQRUp
       setOpen={setOpen}
       buttonIcon={<MoreVertIcon fontSize="small" />}
       buttonClassName={classes.menuButton}
-      ariaLabel="Open channel options menu."
+      ariaLabel="Open channel options menu"
     >
-      <MenuItem dense disableGutters onClick={handleRemove} getAriaLabel={() => 'Click to remove channel'}>
+      <MenuItem dense disableGutters onClick={handleRemove} aria-label="Click to remove channel">
         <MuiSpan>Remove</MuiSpan>
       </MenuItem>
       <MenuItem
         dense
         disableGutters
         onClick={handleIQRUpdate}
-        getAriaLabel={() => 'Click to use IQR for channel'}
+        aria-label="Click to use IQR for channel"
       >
         <MuiSpan>Use IQR</MuiSpan>
       </MenuItem>
@@ -61,7 +61,7 @@ function ChannelOptions({ handlePropertyChange, handleChannelRemove, handleIQRUp
         dense
         disableGutters
         className={classes.colors}
-        getAriaLabel={() => 'Click to select color for channel'}
+        aria-label="Click to select color for channel"
       >
         <ColorPalette handleChange={handleColorSelect} />
       </MenuItem>

--- a/packages/view-types/layer-controller/src/ChannelOptions.js
+++ b/packages/view-types/layer-controller/src/ChannelOptions.js
@@ -44,7 +44,7 @@ function ChannelOptions({ handlePropertyChange, handleChannelRemove, handleIQRUp
       setOpen={setOpen}
       buttonIcon={<MoreVertIcon fontSize="small" />}
       buttonClassName={classes.menuButton}
-      ariaLabel="Open channel options menu"
+      aria-label="Open channel options menu"
     >
       <MenuItem dense disableGutters onClick={handleRemove} aria-label="Click to remove channel">
         <MuiSpan>Remove</MuiSpan>

--- a/packages/view-types/layer-controller/src/ColorPalette.js
+++ b/packages/view-types/layer-controller/src/ColorPalette.js
@@ -33,7 +33,7 @@ const ColorPalette = ({ handleChange }) => {
           className={classes.button}
           key={color}
           onClick={() => handleChange(color)}
-          getAriaLabel={() => `Change color to ${color}`}
+          aria-label={`Change color to ${color}`}
         >
           <LensIcon
             fontSize="small"

--- a/packages/view-types/layer-controller/src/LayerController.js
+++ b/packages/view-types/layer-controller/src/LayerController.js
@@ -493,7 +493,7 @@ export default function LayerController(props) {
         <Grid container direction="column" m={1} justifyContent="center">
           <Grid item classes={{ item: overflowEllipsisGridClasses.item }}>
             <Button
-              getAriaLabel={() => 'Toggle layer visibility'}
+              aria-label="Toggle layer visibility"
               onClick={(e) => {
                 if (!disabled) {
                   // Needed to prevent affecting the expansion panel from changing
@@ -534,7 +534,7 @@ export default function LayerController(props) {
                   value={opacity}
                   onChange={(e, v) => setOpacity(v)}
                   valueLabelDisplay="auto"
-                  getAriaLabel={() => `Adjust opacity for layer ${name}`}
+                  aria-label={`Adjust opacity for layer ${name}`}
                   min={0}
                   max={1}
                   step={0.01}
@@ -554,12 +554,12 @@ export default function LayerController(props) {
             <Tabs
               value={tab}
               onChange={handleTabChange}
-              getAriaLabel={() => 'Change the layer tab type'}
+              aria-label="Change the layer tab type"
               style={{ height: '24px', minHeight: '24px' }}
             >
               <Tab
                 label="Channels"
-                getAriaLabel={() => 'Channels tab'}
+                aria-label="Channels tab"
                 style={{
                   fontSize: '.75rem',
                   bottom: 12,
@@ -570,7 +570,7 @@ export default function LayerController(props) {
               />
               <Tab
                 label="Volume"
-                getAriaLabel={() => 'Volume tab'}
+                aria-label="Volume tab"
                 style={{
                   fontSize: '.75rem',
                   bottom: 12,

--- a/packages/view-types/layer-controller/src/LayerOptions.js
+++ b/packages/view-types/layer-controller/src/LayerOptions.js
@@ -126,7 +126,7 @@ function VolumeDropdown({
           e.target.value === '2D' ? e.target.value : Number(e.target.value),
         )
         }
-        getAriaLabel={() => 'Resolution selector'}
+        inputProps={{ 'aria-label': 'Resolution selector'}}
         classes={{ root: classes.selectRoot }}
       >
         <option key="2D" value="2D">
@@ -181,10 +181,9 @@ function ColormapSelect({ value, inputId, handleChange }) {
       native
       onChange={e => handleChange(e.target.value === '' ? null : e.target.value)}
       value={value}
-      inputProps={{ name: 'colormap', id: inputId }}
+      inputProps={{ name: 'colormap', id: inputId, 'aria-label': 'Colormap selector' }}
       style={{ width: '100%' }}
       classes={{ root: classes.selectRoot }}
-      getAriaLabel={() => 'Colormap selector'}
     >
       <option aria-label="None" value="">None</option>
       {COLORMAP_OPTIONS.map(name => (
@@ -228,7 +227,7 @@ function OpacitySlider({ value, handleChange }) {
       value={value}
       onChange={(e, v) => handleChange(v)}
       valueLabelDisplay="auto"
-      getAriaLabel={() => 'Layer opacity slider'}
+      aria-label="Layer opacity slider"
       min={0}
       max={1}
       step={0.01}
@@ -250,10 +249,9 @@ function SliderDomainSelector({ value, inputId, handleChange }) {
       native
       onChange={e => handleChange(e.target.value)}
       value={value}
-      inputProps={{ name: 'domain-selector', id: inputId }}
+      inputProps={{ name: 'domain-selector', id: inputId, 'aria-label': 'Domain type selector' }}
       style={{ width: '100%' }}
       classes={{ root: classes.selectRoot }}
-      getAriaLabel={() => 'Domain type selector'}
     >
       {DOMAIN_OPTIONS.map(name => (
         <option key={name} value={name}>
@@ -295,7 +293,7 @@ function GlobalSelectionSlider({
         }
       }
       valueLabelDisplay="auto"
-      getAriaLabel={() => `${field} slider`}
+      aria-label={`${field} slider`}
       marks={possibleValues.map(val => ({ value: val }))}
       min={Number(possibleValues[0])}
       max={Number(possibleValues.slice(-1))}

--- a/packages/view-types/layer-controller/src/LayerOptions.js
+++ b/packages/view-types/layer-controller/src/LayerOptions.js
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useId } from 'react';
 import { range } from 'lodash-es';
 import { Matrix4 } from 'math.gl';
 import { Grid, Slider, InputLabel, Select, Checkbox } from '@material-ui/core';
@@ -195,7 +195,7 @@ function ColormapSelect({ value, inputId, handleChange }) {
   );
 }
 
-function TransparentColorCheckbox({ value, handleChange }) {
+function TransparentColorCheckbox({ value, inputId, handleChange }) {
   return (
     <Checkbox
       style={{ float: 'left', padding: 0 }}
@@ -208,6 +208,7 @@ function TransparentColorCheckbox({ value, handleChange }) {
         }
       }}
       checked={Boolean(value)}
+      id={inputId}
       inputProps={{ 'aria-label': 'Enable or disable color transparency' }}
     />
   );
@@ -218,7 +219,7 @@ function TransparentColorCheckbox({ value, handleChange }) {
  * @prop {string} value Currently selected value between 0 and 1.
  * @prop {function} handleChange Callback for every change in opacity.
  */
-function OpacitySlider({ value, handleChange }) {
+function OpacitySlider({ value, inputId, handleChange }) {
   const classes = useChannelSliderStyles();
 
   return (
@@ -228,6 +229,7 @@ function OpacitySlider({ value, handleChange }) {
       onChange={(e, v) => handleChange(v)}
       valueLabelDisplay="auto"
       aria-label="Layer opacity slider"
+      id={inputId}
       min={0}
       max={1}
       step={0.01}
@@ -249,7 +251,8 @@ function SliderDomainSelector({ value, inputId, handleChange }) {
       native
       onChange={e => handleChange(e.target.value)}
       value={value}
-      inputProps={{ name: 'domain-selector', id: inputId, 'aria-label': 'Domain type selector' }}
+      id={inputId}
+      inputProps={{ name: 'domain-selector', 'aria-label': 'Domain type selector' }}
       style={{ width: '100%' }}
       classes={{ root: classes.selectRoot }}
     >
@@ -272,6 +275,7 @@ function SliderDomainSelector({ value, inputId, handleChange }) {
 function GlobalSelectionSlider({
   field,
   value,
+  inputId,
   handleChange,
   possibleValues,
 }) {
@@ -294,6 +298,7 @@ function GlobalSelectionSlider({
       }
       valueLabelDisplay="auto"
       aria-label={`${field} slider`}
+      id={inputId}
       marks={possibleValues.map(val => ({ value: val }))}
       min={Number(possibleValues[0])}
       max={Number(possibleValues.slice(-1))}
@@ -374,6 +379,12 @@ function LayerOptions({
   const hasViewableResolutions = Boolean(Array.from({
     length: loader.data.length,
   }).filter((_, res) => canLoadResolution(loader.data, res)).length);
+
+  const globalSelectionSliderId = useId();
+  const colormapSelectId = useId();
+  const domainSelectorId = useId();
+  const opacitySliderId = useId();
+  const zeroTransparentId = useId();
   return (
     <Grid container direction="column" style={{ width: '100%' }}>
       {hasZStack
@@ -402,9 +413,10 @@ function LayerOptions({
         && !use3d
         && globalControlLabels.map(
           field => shape[labels.indexOf(field)] > 1 && (
-          <LayerOption name={field} inputId={`${field}-slider`} key={field}>
+          <LayerOption name={field} inputId={`${field}-${globalSelectionSliderId}`} key={field}>
             <GlobalSelectionSlider
               field={field}
+              inputId={`${field}-${globalSelectionSliderId}`}
               value={globalLabelValues[field]}
               handleChange={handleGlobalChannelsSelectionChange}
               possibleValues={range(shape[labels.indexOf(field)])}
@@ -416,10 +428,10 @@ function LayerOptions({
         <>
           {shouldShowColormap && (
             <Grid item>
-              <LayerOption name="Colormap" inputId="colormap-select">
+              <LayerOption name="Colormap" inputId={colormapSelectId}>
                 <ColormapSelect
                   value={colormap || ''}
-                  inputId="colormap-select"
+                  inputId={colormapSelectId}
                   handleChange={handleColormapChange}
                 />
               </LayerOption>
@@ -427,9 +439,10 @@ function LayerOptions({
           )}
           {shouldShowDomain && (
             <Grid item>
-              <LayerOption name="Domain" inputId="domain-selector">
+              <LayerOption name="Domain" inputId={domainSelectorId}>
                 <SliderDomainSelector
                   value={domainType || DEFAULT_RASTER_DOMAIN_TYPE}
+                  inputId={domainSelectorId}
                   handleChange={(value) => {
                     handleDomainChange(value);
                   }}
@@ -441,8 +454,12 @@ function LayerOptions({
       ) : null}
       {!use3d && (
         <Grid item>
-          <LayerOption name="Opacity" inputId="opacity-slider">
-            <OpacitySlider value={opacity} handleChange={handleOpacityChange} />
+          <LayerOption name="Opacity" inputId={opacitySliderId}>
+            <OpacitySlider
+              value={opacity}
+              handleChange={handleOpacityChange}
+              inputId={opacitySliderId}
+            />
           </LayerOption>
         </Grid>
       )}
@@ -450,11 +467,12 @@ function LayerOptions({
         <Grid item>
           <LayerOption
             name="Zero Transparent"
-            inputId="transparent-color-selector"
+            inputId={zeroTransparentId}
           >
             <TransparentColorCheckbox
               value={transparentColor}
               handleChange={handleTransparentColorChange}
+              inputId={zeroTransparentId}
             />
           </LayerOption>
         </Grid>

--- a/packages/view-types/layer-controller/src/LayerOptions.js
+++ b/packages/view-types/layer-controller/src/LayerOptions.js
@@ -126,7 +126,7 @@ function VolumeDropdown({
           e.target.value === '2D' ? e.target.value : Number(e.target.value),
         )
         }
-        inputProps={{ 'aria-label': 'Resolution selector'}}
+        inputProps={{ 'aria-label': 'Resolution selector' }}
         classes={{ root: classes.selectRoot }}
       >
         <option key="2D" value="2D">

--- a/packages/view-types/layer-controller/src/RasterChannelController.js
+++ b/packages/view-types/layer-controller/src/RasterChannelController.js
@@ -79,7 +79,7 @@ function ChannelSlider({
       valueLabelDisplay="auto"
       getAriaLabel={(index) => {
         const labelPrefix = index === 0 ? 'Low value slider' : 'High value slider';
-        return `${labelPrefix} for ${color} colormap channel.`;
+        return `${labelPrefix} for ${color} colormap channel`;
       }}
       getAriaValueText={() => `Current colormap values: ${color}-${slider}`}
       min={min}

--- a/packages/view-types/layer-controller/src/VolumeOptions.js
+++ b/packages/view-types/layer-controller/src/VolumeOptions.js
@@ -88,7 +88,7 @@ const Slicer = ({
             onChange={(e, v) => setVal(v)}
             valueLabelDisplay="auto"
             valueLabelFormat={v => abbreviateNumber(v)}
-            getAriaLabel={() => `Volume options ${label} slider`}
+            aria-label={`Volume options ${label} slider`}
             min={min}
             max={max}
             step={0.005}
@@ -132,10 +132,10 @@ function RenderingModeSelect({
         inputProps={{
           name: 'rendering-mode',
           id: 'rendering-mode-select',
+          'aria-label': 'Select rendering mode option',
         }}
         disabled={!use3d}
         classes={{ root: classes.selectRoot }}
-        getAriaLabel={() => 'Select rendering mode option'}
       >
         {options.map(name => (
           <option key={name} value={name}>

--- a/packages/view-types/layer-controller/src/shared-channel-controls.js
+++ b/packages/view-types/layer-controller/src/shared-channel-controls.js
@@ -23,7 +23,7 @@ export function ChannelSelectionDropdown({
       native
       value={selectionIndex}
       onChange={e => handleChange(Number(e.target.value))}
-      getAriaLabel={() => 'Select a channel'}
+      inputProps={{ 'aria-label': 'Select a channel' }}
     >
       {channelOptions.map((opt, i) => (
         <option disabled={disabled} key={opt} value={i}>

--- a/packages/view-types/scatterplot/src/ScatterplotOptions.js
+++ b/packages/view-types/scatterplot/src/ScatterplotOptions.js
@@ -156,7 +156,7 @@ export default function ScatterplotOptions(props) {
             disabled={!cellSetLabelsVisible}
             value={cellSetLabelSize}
             onChange={handleLabelSizeChange}
-            getAriaLabel={() => 'Scatterplot label size slider'}
+            aria-label="Scatterplot label size slider"
             id={`scatterplot-set-label-size-${scatterplotOptionsId}`}
             valueLabelDisplay="auto"
             step={1}
@@ -223,7 +223,7 @@ export default function ScatterplotOptions(props) {
             disabled={cellRadiusMode !== 'manual'}
             value={cellRadius}
             onChange={handleRadiusChange}
-            getAriaLabel={() => 'Scatterplot radius size slider'}
+            aria-label="Scatterplot radius size slider"
             id={`scatterplot-set-radius-size-select-${scatterplotOptionsId}`}
             valueLabelDisplay="auto"
             step={0.01}
@@ -268,7 +268,7 @@ export default function ScatterplotOptions(props) {
             disabled={cellOpacityMode !== 'manual'}
             value={cellOpacity}
             onChange={handleOpacityChange}
-            getAriaLabel={() => 'Scatterplot opacity level slider'}
+            aria-label="Scatterplot opacity level slider"
             id={`scatterplot-set-opacity-level-${scatterplotOptionsId}`}
             valueLabelDisplay="auto"
             step={0.05}

--- a/packages/view-types/scatterplot/src/shared-spatial-scatterplot/ToolMenu.js
+++ b/packages/view-types/scatterplot/src/shared-spatial-scatterplot/ToolMenu.js
@@ -136,7 +136,7 @@ export default function ToolMenu(props) {
       <IconButton
         alt="click to recenter"
         onClick={() => onRecenterButtonCLick()}
-        getAriaLabel={() => 'Recenter scatterplot view'}
+        aria-label="Recenter scatterplot view"
       ><CenterFocusStrong />
       </IconButton>
     </div>

--- a/packages/vit-s/src/TitleInfo.js
+++ b/packages/vit-s/src/TitleInfo.js
@@ -91,7 +91,7 @@ function DownloadOptions(props) {
       buttonIcon={<CloudDownloadIconWithArrow open={open} />}
       buttonClassName={classes.iconButton}
       placement="bottom-end"
-      ariaLabel="Open download options menu."
+      ariaLabel="Open download options menu"
     >
       {urls.map(({ url, name }) => (
         <MenuItem dense key={`${url}_${name}`} getArialLabel={() => `Click to download ${name}`}>
@@ -113,7 +113,7 @@ function ClosePaneButton(props) {
       size="small"
       className={classes.iconButton}
       title="close"
-      getAriaLabel={() => 'Close panel button'}
+      aria-label="Close panel button"
     >
       <CloseIcon />
     </IconButton>

--- a/packages/vit-s/src/shared-mui/components.js
+++ b/packages/vit-s/src/shared-mui/components.js
@@ -30,7 +30,7 @@ export function PopperMenu(props) {
     children,
     buttonClassName,
     placement = 'bottom-end',
-    ariaLabel,
+    'aria-label': ariaLabel,
   } = props;
   const classes = useStyles();
 

--- a/packages/vit-s/src/shared-mui/components.js
+++ b/packages/vit-s/src/shared-mui/components.js
@@ -56,7 +56,7 @@ export function PopperMenu(props) {
         onTouchEnd={handleClick}
         size="small"
         className={buttonClassName}
-        getArialLabel={() => ariaLabel}
+        aria-label={ariaLabel}
       >
         {buttonIcon}
       </IconButton>

--- a/packages/vit-s/src/shared-plot-options/OptionsContainer.js
+++ b/packages/vit-s/src/shared-plot-options/OptionsContainer.js
@@ -15,7 +15,7 @@ export default function OptionsContainer(props) {
         <Table
           className={classes.table}
           size="small"
-          getAriaLabel={() => 'Menu of options available for the view'}
+          aria-label="Menu of options available for the view"
         >
           <TableBody>
             {children}

--- a/sites/docs/docs/tutorial-plugin-coordination-type.mdx
+++ b/sites/docs/docs/tutorial-plugin-coordination-type.mdx
@@ -40,7 +40,7 @@ function MyPluginSlider(props) {
         min={0.0}
         max={1.0}
         step={0.005}
-        getAriaLabel={() => 'custom-coordination-type-slider'}
+        aria-label="Custom coordination type slider"
       />
     </div>
   );


### PR DESCRIPTION
- Only MUI Slider supports getAriaLabel: https://v4.mui.com/api/slider/#props
- MUI components for MenuItem, IconButton, Button, Tabs, Tab, and Table do not support getAriaLabel
  - These components pass extra props down to the corresponding native HTML element
  - Native Select passes extra props down via `inputProps` prop https://v4.mui.com/api/native-select/#nativeselect-api
  - React supports `aria-label` as a prop https://legacy.reactjs.org/docs/accessibility.html#wai-aria
- There were still periods in the label text