### PR TITLE
(fix): don't calculate statistics for masks

### DIFF
--- a/packages/file-types/zarr/src/ome-loaders/OmeZarrLoader.js
+++ b/packages/file-types/zarr/src/ome-loaders/OmeZarrLoader.js
@@ -149,8 +149,9 @@ export default class OmeZarrLoader extends AbstractTwoStepLoader {
             transform: {
               matrix: transformMatrix,
             },
+            isBitmask: isLabels
           },
-        } : {}),
+        } : { isBitmask: isLabels }),
         loaderCreator: async () => ({ ...loader, channels: channelLabels }),
       },
     ];


### PR DESCRIPTION
#### Background
Something I noticed while playing around is that we were calculating stats for masks as well.  So this PR should fix that.  I am open to other options for this!
#### Change List
- Add `isBitmask` argument to `initializeLayerChannels` to stop stats calculation
#### Checklist
 - [ ] Ensure PR works with all demos on the dev.vitessce.io homepage
 - [ ] Open (draft) PR's into [`vitessce-python`](https://github.com/vitessce/vitessce-python) and [`vitessce-r`](https://github.com/vitessce/vitessce-r) if this is a release PR
 - [ ] Documentation added or updated