### PR TITLE
WashU volume demo

### DIFF
--- a/examples/configs/src/index.js
+++ b/examples/configs/src/index.js
@@ -47,6 +47,7 @@ import { imsAlgorithmComparison } from './view-configs/spatial-beta/ims-algorith
 import { neumanOop2023 } from './view-configs/spatial-beta/neumann-oop.js';
 import { lightsheetOop2023 } from './view-configs/spatial-beta/lightsheet-oop.js';
 import { visiumPolygonsOop2023 } from './view-configs/spatial-beta/visium-polygons-oop.js';
+import { washuVolume2023 } from './view-configs/spatial-beta/washu.js';
 
 
 export const coordinationTypeConfigs = {
@@ -104,6 +105,7 @@ export const configs = {
   'codeluppi-2018-2': codeluppiOop2018,
   'kpmp-2023': kpmp2023,
   'kpmp-2023-2': kpmpOop2023,
+  'washu-2023': washuVolume2023,
 
   // TODO(spatialBeta): clean up
   'ims-algorithm-comparison': imsAlgorithmComparison,

--- a/examples/configs/src/view-configs/spatial-beta/washu.js
+++ b/examples/configs/src/view-configs/spatial-beta/washu.js
@@ -4,6 +4,24 @@ import {
   hconcat,
 } from '@vitessce/config';
 
+
+// We do not want to commit any presigned URLs to the repository, so we will set them as environment variables in the terminal.
+
+// Get the presigned URLs for these files on S3:
+// s3://hdv-spatial-data/washu-kidney/Lighsheet_test_data/sample_16/20x/stitched-ome_tiff/Sample_16_20x_2-Stitched.pyramid.offsets.json
+// s3://hdv-spatial-data/washu-kidney/Lighsheet_test_data/sample_16/20x/stitched-ome_tiff/Sample_16_20x_2-Stitched.pyramid.ome.tif
+
+// Set these presigned URLs as environment variables in the terminal by running:
+
+// export VITE_TIFF_URL='{your presigned URL for the OME-TIFF file}'
+// export VITE_JSON_URL='{your presigned URL for the offsets JSON file}'
+
+// Note: You may need to disable 'Terminal may enable paste bracketing' in iTerm2 Settings > Profiles > Terminal.
+// Reference: https://stackoverflow.com/a/75748117
+
+const omeTiffPresignedUrl = import.meta.env.VITE_TIFF_URL;
+const offsetsPresignedUrl = import.meta.env.VITE_JSON_URL;
+
 function generateWashUConfig() {
   const config = new VitessceConfig({
     schemaVersion: '1.0.16',
@@ -11,9 +29,9 @@ function generateWashUConfig() {
   });
   const dataset = config.addDataset('WashU data').addFile({
     fileType: 'image.ome-tiff',
-    url: 'https://hdv-spatial-data.s3.us-east-1.amazonaws.com/washu-kidney/Lighsheet_test_data/sample_16/20x/stitched-ome_tiff/Sample_16_20x_2-Stitched.pyramid.ome.tif',
+    url: omeTiffPresignedUrl,
     options: {
-        offsetsUrl: 'https://hdv-spatial-data.s3.us-east-1.amazonaws.com/washu-kidney/Lighsheet_test_data/sample_16/20x/stitched-ome_tiff/Sample_16_20x_2-Stitched.pyramid.offsets.json'
+        offsetsUrl: offsetsPresignedUrl
     },
     coordinationValues: {
       fileUid: 'Sample_16_20x_2-Stitched',
@@ -43,9 +61,23 @@ function generateWashUConfig() {
           },
           {
             spatialTargetC: 1,
-            spatialChannelColor: [0, 255, 0],
+            spatialChannelColor: [255, 255, 0],
             spatialChannelVisible: true,
             spatialChannelOpacity: 1.0,
+            spatialChannelWindow: null,
+          },
+          {
+            spatialTargetC: 2,
+            spatialChannelColor: [0, 255, 255],
+            spatialChannelVisible: true,
+            spatialChannelOpacity: 1.0,
+            spatialChannelWindow: null,
+          },
+          {
+            spatialTargetC: 3,
+            spatialChannelColor: [255, 255, 255],
+            spatialChannelVisible: true,
+            spatialChannelOpacity: 0.5,
             spatialChannelWindow: null,
           },
         ]),

--- a/examples/configs/src/view-configs/spatial-beta/washu.js
+++ b/examples/configs/src/view-configs/spatial-beta/washu.js
@@ -1,0 +1,62 @@
+import {
+  VitessceConfig,
+  CoordinationLevel as CL,
+  hconcat,
+} from '@vitessce/config';
+
+function generateWashUConfig() {
+  const config = new VitessceConfig({
+    schemaVersion: '1.0.16',
+    name: 'WashU Volume Demo',
+  });
+  const dataset = config.addDataset('WashU data').addFile({
+    fileType: 'image.ome-tiff',
+    url: 'https://hdv-spatial-data.s3.us-east-1.amazonaws.com/washu-kidney/Lighsheet_test_data/sample_16/20x/stitched-ome_tiff/Sample_16_20x_2-Stitched.pyramid.ome.tif',
+    options: {
+        offsetsUrl: 'https://hdv-spatial-data.s3.us-east-1.amazonaws.com/washu-kidney/Lighsheet_test_data/sample_16/20x/stitched-ome_tiff/Sample_16_20x_2-Stitched.pyramid.offsets.json'
+    },
+    coordinationValues: {
+      fileUid: 'Sample_16_20x_2-Stitched',
+    },
+  });
+
+  const spatialView = config.addView(dataset, 'spatialBeta');
+  const lcView = config.addView(dataset, 'layerControllerBeta');
+
+  config.linkViewsByObject([spatialView, lcView], {
+    spatialTargetZ: 0,
+    spatialTargetT: 0,
+    imageLayer: CL([
+      {
+        fileUid: 'Sample_16_20x_2-Stitched',
+        spatialLayerOpacity: 1,
+        spatialLayerVisible: true,
+        photometricInterpretation: 'BlackIsZero',
+        spatialTargetResolution: null,
+        imageChannel: CL([
+          {
+            spatialTargetC: 0,
+            spatialChannelColor: [255, 0, 0],
+            spatialChannelVisible: true,
+            spatialChannelOpacity: 1.0,
+            spatialChannelWindow: null,
+          },
+          {
+            spatialTargetC: 1,
+            spatialChannelColor: [0, 255, 0],
+            spatialChannelVisible: true,
+            spatialChannelOpacity: 1.0,
+            spatialChannelWindow: null,
+          },
+        ]),
+      },
+    ]),
+  });
+
+  config.layout(hconcat(spatialView, lcView));
+
+  const configJSON = config.toJSON();
+  return configJSON;
+}
+
+export const washuVolume2023 = generateWashUConfig();

--- a/packages/utils/image-utils/src/ImageWrapper.ts
+++ b/packages/utils/image-utils/src/ImageWrapper.ts
@@ -61,6 +61,18 @@ export default class ImageWrapper<S extends string[]> {
   constructor(vivLoader: VivLoaderType<S>, options: ImageOptions) {
     this.options = options || {};
     this.vivLoader = vivLoader;
+    
+    this.vivLoader.data.forEach((data: any) => {
+
+      const oldIndexer = data._indexer;
+
+      data._indexer = async (selection: any) => {
+        const image = await oldIndexer(selection);
+        image.fileDirectory.SampleFormat = Uint16Array.from([1]);
+        image.fileDirectory.BitsPerSample = Uint16Array.from([16]);
+        return image;
+      };
+    });
   }
 
   getType(): 'ome-tiff' | 'ome-zarr' {


### PR DESCRIPTION
<!-- Credit (as a starting template): https://github.com/visgl/deck.gl/blob/master/.github/pull_request_template.md -->
<!-- For feature, feature enhancement or bug fix, create an issue first and finish To Do List there -->
<!-- Anything doesn't work as expected is a bug, including code, doc and test -->

<!-- For other PRs without open issue -->
#### Background

For some reason, the OME-TIFF pyramids we converted on AWS have an empty `fileDirectory` object when loaded by `geotiff.js`. In this PR I added a hacky workaround for the time being to manually provide the required TIFF tag values for `SampleFormat` and `BitsPerSample`, and then geotiff is able to load this:

```js
image.fileDirectory.SampleFormat = Uint16Array.from([1]);
image.fileDirectory.BitsPerSample = Uint16Array.from([16]);
```

The presigned URLs can be set as environment variables before starting the demo:

```sh
export VITE_TIFF_URL='{your presigned URL for the OME-TIFF file}'
export VITE_JSON_URL='{your presigned URL for the offsets JSON file}'

pnpm run start-demo
```

I have added a demo config which can be accessed at http://localhost:3000/?dataset=washu-2023 after starting the demo site.

I have tested with these files so far:

```
s3://hdv-spatial-data/washu-kidney/Lighsheet_test_data/sample_16/20x/stitched-ome_tiff/Sample_16_20x_2-Stitched.pyramid.offsets.json
s3://hdv-spatial-data/washu-kidney/Lighsheet_test_data/sample_16/20x/stitched-ome_tiff/Sample_16_20x_2-Stitched.pyramid.ome.tif
```


#### Checklist
 - [ ] Ensure PR works with all demos on the dev.vitessce.io homepage
 - [ ] Open (draft) PR's into [`vitessce-python`](https://github.com/vitessce/vitessce-python) and [`vitessce-r`](https://github.com/vitessce/vitessce-r) if this is a release PR
 - [ ] Documentation added or updated