### PR TITLE
Added ObsSets to tooltip for segmentations

### DIFF
--- a/.changeset/rare-mirrors-thank.md
+++ b/.changeset/rare-mirrors-thank.md
@@ -1,0 +1,5 @@
+---
+"@vitessce/spatial-beta": patch
+---
+
+Add obsSets to tooltip for Segmetations

--- a/packages/view-types/spatial-beta/src/SpatialSubscriber.js
+++ b/packages/view-types/spatial-beta/src/SpatialSubscriber.js
@@ -955,6 +955,7 @@ export function SpatialSubscriber(props) {
           segmentationLayerScopes={segmentationLayerScopes}
           segmentationChannelScopesByLayer={segmentationChannelScopesByLayer}
           segmentationChannelCoordination={segmentationChannelCoordination}
+          obsSegmentationsSetsData={obsSegmentationsSetsData}
 
           // Images
           imageLayerScopes={imageLayerScopes}

--- a/packages/view-types/spatial-beta/src/SpatialSubscriber.js
+++ b/packages/view-types/spatial-beta/src/SpatialSubscriber.js
@@ -670,9 +670,8 @@ export function SpatialSubscriber(props) {
             let obsId;
             if (layerType === 'segmentation-bitmask') {
               const { obsIndex } = segmentationMultiIndicesData?.[segmentationLayerScope]?.[channelScope] || {};
-              // We subtract one because we use 0 to represent background.
-              obsI -= 1;
               if (obsIndex && bitmaskValueIsIndex) {
+                obsI -= 1; // We subtract one because we use 0 to represent background.
                 obsId = obsIndex?.[obsI];
               } else {
                 // When there is not a corresponding obsIndex to use,


### PR DESCRIPTION
This PR adds obsSets to tooltip for segmentations in the SpatialLayoutBeta component.
Fixes part of 1685 (Towards #1685 (obsSets in tooltips))
<!-- For other PRs without open issue -->
#### Background
<!-- For all the PRs -->
#### Change List
-
#### Checklist
 - [ ] Have tested PR with one or more demo configurations
 - [ ] Documentation added, updated, or not applicable
