### PR TITLE
Fix spatialdata file options bug

### DIFF
--- a/.changeset/small-adults-collect.md
+++ b/.changeset/small-adults-collect.md
@@ -1,0 +1,6 @@
+---
+"@vitessce/constants-internal": patch
+"@vitessce/schemas": patch
+---
+
+Fix incorrect obsSets.spatialdata.zarr file definition schema. Add featureLabelsType coordination type.

--- a/examples/configs/src/view-configs/spatial-beta/codex.js
+++ b/examples/configs/src/view-configs/spatial-beta/codex.js
@@ -28,7 +28,14 @@ function generateCodexConfig() {
       offsetsUrl: 'https://assets.hubmapconsortium.org/8d86e6c899e80d0f5f95604eb4ad492e/output_offsets/pipeline_output/mask/reg001_mask.offsets.json?token=',
       // TODO: figure out why tooltips are not working with this.
       coordinateTransformations: [
-
+        {
+          type: 'scale',
+          // The mask does not specify PhysicalSizeX or PhysicalSizeY,
+          // but the image does (377.44nm x 377.44nm),
+          // so we need to scale the mask despite it having the same
+          // pixel dimensions as the image.
+          scale: [377.44 / 1000, 377.44 / 1000, 1, 1, 1],
+        },
       ],
     },
     coordinationValues: {

--- a/examples/configs/src/view-configs/spatial-beta/codex.js
+++ b/examples/configs/src/view-configs/spatial-beta/codex.js
@@ -28,14 +28,7 @@ function generateCodexConfig() {
       offsetsUrl: 'https://assets.hubmapconsortium.org/8d86e6c899e80d0f5f95604eb4ad492e/output_offsets/pipeline_output/mask/reg001_mask.offsets.json?token=',
       // TODO: figure out why tooltips are not working with this.
       coordinateTransformations: [
-        {
-          type: 'scale',
-          // The mask does not specify PhysicalSizeX or PhysicalSizeY,
-          // but the image does (377.44nm x 377.44nm),
-          // so we need to scale the mask despite it having the same
-          // pixel dimensions as the image.
-          scale: [377.44 / 1000, 377.44 / 1000, 1, 1, 1],
-        },
+
       ],
     },
     coordinationValues: {

--- a/packages/constants-internal/src/constants.ts
+++ b/packages/constants-internal/src/constants.ts
@@ -181,6 +181,7 @@ export const CoordinationType = {
   FEATURE_TYPE: 'featureType',
   FEATURE_VALUE_TYPE: 'featureValueType',
   OBS_LABELS_TYPE: 'obsLabelsType',
+  FEATURE_LABELS_TYPE: 'featureLabelsType',
   // Other types
   EMBEDDING_TYPE: 'embeddingType',
   EMBEDDING_ZOOM: 'embeddingZoom',

--- a/packages/file-types/zarr/src/spatialdata-loaders/SpatialDataObsSetsLoader.js
+++ b/packages/file-types/zarr/src/spatialdata-loaders/SpatialDataObsSetsLoader.js
@@ -7,6 +7,5 @@ export default class SpatialDataObsSetsLoader extends ObsSetsAnndataLoader {
   constructor(dataSource, params) {
     super(dataSource, params);
     this.region = this.options.region;
-    this.options = this.options.obsSets;
   }
 }

--- a/packages/main/all/src/base-plugins.ts
+++ b/packages/main/all/src/base-plugins.ts
@@ -330,6 +330,7 @@ export const baseCoordinationTypes = [
   new PluginCoordinationType(CoordinationType.FEATURE_TYPE, 'gene', z.string()),
   new PluginCoordinationType(CoordinationType.FEATURE_VALUE_TYPE, 'expression', z.string()),
   new PluginCoordinationType(CoordinationType.OBS_LABELS_TYPE, null, z.string().nullable()),
+  new PluginCoordinationType(CoordinationType.FEATURE_LABELS_TYPE, null, z.string().nullable()),
   new PluginCoordinationType(CoordinationType.EMBEDDING_ZOOM, null, z.number().nullable()),
   new PluginCoordinationType(CoordinationType.EMBEDDING_ROTATION, 0, z.number().nullable()),
   new PluginCoordinationType(CoordinationType.EMBEDDING_TARGET_X, null, z.number().nullable()),

--- a/packages/schemas/src/file-def-options.ts
+++ b/packages/schemas/src/file-def-options.ts
@@ -154,7 +154,7 @@ export const obsSetsSpatialdataSchema = z.object({
   tablePath: z.string()
     .optional()
     .describe('The path to a table which contains the index for the set values.'),
-  obsSets: annDataObsSets,
+  obsSets: annDataObsSetsArr,
 });
 
 // GLB


### PR DESCRIPTION
<!-- Credit (as a starting template): https://github.com/visgl/deck.gl/blob/master/.github/pull_request_template.md -->
<!-- For feature, feature enhancement or bug fix, create an issue first and finish To Do List there -->
<!-- Anything doesn't work as expected is a bug, including code, doc and test -->
Fixes #
<!-- For other PRs without open issue -->
#### Background

In https://github.com/vitessce/vitessce/pull/1811 I incorrectly used the object schema `{ obsSets: [] }`  instead of the array schema directly, causing the schema validation for spatialdata configs to fail. This PR fixes that issue

<!-- For all the PRs -->
#### Change List
-
#### Checklist
 - [ ] Have tested PR with one or more demo configurations
 - [ ] Documentation added, updated, or not applicable
