### PR TITLE
NickAkhmetov/Add support for `requestInit` in genomic profiles view

### DIFF
--- a/.changeset/five-geese-tan.md
+++ b/.changeset/five-geese-tan.md
@@ -1,0 +1,5 @@
+---
+"@vitessce/genomic-profiles": patch
+---
+
+Added support for providing requestInit options to genomic profiles requests

--- a/packages/file-types/zarr/src/genomic-loaders/GenomicProfilesZarrLoader.js
+++ b/packages/file-types/zarr/src/genomic-loaders/GenomicProfilesZarrLoader.js
@@ -10,8 +10,13 @@ export default class GenomicProfilesZarrLoader extends AbstractTwoStepLoader {
   }
 
   load() {
-    const { url } = this;
+    const { url, requestInit } = this;
     return this.loadAttrs()
-      .then(attrs => Promise.resolve(new LoaderResult(attrs, url)));
+      .then(attrs => Promise.resolve(new LoaderResult(
+        attrs,
+        url,
+        null,
+        requestInit,
+      )));
   }
 }

--- a/packages/view-types/genomic-profiles/package.json
+++ b/packages/view-types/genomic-profiles/package.json
@@ -37,7 +37,7 @@
     "d3-array": "^2.4.0",
     "higlass-no-github-deps": "1.11.13",
     "higlass-register": "^0.3.0",
-    "higlass-zarr-datafetchers": "0.3.0-next.2",
+    "higlass-zarr-datafetchers": "0.3.0-next.3",
     "lodash-es": "^4.17.21"
   },
   "devDependencies": {

--- a/packages/view-types/genomic-profiles/src/GenomicProfilesSubscriber.js
+++ b/packages/view-types/genomic-profiles/src/GenomicProfilesSubscriber.js
@@ -96,7 +96,10 @@ export function GenomicProfilesSubscriber(props) {
     coordinationScopes,
   );
 
-  const [genomicProfilesAttrs, genomicProfilesStatus, genomicProfilesUrls] = useGenomicProfilesData(
+  const [
+    genomicProfilesAttrs, genomicProfilesStatus,
+    genomicProfilesUrls, genomicProfilesRequestInit,
+  ] = useGenomicProfilesData(
     loaders, dataset, true, {}, {},
     {},
   );
@@ -190,9 +193,9 @@ export function GenomicProfilesSubscriber(props) {
       // Get the track UID as a string before passing to HiGlass.
       const trackUidString = isPath ? trackUid.join('__') : trackUid;
       // Get the requestInit object from the current loader, if it exists.
-      const currentLoader = loaders[dataset]?.loaders?.['genomic-profiles'].entries().next().value[1];
-      const requestInit = currentLoader?.requestInit;
-      const options = requestInit ? { overrides: requestInit } : undefined;
+      const options = genomicProfilesRequestInit
+        ? { overrides: genomicProfilesRequestInit }
+        : undefined;
       // Create the HiGlass track definition for this profile.
       const track = {
         type: 'horizontal-bar',

--- a/packages/view-types/genomic-profiles/src/GenomicProfilesSubscriber.js
+++ b/packages/view-types/genomic-profiles/src/GenomicProfilesSubscriber.js
@@ -189,6 +189,10 @@ export function GenomicProfilesSubscriber(props) {
       const setColor = isPath ? cellSetColor?.find(s => isEqual(s.path, trackUid))?.color : null;
       // Get the track UID as a string before passing to HiGlass.
       const trackUidString = isPath ? trackUid.join('__') : trackUid;
+      // Get the requestInit object from the current loader, if it exists.
+      const currentLoader = loaders[dataset]?.loaders?.['genomic-profiles'].entries().next().value[1];
+      const requestInit = currentLoader?.requestInit;
+      const options = requestInit ? {overrides: requestInit} : undefined;
       // Create the HiGlass track definition for this profile.
       const track = {
         type: 'horizontal-bar',
@@ -196,6 +200,7 @@ export function GenomicProfilesSubscriber(props) {
         data: {
           type: 'zarr-multivec',
           url,
+          options,
           row: i,
         },
         options: {

--- a/packages/view-types/genomic-profiles/src/GenomicProfilesSubscriber.js
+++ b/packages/view-types/genomic-profiles/src/GenomicProfilesSubscriber.js
@@ -192,7 +192,7 @@ export function GenomicProfilesSubscriber(props) {
       // Get the requestInit object from the current loader, if it exists.
       const currentLoader = loaders[dataset]?.loaders?.['genomic-profiles'].entries().next().value[1];
       const requestInit = currentLoader?.requestInit;
-      const options = requestInit ? {overrides: requestInit} : undefined;
+      const options = requestInit ? { overrides: requestInit } : undefined;
       // Create the HiGlass track definition for this profile.
       const track = {
         type: 'horizontal-bar',

--- a/packages/vit-s/src/data-hook-utils.js
+++ b/packages/vit-s/src/data-hook-utils.js
@@ -66,11 +66,11 @@ export async function dataQueryFn(ctx) {
     // TODO: can cacheing logic be removed from all loaders?
     const payload = await loader.load();
     if (!payload) return placeholderObject; // TODO: throw error instead?
-    const { data, url, coordinationValues } = payload;
+    const { data, url, requestInit, coordinationValues } = payload;
     // Status: success
     // Array of objects like  { url, name }.
     const urls = (Array.isArray(url) ? url : [{ url, name: dataType }]).filter(d => d.url);
-    return { data, coordinationValues, urls };
+    return { data, coordinationValues, urls, requestInit };
   }
   // No loader was found.
   if (isRequired) {
@@ -129,6 +129,8 @@ export function useDataType(
 
   const coordinationValues = data?.coordinationValues;
   const urls = data?.urls;
+  const requestInit = data?.requestInit;
+
 
   useEffect(() => {
     initCoordinationSpace(
@@ -145,7 +147,7 @@ export function useDataType(
   }, [error, setWarning]);
 
   const dataStatus = isFetching ? STATUS.LOADING : status;
-  return [loadedData, dataStatus, urls];
+  return [loadedData, dataStatus, urls, requestInit];
 }
 
 /**

--- a/packages/vit-s/src/data/LoaderResult.js
+++ b/packages/vit-s/src/data/LoaderResult.js
@@ -8,10 +8,12 @@ export default class LoaderResult {
    * @param {LoaderDataType} data
    * @param {object[]|string|null} url Single URL or array of { url, name } objects.
    * @param {object|null} coordinationValues
+   * @param {RequestInit|null} requestInit
    */
-  constructor(data, url, coordinationValues = null) {
+  constructor(data, url, coordinationValues = null, requestInit = null) {
     this.data = data;
     this.url = url;
     this.coordinationValues = coordinationValues;
+    this.requestInit = requestInit;
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1063,8 +1063,8 @@ importers:
         specifier: ^0.3.0
         version: 0.3.0
       higlass-zarr-datafetchers:
-        specifier: 0.3.0-next.2
-        version: 0.3.0-next.2
+        specifier: 0.3.0-next.3
+        version: 0.3.0-next.3
       lodash-es:
         specifier: ^4.17.21
         version: 4.17.21
@@ -16116,12 +16116,12 @@ packages:
     resolution: {integrity: sha512-D4I+ATxFuTn+Q6p8Y9rUa+X3b3cqMqhu9Tya6uHtvgV5cs39Mk7i6Z+7PMA8YuwQd5gLMSxCm2lCyWmxRVBQsQ==}
     dev: false
 
-  /higlass-zarr-datafetchers@0.3.0-next.2:
-    resolution: {integrity: sha512-04CACWOZOLSRzqtr8jHGPNccTvrVPXVc2IAbBDyQHsiEKHmtiDNCR+CY5me8DjLNwG3ET5PSnRGvNC5j1X2kwQ==}
+  /higlass-zarr-datafetchers@0.3.0-next.3:
+    resolution: {integrity: sha512-OKhf3a5IcSTvF1PmN6i5TQaNXDU9nlwzgDcErAU+QVqMBH+TIQYegxJiIgrMVfULt4kggPaM7LF5OgiQ2i27HQ==}
     dependencies:
       higlass-register: 0.3.0
       slugid: 3.2.0
-      zarrita: 0.4.0-next.4
+      zarrita: 0.4.0-next.10
     dev: false
 
   /history@4.10.1:
@@ -25245,14 +25245,6 @@ packages:
 
   /zarrita@0.4.0-next.10:
     resolution: {integrity: sha512-S9SODuy40xuv4jSYP0AtfdItWOetKTyEGGRCO0uv7NQ+JY66Q/k4kvGxuM040sxVIIboKkjuA7V+pT3uyPtgLA==}
-    dependencies:
-      '@zarrita/core': 0.1.0-next.8
-      '@zarrita/indexing': 0.1.0-next.10
-      '@zarrita/storage': 0.1.0-next.4
-    dev: false
-
-  /zarrita@0.4.0-next.4:
-    resolution: {integrity: sha512-IcSzNKUzkjFpFYozpjUsdK7nTjzGQbXJC0cSJj/uUxlv48dFRCc75UERblwRDi+BflcSBopWm3fY5V+ZgEjrZQ==}
     dependencies:
       '@zarrita/core': 0.1.0-next.8
       '@zarrita/indexing': 0.1.0-next.10


### PR DESCRIPTION
<!-- Credit (as a starting template): https://github.com/visgl/deck.gl/blob/master/.github/pull_request_template.md -->
<!-- For feature, feature enhancement or bug fix, create an issue first and finish To Do List there -->
<!-- Anything doesn't work as expected is a bug, including code, doc and test -->
Fixes #1593 
<!-- For other PRs without open issue -->
#### Background

The genomic profiles view failed to load data from sources which require an `Authorization` header; with this change, it is possible for the appropriate headers to be provided as part of a `requestInit` object like it is for other AnnData loaders.

#### Change List
- Bumped `higlass-zarr-datafetchers` to `0.3.0-next.3`
- Added `requestInit` support to the loader
#### Checklist
 - [x] Ensure PR works with all demos on the dev.vitessce.io homepage
 - [ ] Documentation added or updated