### PR TITLE
Fix tooltips in segmentations without locations in spatial layer

### DIFF
--- a/packages/view-types/spatial/src/Spatial.js
+++ b/packages/view-types/spatial/src/Spatial.js
@@ -158,6 +158,7 @@ class Spatial extends AbstractSpatialOrScatterplot {
       cellSelection,
       setCellHighlight,
       setComponentHover,
+      setHoverInfo,
       getCellIsSelected = makeDefaultGetCellIsSelected(
         obsIndex.length === cellSelection.length ? null : cellSelection,
       ),
@@ -179,6 +180,14 @@ class Spatial extends AbstractSpatialOrScatterplot {
         const r = radius;
         return [[x, y + r], [x + r, y], [x, y - r], [x - r, y]];
       };
+
+    const onHoverCallback = (info) => {
+      const standardOnHoverCallback = getOnHoverCallback(obsIndex, setCellHighlight, setComponentHover);
+      const obsId = obsIndex[info.index];
+      setHoverInfo([obsId], [info.x, info.y]);
+      standardOnHoverCallback(info);
+    };
+
     return new deck.PolygonLayer({
       id: CELLS_LAYER_ID,
       data: this.obsSegmentationsData,
@@ -213,7 +222,7 @@ class Spatial extends AbstractSpatialOrScatterplot {
           onCellClick(info);
         }
       },
-      onHover: getOnHoverCallback(obsIndex, setCellHighlight, setComponentHover),
+      onHover: onHoverCallback,
       visible,
       getLineWidth: stroked ? 1 : 0,
       lineWidthScale,

--- a/packages/view-types/spatial/src/SpatialTooltipSubscriber.js
+++ b/packages/view-types/spatial/src/SpatialTooltipSubscriber.js
@@ -29,8 +29,7 @@ export default function SpatialTooltipSubscriber(props) {
     const obsId = getObsIdFromHoverData(hoverData);
     if (obsId) {
       [cellInfo, x, y] = [
-        getObsInfo(obsId),
-        ...(viewInfo && viewInfo.project ? viewInfo.project(hoverCoord) : [null, null]),
+        getObsInfo(obsId), ...hoverCoord,
       ];
     }
   } else if (!useHoverInfoForTooltip && getObsInfo && obsHighlight) {


### PR DESCRIPTION
Fixes #1981
<!-- For other PRs without open issue -->
#### Change List
- `packages/view-types/spatial/src/Spatial.js` was not calling `setHoverInfo`, so no information about the hovered obs or hovered coordinates was being stored or passed to `packages/view-types/spatial/src/SpatialTooltipSubscriber.js`
- `packages/view-types/spatial/src/SpatialTooltipSubscriber.js` was applying a transform to the raw x and y mouse coordinates that was causing it to appear in the wrong location.

#### Checklist
 - [X] Have tested PR with one or more demo configurations
 - [X] Documentation added, updated, or not applicable
