### PR TITLE
Cell/obs set color support in spatialBeta view

### DIFF
--- a/examples/configs/src/view-configs/codex-oop.js
+++ b/examples/configs/src/view-configs/codex-oop.js
@@ -42,7 +42,7 @@ function generateCodexConfig() {
       fileUid: 'reg001_mask',
     },
   }).addFile({
-    fileType: "anndata.zarr",
+    fileType: 'anndata.zarr',
     options: {
       /*
       "obsEmbedding": [
@@ -62,10 +62,10 @@ function generateCodexConfig() {
         "path": "obsm/xy"
       },
       */
-      "obsSets": [
+      obsSets: [
         {
-          "name": "Cell K-Means",
-          "path": "obs/Cell K-Means [tSNE_All_Features]"
+          name: 'Cell K-Means',
+          path: 'obs/Cell K-Means [tSNE_All_Features]',
         },
         /*
         {
@@ -93,24 +93,25 @@ function generateCodexConfig() {
           "path": "obs/Cell K-Means [Covariance] Expression"
         }
         */
-      ]
+      ],
     },
-    url: "https://assets.hubmapconsortium.org/8d86e6c899e80d0f5f95604eb4ad492e/anndata-zarr/reg001_expr-anndata.zarr"
-  }).addFile({
-    fileType: "anndata.zarr",
-    options: {
-      "obsSets": [
-        {
-          "name": "Cell K-Means",
-          "path": "obs/Cell K-Means [tSNE_All_Features]"
-        },
-      ]
-    },
-    url: "https://assets.hubmapconsortium.org/8d86e6c899e80d0f5f95604eb4ad492e/anndata-zarr/reg001_expr-anndata.zarr",
-    coordinationValues: {
-      obsType: 'nucleus'
-    }
-  });
+    url: 'https://assets.hubmapconsortium.org/8d86e6c899e80d0f5f95604eb4ad492e/anndata-zarr/reg001_expr-anndata.zarr',
+  })
+    .addFile({
+      fileType: 'anndata.zarr',
+      options: {
+        obsSets: [
+          {
+            name: 'Cell K-Means',
+            path: 'obs/Cell K-Means [tSNE_All_Features]',
+          },
+        ],
+      },
+      url: 'https://assets.hubmapconsortium.org/8d86e6c899e80d0f5f95604eb4ad492e/anndata-zarr/reg001_expr-anndata.zarr',
+      coordinationValues: {
+        obsType: 'nucleus',
+      },
+    });
 
   const spatialView = config.addView(dataset, 'spatialBeta');
   const lcView = config.addView(dataset, 'layerControllerBeta');

--- a/examples/configs/src/view-configs/visium-polygons-oop.js
+++ b/examples/configs/src/view-configs/visium-polygons-oop.js
@@ -62,6 +62,12 @@ function generateVisiumConfig() {
     },
   });
 
+  const [
+    obsSetColorScope,
+    obsSetSelectionScope,
+    additionalObsSetsScope,
+  ] = config.addCoordination('obsSetColor', 'obsSetSelection', 'additionalObsSets');
+
   const scopes = config.addCoordinationByObject({
     spatialTargetZ: 0,
     spatialTargetT: 0,
@@ -90,6 +96,9 @@ function generateVisiumConfig() {
       spatialLayerColor: [255, 0, 0],
       obsColorEncoding: 'spatialLayerColor',
       obsHighlight: null,
+      obsSetColor: obsSetColorScope,
+      obsSetSelection: obsSetSelectionScope,
+      additionalObsSets: additionalObsSetsScope,
     }),
     segmentationLayer: CL([
       {
@@ -103,6 +112,9 @@ function generateVisiumConfig() {
             spatialChannelOpacity: 1.0,
             obsColorEncoding: 'spatialChannelColor',
             obsHighlight: null,
+            obsSetColor: obsSetColorScope,
+            obsSetSelection: obsSetSelectionScope,
+            additionalObsSets: additionalObsSetsScope,
           },
         ]),
       },
@@ -124,6 +136,8 @@ function generateVisiumConfig() {
   lcViewSimple.useMetaCoordination(metaCoordinationScope);
 
   config.linkViews([obsSets, featureList], ['obsType'], ['spot']);
+
+  obsSets.useCoordination(obsSetColorScope, obsSetSelectionScope, additionalObsSetsScope);
 
   config.layout(hconcat(spatialViewSimple, spatialView2, vconcat(lcViewSimple, obsSets, featureList)));
 

--- a/packages/gl/src/BitmaskLayerBeta.js
+++ b/packages/gl/src/BitmaskLayerBeta.js
@@ -126,9 +126,12 @@ export default class BitmaskLayer extends XRLayer {
         channelIsSetColorMode,
       );
       this.setState({
-        valueTex, colorTex,
-        valueTexOffsets, colorTexOffsets,
-        valueTexHeight, colorTexHeight,
+        valueTex,
+        colorTex,
+        valueTexOffsets,
+        colorTexOffsets,
+        valueTexHeight,
+        colorTexHeight,
       });
     }
     if (props.colormap !== oldProps.colormap) {
@@ -289,7 +292,7 @@ export default class BitmaskLayer extends XRLayer {
     let totalColorsLength = 0;
 
     channelIsSetColorMode.forEach((isSetColorMode, i) => {
-      if(isSetColorMode) {
+      if (isSetColorMode) {
         totalValuesLength += setColorValues[i]?.obsIndex?.length || 0;
         totalColorsLength += (setColorValues[i]?.setColors?.length || 0) * 3;
       } else {
@@ -318,16 +321,16 @@ export default class BitmaskLayer extends XRLayer {
     let colorOffset = 0;
     // Iterate over the data for each channel.
     channelIsSetColorMode.forEach((isSetColorMode, i) => {
-      if(isSetColorMode) {
+      if (isSetColorMode) {
         const { setColorIndices, setColors, obsIndex } = setColorValues[i] || {};
-        if(setColorIndices && setColors && obsIndex) {
-          for(let i = 0; i < obsIndex.length; i ++) {
+        if (setColorIndices && setColors && obsIndex) {
+          for (let i = 0; i < obsIndex.length; i++) {
             // TODO: should one be added here to account for background pixel value?
             // TODO: should another one be added to account for "null" (i.e., a cell that does not belong to any selected set).
-            const colorIndex = setColorIndices.get(String(i+1));
+            const colorIndex = setColorIndices.get(String(i + 1));
             totalData[indexOffset + i] = colorIndex === undefined ? 0 : colorIndex + 1;
           }
-          for(let i = 0; i < setColors.length; i ++) {
+          for (let i = 0; i < setColors.length; i++) {
             totalColors[(colorOffset + i) * 3 + 0] = setColors[i].color[0];
             totalColors[(colorOffset + i) * 3 + 1] = setColors[i].color[1];
             totalColors[(colorOffset + i) * 3 + 2] = setColors[i].color[2];

--- a/packages/gl/src/BitmaskLayerBeta.js
+++ b/packages/gl/src/BitmaskLayerBeta.js
@@ -117,9 +117,12 @@ export default class BitmaskLayer extends XRLayer {
       // Use one expressionTex for all channels,
       // using an offset mechanism.
       const [
-        valueTex, colorTex,
-        valueTexOffsets, colorTexOffsets,
-        valueTexHeight, colorTexHeight,
+        valueTex,
+        colorTex,
+        valueTexOffsets,
+        colorTexOffsets,
+        valueTexHeight,
+        colorTexHeight,
       ] = this.multiSetsToTexture(
         multiFeatureValues,
         setColorValues,

--- a/packages/gl/src/BitmaskLayerBeta.js
+++ b/packages/gl/src/BitmaskLayerBeta.js
@@ -332,8 +332,8 @@ export default class BitmaskLayer extends XRLayer {
 
   multiSetsToTexture(data) {
     const isWebGL2On = isWebGL2(this.context.gl);
-    const totalIndicesLength = data.reduce((a, h) => a + h.setColorIndices.size, 0); // Throw error if too large
-    const totalColorLength = data.reduce((a, h) => a + h.setColors.length * 3, 0); // Throw error if too large
+    const totalIndicesLength = data.reduce((a, h) => a + (h?.setColorIndices?.size || 0), 0); // Throw error if too large
+    const totalColorLength = data.reduce((a, h) => a + (h?.setColors?.length || 0) * 3, 0); // Throw error if too large
     const texIndicesHeight = Math.max(2, Math.ceil(totalIndicesLength / MULTI_FEATURE_TEX_SIZE));
     const texColorHeight = Math.max(2, Math.ceil(totalColorLength / MULTI_FEATURE_TEX_SIZE));
     if (texIndicesHeight > MULTI_FEATURE_TEX_SIZE) {
@@ -350,21 +350,23 @@ export default class BitmaskLayer extends XRLayer {
     let colorOffset = 0;
     // Iterate over the data for each channel.
     data.forEach((dataObj) => {
-      const { setColorIndices, setColors } = dataObj;
-      for(let i = 0; i < setColorIndices.size; i ++) {
-        // TODO: should one be added here to account for background pixel value?
-        // TODO: should another one be added to account for "null" (i.e., a cell that does not belong to any selected set).
-        totalData[indexOffset + i] = setColorIndices.get(String(i+1));
-      }
-      for(let i = 0; i < setColors.length; i ++) {
-        totalColors[(colorOffset + i) * 3 + 0] = setColors[i].color[0];
-        totalColors[(colorOffset + i) * 3 + 1] = setColors[i].color[1];
-        totalColors[(colorOffset + i) * 3 + 2] = setColors[i].color[2];
+      const { setColorIndices, setColors } = dataObj || {};
+      if(setColorIndices && setColors) {
+        for(let i = 0; i < setColorIndices.size; i ++) {
+          // TODO: should one be added here to account for background pixel value?
+          // TODO: should another one be added to account for "null" (i.e., a cell that does not belong to any selected set).
+          totalData[indexOffset + i] = setColorIndices.get(String(i+1));
+        }
+        for(let i = 0; i < setColors.length; i ++) {
+          totalColors[(colorOffset + i) * 3 + 0] = setColors[i].color[0];
+          totalColors[(colorOffset + i) * 3 + 1] = setColors[i].color[1];
+          totalColors[(colorOffset + i) * 3 + 2] = setColors[i].color[2];
+        }
       }
       indicesOffsets.push(indexOffset);
       colorsOffsets.push(colorOffset);
-      indexOffset += setColorIndices.size;
-      colorOffset += setColors.length;
+      indexOffset += (setColorIndices?.size || 0);
+      colorOffset += (setColors?.length || 0);
     });
 
     return [

--- a/packages/gl/src/BitmaskLayerBeta.js
+++ b/packages/gl/src/BitmaskLayerBeta.js
@@ -332,7 +332,7 @@ export default class BitmaskLayer extends XRLayer {
 
   multiSetsToTexture(data) {
     const isWebGL2On = isWebGL2(this.context.gl);
-    const totalIndicesLength = data.reduce((a, h) => a + (h?.setColorIndices?.size || 0), 0); // Throw error if too large
+    const totalIndicesLength = data.reduce((a, h) => a + (h?.obsIndex?.length || 0), 0); // Throw error if too large
     const totalColorLength = data.reduce((a, h) => a + (h?.setColors?.length || 0) * 3, 0); // Throw error if too large
     const texIndicesHeight = Math.max(2, Math.ceil(totalIndicesLength / MULTI_FEATURE_TEX_SIZE));
     const texColorHeight = Math.max(2, Math.ceil(totalColorLength / MULTI_FEATURE_TEX_SIZE));
@@ -350,12 +350,13 @@ export default class BitmaskLayer extends XRLayer {
     let colorOffset = 0;
     // Iterate over the data for each channel.
     data.forEach((dataObj) => {
-      const { setColorIndices, setColors } = dataObj || {};
-      if(setColorIndices && setColors) {
-        for(let i = 0; i < setColorIndices.size; i ++) {
+      const { setColorIndices, setColors, obsIndex } = dataObj || {};
+      if(setColorIndices && setColors && obsIndex) {
+        for(let i = 0; i < obsIndex.length; i ++) {
           // TODO: should one be added here to account for background pixel value?
           // TODO: should another one be added to account for "null" (i.e., a cell that does not belong to any selected set).
-          totalData[indexOffset + i] = setColorIndices.get(String(i+1));
+          const colorIndex = setColorIndices.get(String(i+1));
+          totalData[indexOffset + i] = colorIndex === undefined ? 0 : colorIndex + 1;
         }
         for(let i = 0; i < setColors.length; i ++) {
           totalColors[(colorOffset + i) * 3 + 0] = setColors[i].color[0];
@@ -365,7 +366,7 @@ export default class BitmaskLayer extends XRLayer {
       }
       indicesOffsets.push(indexOffset);
       colorsOffsets.push(colorOffset);
-      indexOffset += (setColorIndices?.size || 0);
+      indexOffset += (obsIndex?.length || 0);
       colorOffset += (setColors?.length || 0);
     });
 

--- a/packages/gl/src/bitmask-layer-beta-shaders.js
+++ b/packages/gl/src/bitmask-layer-beta-shaders.js
@@ -41,8 +41,6 @@ uniform sampler2D channel5;
 uniform sampler2D channel6;
 
 // Color texture
-// uniform float colorTexHeight;
-// uniform float colorTexWidth;
 uniform float hovered;
 
 // Channel-specific properties

--- a/packages/gl/src/bitmask-layer-beta-shaders.js
+++ b/packages/gl/src/bitmask-layer-beta-shaders.js
@@ -142,23 +142,28 @@ vec4 dataToColor(vec3 sampledDataAndIsEdge, bool isStaticColorMode, vec3 channel
   vec2 setIndicesTexCoord = vec2(mod(offsetSampledData, multiFeatureTexSize) / multiFeatureTexSize, floor(offsetSampledData / multiFeatureTexSize) / (setIndicesTexHeight - 1.));
   float setColorIndex = texture(setIndicesTex, setIndicesTexCoord).r;
 
-  float setColorOffsetR = (setColorIndex + setColorOffset) * 3.0 + 0.0;
-  vec2 setColorTexCoordR = vec2(mod(setColorOffsetR, multiFeatureTexSize) / multiFeatureTexSize, floor(setColorOffsetR / multiFeatureTexSize) / (setColorTexHeight - 1.));
-  float setColorR = texture(setColorTex, setColorTexCoordR).r / 255.;
+  // Initialize to the default "null" color.
+  vec3 setColor = vec3(200. / 255., 200. / 255., 200. / 255.);
+  if(setColorIndex != 0.) {
+    // Subtract one from setColorIndex because we have already checked for the "null" value.
+    setColorIndex = setColorIndex - 1.;
 
-  float setColorOffsetG = (setColorIndex + setColorOffset) * 3.0 + 1.0;
-  vec2 setColorTexCoordG = vec2(mod(setColorOffsetG, multiFeatureTexSize) / multiFeatureTexSize, floor(setColorOffsetG / multiFeatureTexSize) / (setColorTexHeight - 1.));
-  float setColorG = texture(setColorTex, setColorTexCoordG).r / 255.;
+    float setColorOffsetR = (setColorIndex + setColorOffset) * 3.0 + 0.0;
+    vec2 setColorTexCoordR = vec2(mod(setColorOffsetR, multiFeatureTexSize) / multiFeatureTexSize, floor(setColorOffsetR / multiFeatureTexSize) / (setColorTexHeight - 1.));
+    float setColorR = texture(setColorTex, setColorTexCoordR).r / 255.;
 
-  float setColorOffsetB = (setColorIndex + setColorOffset) * 3.0 + 2.0;
-  vec2 setColorTexCoordB = vec2(mod(setColorOffsetB, multiFeatureTexSize) / multiFeatureTexSize, floor(setColorOffsetB / multiFeatureTexSize) / (setColorTexHeight - 1.));
-  float setColorB = texture(setColorTex, setColorTexCoordB).r / 255.;
+    float setColorOffsetG = (setColorIndex + setColorOffset) * 3.0 + 1.0;
+    vec2 setColorTexCoordG = vec2(mod(setColorOffsetG, multiFeatureTexSize) / multiFeatureTexSize, floor(setColorOffsetG / multiFeatureTexSize) / (setColorTexHeight - 1.));
+    float setColorG = texture(setColorTex, setColorTexCoordG).r / 255.;
 
-  vec3 setColor = vec3(setColorR, setColorG, setColorB);
+    float setColorOffsetB = (setColorIndex + setColorOffset) * 3.0 + 2.0;
+    vec2 setColorTexCoordB = vec2(mod(setColorOffsetB, multiFeatureTexSize) / multiFeatureTexSize, floor(setColorOffsetB / multiFeatureTexSize) / (setColorTexHeight - 1.));
+    float setColorB = texture(setColorTex, setColorTexCoordB).r / 255.;
+
+    setColor = vec3(setColorR, setColorG, setColorB);
+  }
+
   
-
-
-
   vec4 sampledColor = (1. - (float(isStaticColorMode) + float(isSetColorMode))) * vec4(COLORMAP_FUNC(clamp(scaledExpressionValue, 0.0, 1.0)).rgb, channelOpacity) + float(isStaticColorMode) * vec4(channelColor.rgb, channelOpacity) + float(isSetColorMode) * vec4(setColor, channelOpacity);
   // Only return a color if the data is non-zero.
   

--- a/packages/utils/sets-utils/src/cell-set-utils.js
+++ b/packages/utils/sets-utils/src/cell-set-utils.js
@@ -425,6 +425,65 @@ export function treeToCellColorsBySetNames(currTree, selectedNamePaths, cellSetC
 }
 
 /**
+ * Given a tree with state, get a mapping from cell ID to cell set path,
+ * based on the nodes currently marked as "visible".
+ * @param {object} currTree A tree object.
+ *  @param {array} selectedNamePaths Array of arrays of strings,
+ * representing set "paths".
+ * @returns {array} Tuple of [cellIds, cellColors]
+ * where cellIds is an array of strings,
+ * and cellColors is an object mapping cellIds to color [r,g,b] arrays.
+ */
+export function treeToCellSetPathsBySetNames(currTree, selectedNamePaths) {
+  let cellColorsArray = [];
+  selectedNamePaths.forEach((setNamePath) => {
+    const node = treeFindNodeByNamePath(currTree, setNamePath);
+    if (node) {
+      const nodeSet = nodeToSet(node);
+      cellColorsArray = [
+        ...cellColorsArray,
+        ...nodeSet.map(([cellId]) => [
+          cellId,
+          setNamePath,
+        ]),
+      ];
+    }
+  });
+  return new Map(cellColorsArray);
+}
+
+/**
+ * Given a tree with state, get a mapping from cell ID to cell set color index,
+ * based on the nodes currently marked as "visible".
+ * @param {object} currTree A tree object.
+ *  @param {array} selectedNamePaths Array of arrays of strings,
+ * representing set "paths".
+ * @param {object[]} cellSetColor Array of objects with the
+ * properties `path` and `color`.
+ * @returns {array} Tuple of [cellIds, cellColors]
+ * where cellIds is an array of strings,
+ * and cellColors is an object mapping cellIds to color [r,g,b] arrays.
+ */
+export function treeToCellSetColorIndicesBySetNames(currTree, selectedNamePaths, cellSetColor) {
+  let cellColorsArray = [];
+  selectedNamePaths?.forEach((setNamePath) => {
+    const node = treeFindNodeByNamePath(currTree, setNamePath);
+    if (node) {
+      const nodeSet = nodeToSet(node);
+      const nodeColorIndex = cellSetColor?.findIndex(d => isEqual(d.path, setNamePath));
+      cellColorsArray = [
+        ...cellColorsArray,
+        ...nodeSet.map(([cellId]) => [
+          cellId,
+          nodeColorIndex,
+        ]),
+      ];
+    }
+  });
+  return new Map(cellColorsArray);
+}
+
+/**
  * Given a tree with state, get an array of
  * objects with cellIds and cellColors,
  * based on the nodes currently marked as "visible".

--- a/packages/utils/sets-utils/src/index.js
+++ b/packages/utils/sets-utils/src/index.js
@@ -1,5 +1,6 @@
 export {
   treeToCellColorsBySetNames,
+  treeToCellSetColorIndicesBySetNames,
   treeToSetSizesBySetNames,
   treeToObjectsBySetNames,
   treeExportLevelZeroNode,

--- a/packages/view-types/spatial-beta/src/Spatial.js
+++ b/packages/view-types/spatial-beta/src/Spatial.js
@@ -32,7 +32,9 @@ const makeDefaultGetCellColors = (cellColors, obsIndex, theme) => (object, { ind
   ) || getDefaultColor(theme);
   return [r, g, b, 255 * (a || 1)];
 };
-const makeDefaultGetCellColorsFromIndices = (setColorObj, obsIndex, theme) => (object, { index }) => {
+const makeDefaultGetCellColorsFromIndices = (
+  setColorObj, obsIndex, theme,
+) => (object, { index }) => {
   // setColorIndices is a JS Map() from cell ID to color index.
   // setColors is an array of { path, color: [r, g, b] }.
   const { setColorIndices, setColors } = setColorObj || {};

--- a/packages/view-types/spatial-beta/src/Spatial.js
+++ b/packages/view-types/spatial-beta/src/Spatial.js
@@ -1059,7 +1059,6 @@ class Spatial extends AbstractSpatialOrScatterplot {
           obsSetSelection,
           obsSetColor,
         );
-        console.log(obsColorIndices, obsSetColor);
         // Initialize layer-level objects if necessary.
         if (!this.segmentationColors[layerScope]) {
           this.segmentationColors[layerScope] = {};
@@ -1073,6 +1072,7 @@ class Spatial extends AbstractSpatialOrScatterplot {
         this.segmentationColors[layerScope][channelScope] = {
           setColorIndices: obsColorIndices, // The Map from cell ID to color index.
           setColors: obsSetColor, // The array with [{ path, color: [r, g, b] }, ...].
+          obsIndex: layerIndex, // TODO: how to ensure this obsIndex.length matches the number of cells? Would obsFeatureMatrix obsIndex be better (if it is available in the dataset)?
         };
         this.prevSegmentationSetColor[layerScope][channelScope] = obsSetColor;
         this.prevSegmentationSetSelection[layerScope][channelScope] = obsSetSelection;

--- a/packages/view-types/spatial-beta/src/SpatialSubscriber.js
+++ b/packages/view-types/spatial-beta/src/SpatialSubscriber.js
@@ -38,7 +38,6 @@ import {
 } from '@vitessce/vit-s';
 import { COMPONENT_COORDINATION_TYPES, ViewType, CoordinationType } from '@vitessce/constants-internal';
 import { commaNumber } from '@vitessce/utils';
-import { mergeObsSets } from '@vitessce/sets-utils';
 import { MultiLegend } from '@vitessce/legend';
 import Spatial from './Spatial.js';
 import SpatialOptions from './SpatialOptions.js';


### PR DESCRIPTION
TODO:
- [x] optimizations by re-using expression textures
- [x] testing with datasets without cell sets (KPMP example)
- [x] testing with mixture of cell set and feature value color mappings for different channels
- [x] supporting a "null" color