### PR TITLE
Fix DataSource class name bug

### DIFF
--- a/.changeset/mean-dryers-protect.md
+++ b/.changeset/mean-dryers-protect.md
@@ -1,0 +1,5 @@
+---
+"@vitessce/vit-s": patch
+---
+
+Fixes a bug in which DataSource classes were not selected correctly following JS bundle minification, as the class names were being mapped to conflicting minified strings.

--- a/packages/vit-s/src/vitessce-grid-utils.js
+++ b/packages/vit-s/src/vitessce-grid-utils.js
@@ -129,6 +129,10 @@ export function createLoaders(datasets, configDescription, fileTypes, coordinati
   const defaultCoordinationValues = Object.fromEntries(
     coordinationTypes.map(ct => ([ct.name, ct.defaultValue])),
   );
+  // Create an array of unique data source classes.
+  // This is used to get a unique index for each data source class,
+  // which is used below to construct `dataSourceKey`s.
+  const dataSourceClasses = Array.from(new Set(fileTypes.map(ft => ft.dataSourceClass)));
   datasets.forEach((dataset) => {
     const datasetLoaders = {
       name: dataset.name,
@@ -155,10 +159,11 @@ export function createLoaders(datasets, configDescription, fileTypes, coordinati
       // Create _one_ DataSourceClass instance per (URL, DataSource class name) pair.
       // Derived loaders share this object.
       const fileId = url || JSON.stringify(options);
-      // The class name might be minified but that should not matter;
-      // we just need a string that is unique to the class for the key.
-      const dataSourceName = DataSourceClass.prototype.constructor.name;
-      const dataSourceKey = [fileId, dataSourceName];
+      // The DataSourceClass class name might be minified, so
+      // DataSourceClass.prototype.constructor.name
+      // will not work, as it can result in conflicting strings.
+      const dataSourceIndex = dataSourceClasses.indexOf(DataSourceClass);
+      const dataSourceKey = [fileId, dataSourceIndex];
       if (!dataSources.has(dataSourceKey)) {
         dataSources.set(dataSourceKey, new DataSourceClass({
           url,


### PR DESCRIPTION
<!-- Credit (as a starting template): https://github.com/visgl/deck.gl/blob/master/.github/pull_request_template.md -->
<!-- For feature, feature enhancement or bug fix, create an issue first and finish To Do List there -->
<!-- Anything doesn't work as expected is a bug, including code, doc and test -->

This PR fixes a bug that i was encountering only on the production vitessce.io docs site.
It was due to the JS minification affecting the `DataSourceClass.prototype.constructor.name` strings, resulting in conflicting strings. These conflicting strings resulted in the wrong DataSourceClass being assigned to DataLoaders, causing errors such as methods not being found.

<!-- For other PRs without open issue -->
#### Background
<!-- For all the PRs -->
#### Change List
-
#### Checklist
 - [ ] Have tested PR with one or more demo configurations
 - [ ] Documentation added, updated, or not applicable
