### PR TITLE
Fixes for expand buttons

### DIFF
--- a/sites/docs/src/css/custom.css
+++ b/sites/docs/src/css/custom.css
@@ -20,7 +20,7 @@
   --ifm-code-font-size: 95%;
 
   --ifm-navbar-height: 3.0rem;
-  --ifm-expand-buttons-height: 4.3rem;
+  --ifm-vitessce-toolbar-height: 28px;
 
   --vit-input-foreground: #0451a5;
   --vit-input-background: #ffffff;
@@ -55,23 +55,72 @@
   padding: inherit;
 }
 
+.demo-header.vitessce-expanded {
+  display: none;
+}
+
+.vitessce-and-toolbar {
+  position: relative;
+  right: 0;
+  width: 100%;
+  height: calc(800px + var(--ifm-vitessce-toolbar-height));
+}
+
+.vitessce-and-toolbar.vitessce-expanded {
+  position: absolute;
+  top: var(--ifm-navbar-height);
+  left: 0;
+  width: 100%;
+  height: calc(100vh - var(--ifm-navbar-height));
+}
+
+.vitessce-toolbar {
+  position: relative;
+  width: 100%;
+  height: var(--ifm-vitessce-toolbar-height);
+}
+
+.vitessce-toolbar-buttons {
+  position: absolute;
+  right: calc(10% + 10px);
+  display: inline-block;
+  width: auto;
+}
+
+.vitessce-toolbar-buttons.vitessce-expanded {
+  right: 10px;
+}
+
+.vitessce-toolbar-buttons > button {
+  border: 2px solid var(--ifm-color-primary);
+  color: var(--ifm-color-primary);
+  background-color: transparent;
+  line-height: 1.2em;
+  text-decoration: none !important;
+  text-transform: uppercase;
+  border-radius: 8px;
+  font-size: 14px;
+  font-weight: 700;
+  padding: 1px 5px;
+  margin: 5px;
+  cursor: pointer;
+}
+
 .vitessce-app {
   flex: 1;
   position: relative;
-  padding-top: 40px; /* so that buttons in changeView css class are not hidden */
 }
 
-[data-expanded='expanded'] .vitessce-app .vitessce-container {
-  height: calc(100vh - var(--ifm-navbar-height)); /* so that react-grid-layout resizing works */
-  position: fixed; /* so that the scrollbar doesn't appear */
-  top: var(--ifm-expand-buttons-height);
-  transform: scaleY(0.98);
+.vitessce-app .vitessce-container {
+  width: 80%;
+  left: 10%
 }
 
-[data-expanded='collapsed'] .vitessce-app .vitessce-container {
-  height: calc(100vh - var(--ifm-navbar-height));
+.vitessce-app.vitessce-expanded .vitessce-container {
+  position: relative;
   width: 100%;
-  overflow: hidden;
+  left: 0;
+  height: calc(100vh - var(--ifm-navbar-height) - var(--ifm-vitessce-toolbar-height));
 }
 
 .vitessce-container.vitessce-theme-light .card {

--- a/sites/docs/src/pages/_Index.js
+++ b/sites/docs/src/pages/_Index.js
@@ -4,6 +4,7 @@ import React, { useState, useEffect } from 'react';
 import {
   QueryParamProvider, useQueryParam, StringParam,
 } from 'use-query-params';
+import clsx from 'clsx';
 import useBaseUrl from '@docusaurus/useBaseUrl';
 import { configs } from '@vitessce/example-configs';
 import { useHashParam, useSetHashParams } from './_use-hash-param.js';
@@ -13,8 +14,6 @@ import ThemedVitessce from './_ThemedVitessce.js';
 import ViewConfigEditor from './_ViewConfigEditor.js';
 import { baseJs, baseJson } from './_live-editor-examples.js';
 
-
-import styles from './styles.module.css';
 
 function logConfigUpgrade(prevConfig, nextConfig) {
   // eslint-disable-next-line no-console
@@ -84,15 +83,17 @@ function IndexWithHashParams() {
     setPendingJs(baseJs);
   }
 
+  const isDemo = demo && Object.keys(configs).includes(demo);
+  // Initialize to collapsed if this is a demo.
+  // Otherwise, initialize to expanded.
   const [isExpanded, setIsExpanded] = useState(false);
-  document.documentElement.setAttribute('data-expanded', 'collapsed');
 
   useEffect(() => {
-    if (isExpanded) {
-      document.documentElement.setAttribute('data-expanded', 'expanded');
-    } else {
-      document.documentElement.setAttribute('data-expanded', 'collapsed');
-    }
+    setIsExpanded(!isDemo);
+  }, [isDemo]);
+
+  useEffect(() => {
+    window.dispatchEvent(new Event('resize'));
   }, [isExpanded]);
 
   useEffect(() => {
@@ -199,42 +200,47 @@ function IndexWithHashParams() {
     </>
   ) : validConfig ? (
     <div>
-      {!isExpanded && demo && Object.keys(configs).includes(demo) ? (
-        <>
+      {isDemo ? (
+        <div className={clsx('demo-header', { 'vitessce-expanded': isExpanded })}>
           <DemoStyles />
           <DemoHeader
             demo={demo}
             config={configs[demo]}
           />
-        </>
+        </div>
       ) : (
         <AppStyles dimNavbar />
       )}
-      <main className="vitessce-app">
-        <div className={styles.changeView}>
-          <button
-            type="button"
-            onClick={() => setIsExpanded(!isExpanded)}
-            className={styles.changeViewButtons}
-          >
-            { isExpanded ? 'Collapse' : 'Expand' }
-          </button>
-          <button
-            type="button"
-            className={styles.changeViewButtons}
-            onClick={handleEdit}
-          >
-            Edit
-          </button>
+      <div className={clsx('vitessce-and-toolbar', { 'vitessce-expanded': isExpanded })}>
+        <div className={clsx('vitessce-toolbar', { 'vitessce-expanded': isExpanded })}>
+          <div className={clsx('vitessce-toolbar-buttons', { 'vitessce-expanded': isExpanded })}>
+            {isDemo ? (
+              <button
+                type="button"
+                onClick={() => setIsExpanded(prev => !prev)}
+              >
+                { isExpanded ? 'Collapse' : 'Expand' }
+              </button>
+            ) : null}
+            <button
+              type="button"
+              onClick={handleEdit}
+            >
+              Edit
+            </button>
+          </div>
         </div>
-        <ThemedVitessce
-          validateOnConfigChange={debug}
-          onConfigChange={debug ? console.log : undefined}
-          onConfigUpgrade={debug ? logConfigUpgrade : undefined}
-          config={validConfig}
-          handleEdit={handleEdit}
-        />
-      </main>
+        <main className={clsx('vitessce-app', { 'vitessce-expanded': isExpanded })}>
+          <ThemedVitessce
+            validateOnConfigChange={debug}
+            onConfigChange={debug ? console.log : undefined}
+            onConfigUpgrade={debug ? logConfigUpgrade : undefined}
+            config={validConfig}
+            handleEdit={handleEdit}
+            height={isExpanded ? undefined : 800}
+          />
+        </main>
+      </div>
     </div>
   ) : (!loading ? (
     <Home />

--- a/sites/docs/src/pages/styles.module.css
+++ b/sites/docs/src/pages/styles.module.css
@@ -214,29 +214,6 @@
   opacity: 1;
 }
 
-.changeView {
-  position: absolute;
-  top: 0px;
-  left: 0px;
-  right: 0px;
-  height: auto;
-}
-
-.changeViewButtons {
-  float: right;
-  border: 2px solid var(--ifm-color-primary);
-  color: var(--ifm-color-primary);
-  background-color: transparent;
-  line-height: 1.2em;
-  text-decoration: none !important;
-  text-transform: uppercase;
-  border-radius: 8px;
-  font-size: 14px;
-  font-weight: 700;
-  padding: 5px 10px;
-  margin: 5px;
-  cursor: pointer;
-}
 
 .vitessceAppLoadError {
   background-color: lightcoral;


### PR DESCRIPTION
This fixes the browser window resizing, updates the styles, only shows the expand button when in "demo mode", and initializes to expanded rather than collapsed for "edit mode".

This also changes to only using absolute and relative positioning, and removes the `transform: scaleY`.