### PR TITLE
Tkakar/fix 2111 spatialbeta fix transformations

### DIFF
--- a/.changeset/strange-experts-hunt.md
+++ b/.changeset/strange-experts-hunt.md
@@ -1,0 +1,5 @@
+---
+"@vitessce/spatial-utils": patch
+---
+
+Fixed transformation matrix for assuming xy having equal physical sizes

--- a/packages/utils/spatial-utils/src/spatial.js
+++ b/packages/utils/spatial-utils/src/spatial.js
@@ -95,10 +95,11 @@ export function physicalSizeToMatrix(xSize, ySize, zSize, xUnit, yUnit, zUnit) {
 
   // TODO: is this still needed
   // sizes are special objects with own equals method - see `unit` in declaration
-  if (!sizes[0].equals(sizes[1])) {
-    // Handle scaling in the Y direction for non-square pixels
-    scale[1] = divide(sizes[1], sizes[0]);
-  }
+  // This messess the dimensions when the x & y are little different (e.g., for the geomx data)
+  // if (!sizes[0].equals(sizes[1])) {
+  //   // Handle scaling in the Y direction for non-square pixels
+  //   scale[1] = divide(sizes[1], sizes[0]);
+  // }
   // END TODO: is this still needed
 
   // Add in z dimension needed for Matrix4 scale API.
@@ -444,11 +445,19 @@ export function coordinateTransformationsToMatrix(coordinateTransformations, axe
             ? axisOrderedScale[axisIndex]
             : defaultValue
         ));
+        // console.log(xyzScale, xyzIndices)
         const nextMat = (new Matrix4()).scale(xyzScale);
         mat = mat.multiplyLeft(nextMat);
+        console.log('Applying', transform, '->', nextMat.elements, axes, mat);
       }
     });
   }
+  // return [
+  //   5, 0, 0, 0,
+  //   0, 1, 0, 0,
+  //   0, 0, 1, 0,
+  //   0, 0, 0, 1
+  // ]
   return mat;
 }
 

--- a/packages/utils/spatial-utils/src/spatial.js
+++ b/packages/utils/spatial-utils/src/spatial.js
@@ -445,19 +445,11 @@ export function coordinateTransformationsToMatrix(coordinateTransformations, axe
             ? axisOrderedScale[axisIndex]
             : defaultValue
         ));
-        // console.log(xyzScale, xyzIndices)
         const nextMat = (new Matrix4()).scale(xyzScale);
         mat = mat.multiplyLeft(nextMat);
-        console.log('Applying', transform, '->', nextMat.elements, axes, mat);
       }
     });
   }
-  // return [
-  //   5, 0, 0, 0,
-  //   0, 1, 0, 0,
-  //   0, 0, 1, 0,
-  //   0, 0, 0, 1
-  // ]
   return mat;
 }
 


### PR DESCRIPTION
This PR fixes the `CoordinateTransformation` matrix that was normalizing the yScale if the x and y physicalSizes did not match (which is possible for some images).
Fixes #2111
<!-- For other PRs without open issue -->
#### Background
<!-- For all the PRs -->
#### Change List
-
#### Checklist
 - [ ] Have tested PR with one or more demo configurations
 - [ ] Documentation added, updated, or not applicable
