### PR TITLE
Fix obsSegmentations.raster.json bugs

### DIFF
--- a/.changeset/giant-apricots-think.md
+++ b/.changeset/giant-apricots-think.md
@@ -1,0 +1,5 @@
+---
+"@vitessce/spatial": patch
+---
+
+Fix bug causing crash of Vitessce upon gene selection when earlier configs with both raster.json and expression data are used with pseudo-segmentation diamonds in the spatial view.

--- a/examples/configs/src/index.js
+++ b/examples/configs/src/index.js
@@ -29,6 +29,7 @@ import { marshall2022iScience } from './view-configs/marshall_2022_iscience.js';
 import { meta2022azimuth } from './view-configs/meta_2022_azimuth.js';
 import { rgbOmeTiff } from './view-configs/rgb-ome-tiff.js';
 import { segmentationsOmeTiff } from './view-configs/segmentations-ome-tiff.js';
+import { visiumSpatialViewer } from './view-configs/visium-spatial-viewer.js';
 
 export const coordinationTypeConfigs = {
   [vapi.ct.EMBEDDING_ZOOM]: embeddingZoomConfig,
@@ -69,6 +70,7 @@ export const configs = {
   // Keys which enable backwards compatibility with old links.
   'codeluppi-2018-via-json': codeluppi2018,
   'linnarsson-2018': codeluppi2018,
+  'visium-spatial-viewer': visiumSpatialViewer,
   gating: codeluppiGating,
   vanderbilt: spraggins2020,
   'dries-2019': eng2019,

--- a/examples/configs/src/view-configs/visium-spatial-viewer.js
+++ b/examples/configs/src/view-configs/visium-spatial-viewer.js
@@ -1,0 +1,146 @@
+export const visiumSpatialViewer = {
+  coordinationSpace: {
+    embeddingZoom: {
+      UMAP: 0,
+    },
+    dataset: {
+      A: 'A',
+    },
+    embeddingType: {
+      UMAP: 'UMAP',
+    },
+    embeddingCellRadiusMode: {
+      UMAP: 'manual',
+    },
+    embeddingCellRadius: {
+      UMAP: 3,
+    },
+    spatialCellsLayer: {
+      is_visible: {
+        opacity: 1,
+        radius: 10,
+        visible: true,
+        stroked: false,
+      },
+      is_not_visible: {
+        opacity: 1,
+        radius: 10,
+        visible: false,
+        stroked: false,
+      },
+    },
+  },
+  datasets: [
+    {
+      files: [
+        {
+          type: 'cells',
+          fileType: 'anndata-cells.zarr',
+          url: 'https://s3.amazonaws.com/vitessce-data/0.0.33/main/human-lymph-node-10x-visium/human_lymph_node_10x_visium.h5ad.zarr',
+          options: {
+            xy: 'obsm/spatial',
+            mappings: {
+              UMAP: {
+                key: 'obsm/X_umap',
+                dims: [
+                  0,
+                  1,
+                ],
+              },
+            },
+          },
+        },
+        {
+          type: 'expression-matrix',
+          fileType: 'anndata-expression-matrix.zarr',
+          url: 'https://s3.amazonaws.com/vitessce-data/0.0.33/main/human-lymph-node-10x-visium/human_lymph_node_10x_visium.h5ad.zarr',
+          options: {
+            matrix: 'X',
+          },
+        },
+        {
+          fileType: 'raster.json',
+          options: {
+            images: [
+              {
+                name: 'XY02_Stitch-ome.zarr',
+                type: 'ome-zarr',
+                url: 'https://vitessce-data.storage.googleapis.com/0.0.33/main/human-lymph-node-10x-visium/human_lymph_node_10x_visium.ome.zarr',
+              },
+            ],
+            schemaVersion: '0.0.2',
+            usePhysicalSizeScaling: false,
+          },
+          type: 'raster',
+        },
+      ],
+      name: 'Visualization Files',
+      uid: 'A',
+    },
+  ],
+  description: '10x Visium Spatial Gene Expression',
+  initStrategy: 'auto',
+  layout: [
+    {
+      component: 'description',
+      coordinationScopes: {
+        dataset: 'A',
+      },
+      h: 3,
+      w: 3,
+      x: 0,
+      y: 0,
+    },
+    {
+      component: 'spatial',
+      coordinationScopes: {
+        spatialCellsLayer: 'is_visible',
+        dataset: 'A',
+      },
+      h: 6,
+      w: 4,
+      x: 3,
+      y: 0,
+    },
+    {
+      component: 'spatial',
+      coordinationScopes: {
+        spatialCellsLayer: 'is_not_visible',
+        dataset: 'A',
+      },
+      h: 6,
+      w: 4,
+      x: 3,
+      y: 0,
+    },
+    {
+      component: 'scatterplot',
+      coordinationScopes: {
+        embeddingType: 'UMAP',
+        embeddingZoom: 'UMAP',
+        embeddingCellRadiusMode: 'UMAP',
+        embeddingCellRadius: 'UMAP',
+      },
+      h: 12,
+      w: 5,
+      x: 7,
+      y: 0,
+    },
+    {
+      component: 'genes',
+      x: 0,
+      y: 3,
+      w: 3,
+      h: 5,
+    },
+    {
+      component: 'expressionHistogram',
+      x: 0,
+      y: 7,
+      w: 3,
+      h: 4,
+    },
+  ],
+  name: 'Spatial Viewer',
+  version: '1.0.4',
+};

--- a/packages/file-types/json/src/raster-json-loaders/RasterJsonAsObsSegmentationsLoader.js
+++ b/packages/file-types/json/src/raster-json-loaders/RasterJsonAsObsSegmentationsLoader.js
@@ -26,10 +26,10 @@ export default class RasterJsonAsObsSegmentationsLoader extends RasterLoader {
     }
 
     return new LoaderResult(
-      {
+      (loaders.length > 0 && meta.length > 0 ? ({
         obsSegmentationsType: 'bitmask',
-        obsSegmentations: (loaders.length > 0 && meta.length > 0 ? { loaders, meta } : null),
-      },
+        obsSegmentations: { loaders, meta },
+      }) : null),
       urls,
       {
         // Filter coordinationValues, keeping only bitmask layers.

--- a/packages/view-types/spatial/src/SpatialSubscriber.js
+++ b/packages/view-types/spatial/src/SpatialSubscriber.js
@@ -197,10 +197,14 @@ export function SpatialSubscriber(props) {
     { spatialSegmentationLayer: cellsLayer },
     { obsType }, // TODO: use obsType in matchOn once #1240 is merged.
   );
+  // In the case of obsSegmentations.raster.json files that have been
+  // auto-upgraded from raster.json in older config versions,
+  // it is possible to have an obsSegmentations file type in the dataset,
+  // but one that returns `null` if all of the raster layers end up being
+  // images rather than segmentation bitmasks.
   const hasSegmentationsData = hasSegmentationsLoader && !(
     obsSegmentationsStatus === STATUS.SUCCESS
-    && obsSegmentations
-    && obsSegmentationsType
+    && !(obsSegmentations || obsSegmentationsType)
   );
   const [{ obsSets: cellSets, obsSetsMembership }, obsSetsStatus, obsSetsUrls] = useObsSetsData(
     loaders, dataset, false,

--- a/packages/view-types/spatial/src/SpatialSubscriber.js
+++ b/packages/view-types/spatial/src/SpatialSubscriber.js
@@ -27,7 +27,7 @@ import {
 import { setObsSelection, mergeObsSets, colorArrayToString } from '@vitessce/sets-utils';
 import { canLoadResolution, getCellColors } from '@vitessce/utils';
 import { Legend } from '@vitessce/legend';
-import { COMPONENT_COORDINATION_TYPES, ViewType, DataType } from '@vitessce/constants-internal';
+import { COMPONENT_COORDINATION_TYPES, ViewType, DataType, STATUS } from '@vitessce/constants-internal';
 import { Typography } from '@material-ui/core';
 import Spatial from './Spatial.js';
 import SpatialOptions from './SpatialOptions.js';
@@ -152,7 +152,7 @@ export function SpatialSubscriber(props) {
     { obsType, featureType, featureValueType },
     // TODO: get per-spatialLayerType expression data once #1240 is merged.
   );
-  const hasSegmentationsData = useHasLoader(
+  const hasSegmentationsLoader = useHasLoader(
     loaders, dataset, DataType.OBS_SEGMENTATIONS,
     { obsType }, // TODO: use obsType in matchOn once #1240 is merged.
   );
@@ -196,6 +196,9 @@ export function SpatialSubscriber(props) {
     { setSpatialSegmentationLayer: setCellsLayer },
     { spatialSegmentationLayer: cellsLayer },
     { obsType }, // TODO: use obsType in matchOn once #1240 is merged.
+  );
+  const hasSegmentationsData = hasSegmentationsLoader && !(
+    obsSegmentationsStatus === STATUS.SUCCESS && obsSegmentations === undefined
   );
   const [{ obsSets: cellSets, obsSetsMembership }, obsSetsStatus, obsSetsUrls] = useObsSetsData(
     loaders, dataset, false,

--- a/packages/view-types/spatial/src/SpatialSubscriber.js
+++ b/packages/view-types/spatial/src/SpatialSubscriber.js
@@ -198,7 +198,9 @@ export function SpatialSubscriber(props) {
     { obsType }, // TODO: use obsType in matchOn once #1240 is merged.
   );
   const hasSegmentationsData = hasSegmentationsLoader && !(
-    obsSegmentationsStatus === STATUS.SUCCESS && obsSegmentations === undefined
+    obsSegmentationsStatus === STATUS.SUCCESS
+    && obsSegmentations
+    && obsSegmentationsType
   );
   const [{ obsSets: cellSets, obsSetsMembership }, obsSetsStatus, obsSetsUrls] = useObsSetsData(
     loaders, dataset, false,


### PR DESCRIPTION
<!-- Credit (as a starting template): https://github.com/visgl/deck.gl/blob/master/.github/pull_request_template.md -->
<!-- For feature, feature enhancement or bug fix, create an issue first and finish To Do List there -->
<!-- Anything doesn't work as expected is a bug, including code, doc and test -->
Fixes #1668
<!-- For other PRs without open issue -->
#### Background

I was able to reproduce by copying the config for Spatial Transcriptomics for AKI sample S-2002-007755 and using the debug mode. It appears that since the raster.json as obsSegmentations loader was returning `obsSegmentationsType === 'bitmask'` despite the obsSegmentations data being null, this if statement was evaluating to `true` and running when it should not, causing the crashing. https://github.com/vitessce/vitessce/blob/6762b9242eefb0b9bd28009384123ace4475994c/packages/view-types/spatial/src/SpatialSubscriber.js#L406

I also noticed that the pseudo-segmentation diamonds were not appearing due to the hasSegmentationsData only checking the existence of the loader. Here, I added an extra check that the data is non-null.

<!-- For all the PRs -->
#### Change List
-
#### Checklist
 - [ ] Ensure PR works with all demos on the dev.vitessce.io homepage
 - [ ] Open (draft) PR's into [`vitessce-python`](https://github.com/vitessce/vitessce-python) and [`vitessce-r`](https://github.com/vitessce/vitessce-r) if this is a release PR
 - [ ] Documentation added or updated