### PR TITLE
Fix tooltips in polygon segmentations for spatialBeta

### DIFF
--- a/.changeset/thick-tables-refuse.md
+++ b/.changeset/thick-tables-refuse.md
@@ -1,0 +1,5 @@
+---
+"@vitessce/spatial-beta": patch
+---
+
+Fix tooltips in spatialBeta polygon segmentation

--- a/packages/view-types/spatial-beta/src/SpatialSubscriber.js
+++ b/packages/view-types/spatial-beta/src/SpatialSubscriber.js
@@ -744,7 +744,7 @@ export function SpatialSubscriber(props) {
     // will not bubble up to the onHover callback of the DeckGL canvas."
     // Reference: https://deck.gl/docs/api-reference/core/layer#interaction-properties
     return false;
-  }, []);
+  }, [obsSegmentationsData]);
 
   const isSelectable = (
     spotLayerScopes.length > 0

--- a/packages/view-types/spatial-beta/src/SpatialSubscriber.js
+++ b/packages/view-types/spatial-beta/src/SpatialSubscriber.js
@@ -744,7 +744,7 @@ export function SpatialSubscriber(props) {
     // will not bubble up to the onHover callback of the DeckGL canvas."
     // Reference: https://deck.gl/docs/api-reference/core/layer#interaction-properties
     return false;
-  }, [obsSegmentationsData]);
+  }, [obsSegmentationsData, obsSpotsData, obsPointsData, segmentationMultiIndicesData]);
 
   const isSelectable = (
     spotLayerScopes.length > 0


### PR DESCRIPTION
Fixes #1965 

`obsSegmentationsData` was often turned `undefined` because it was not passed as a dependency to the `delegateHover` callback.

With this change, tooltips should appear whenever a cursor hovers a segmentation polygon in https://vitessce.io/#?dataset=codeluppi-2018-2.

#### Checklist
 - [x] Have tested PR with one or more demo configurations
 - [ ] Documentation added, updated, or not applicable
