### PR TITLE
Fix #2028 - Tooltip issue with spatial beta

### DIFF
--- a/.changeset/lovely-papayas-shout.md
+++ b/.changeset/lovely-papayas-shout.md
@@ -1,0 +1,5 @@
+---
+"@vitessce/spatial-beta": patch
+---
+
+Fix bug where tooltips would not appear when mousing over the body of unfilled polygons/segments in spatial beta component.

--- a/packages/view-types/spatial-beta/src/Spatial.js
+++ b/packages/view-types/spatial-beta/src/Spatial.js
@@ -252,13 +252,21 @@ class Spatial extends AbstractSpatialOrScatterplot {
       coordinateSystem: deck.COORDINATE_SYSTEM.CARTESIAN,
       pickable: true,
       autoHighlight: AUTO_HIGHLIGHT,
-      filled: spatialSegmentationFilled,
+      filled: true,
       stroked: !spatialSegmentationFilled,
       backgroundColor: [0, 0, 0],
       // isSelected: getCellIsSelected,
       getPolygon,
-      getFillColor: isStaticColor ? staticColor : getCellColor,
-      getLineColor: isStaticColor ? staticColor : getCellColor,
+      getFillColor: (object, { index }) => {
+        const color = isStaticColor ? staticColor : getCellColor(object, { index });
+        color[3] = spatialSegmentationFilled ? opacity * 255 : 0;
+        return color;
+      },
+      getLineColor: (object, { index }) => {
+        const color = isStaticColor ? staticColor : getCellColor(object, { index });
+        color[3] = spatialSegmentationFilled ? 0 : opacity * 255;
+        return color;
+      },
       onClick: (info) => {
         /* if (onCellClick) {
           onCellClick(info);
@@ -277,8 +285,20 @@ class Spatial extends AbstractSpatialOrScatterplot {
       isExpressionMode: obsColorEncoding === 'geneSelection',
       colormap: featureValueColormap,
       updateTriggers: {
-        getFillColor: [obsColorEncoding, staticColor, layerColors],
-        getLineColor: [obsColorEncoding, staticColor, layerColors],
+        getFillColor: [
+          opacity,
+          spatialSegmentationFilled,
+          obsColorEncoding,
+          staticColor,
+          layerColors,
+        ],
+        getLineColor: [
+          opacity,
+          spatialSegmentationFilled,
+          obsColorEncoding,
+          staticColor,
+          layerColors,
+        ],
         /*
         getLineWidth: [stroked],
         isSelected: cellSelection,
@@ -668,7 +688,7 @@ class Spatial extends AbstractSpatialOrScatterplot {
       cellTexHeight: this.color.height,
       cellTexWidth: this.color.width,
       excludeBackground: true,
-      onViewportLoad: () => {}, // layerProps.callback, // TODO: figure out callback implementation
+      onViewportLoad: () => { }, // layerProps.callback, // TODO: figure out callback implementation
       colorScaleLo: 0, // TODO: check if these can be removed?
       colorScaleHi: 1, // TODO: check if these can be removed?
       isExpressionMode: false, // TODO: check if these can be removed?
@@ -800,7 +820,7 @@ class Spatial extends AbstractSpatialOrScatterplot {
       xSlice: layerCoordination[CoordinationType.SPATIAL_SLICE_X],
       ySlice: layerCoordination[CoordinationType.SPATIAL_SLICE_Y],
       zSlice: layerCoordination[CoordinationType.SPATIAL_SLICE_Z],
-      onViewportLoad: () => {}, // layerProps.callback, // TODO: figure out callback implementation
+      onViewportLoad: () => { }, // layerProps.callback, // TODO: figure out callback implementation
       excludeBackground: useTransparentColor,
       extensions,
       // Picking / onHover on the root DeckGL component


### PR DESCRIPTION
Fixes #2028

#### Change List
- Fixes bug where tooltips would not appear when mousing over the body of unfilled polygons/segments in a spatial beta component.

#### Checklist
 - [x] Have tested PR with one or more demo configurations
 - [x] Documentation added, updated, or not applicable
