### PR TITLE
ci: exclude changes to markdown from triggering full test suite

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -4,6 +4,8 @@ on:
   push:
     branches:
     - main
+    paths-ignore:
+    - '**/*.md'
   pull_request:
 
 jobs:


### PR DESCRIPTION
<!-- For other PRs without open issue -->
#### Background
Currently, the `Test (monorepo)` CI workflow will run even when a push changes **only markdown files** (e.g., README.md).

With these changes, a push that changes *only* markdown files will not trigger the workflow, thus **speeding up the project's CI** and **saving compute resources** 🌱 (see below for quantity).

###### Example
Here is an example of the behaviour described above: the commit [`308aa92`](https://github.com/vitessce/vitessce/commit/308aa920892c5a4eb32190519f3d06f2062b0a95) changed these files: `.changeset/brave-needles-lie.md`, `sites/docs/docs/js-react-vitessce.md` and, when pushed, triggered [this](https://github.com/vitessce/vitessce/actions/runs/13555395444) workflow run, which ran for ~1 CPU hours. With the proposed changes, these 1 CPU hours would have been saved, clearing the queue for other workflows and speeding up the CI of the project, while also saving resources in general. 

Note that this is a single example out of 4 examples over the last few months; a lower estimate for the accumulated gain is **5 CPU hours**, but the actual number could be higher because our cutoff date is late May and our data go only a few months back.

This only affects the `push` trigger and not the `pull_request` trigger, so the actions related to pull requests (opening, pushing new commits on an open PR, closing) will not be affected, only the pushes to branches which do not have an open pull request.

<details>
<summary>Click here to see all the recent CI runs triggered by markdown files.</summary>

[commit 308aa92](https://github.com/vitessce/vitessce/commit/308aa92) => [run url](https://github.com/vitessce/vitessce/actions/runs/13555395444)
[commit a710f62](https://github.com/vitessce/vitessce/commit/a710f62) => [run url](https://github.com/vitessce/vitessce/actions/runs/10079512626)
[commit 6e85820](https://github.com/vitessce/vitessce/commit/6e85820) => [run url](https://github.com/vitessce/vitessce/actions/runs/10151422659)
[commit d1eda18](https://github.com/vitessce/vitessce/commit/d1eda18) => [run url](https://github.com/vitessce/vitessce/actions/runs/14248539134)

</details>

#### Additional Context
Hi,

We are a team of [researchers](https://www.ifi.uzh.ch/en/zest.html) from University of Zurich and we are currently working on optimizations in GitHub Actions workflows.

Thanks for your time on this.

Kindly let us know (here or in the email below) if you would like to ignore other file types or apply the filter to other workflows/triggers, or if you have any question whatsoever.

Best regards,  
[Konstantinos Kitsios](https://www.ifi.uzh.ch/en/zest/team/konstantinos_kitsios.html)  
konstantinos.kitsios@uzh.ch

<!-- For all the PRs -->
#### Change List
- commits that change exclusively markdown files will not trigger the full test suite now

#### Checklist
 - [ ] Have tested PR with one or more demo configurations
 - [x] Documentation added, updated, or not applicable
