### PR TITLE
Meta-coordination for all views

### DIFF
--- a/.changeset/empty-rocks-whisper.md
+++ b/.changeset/empty-rocks-whisper.md
@@ -1,0 +1,15 @@
+---
+"@vitessce/scatterplot-embedding": patch
+"@vitessce/scatterplot-gating": patch
+"@vitessce/statistical-plots": patch
+"@vitessce/biomarker-select": patch
+"@vitessce/genomic-profiles": patch
+"@vitessce/obs-sets-manager": patch
+"@vitessce/feature-list": patch
+"@vitessce/neuroglancer": patch
+"@vitessce/description": patch
+"@vitessce/heatmap": patch
+"@vitessce/status": patch
+---
+
+Implement meta-coordination in all views.

--- a/examples/configs/src/view-configs/spatial-beta/spatialdata-visium_io.js
+++ b/examples/configs/src/view-configs/spatial-beta/spatialdata-visium_io.js
@@ -88,7 +88,10 @@ function generateVisiumIoConfig() {
     }),
   }, { scopePrefix: getInitialCoordinationScopePrefix('A', 'image') });
 
-  config.linkViews([featureList, heatmap, obsSets, spatialView, lcView], ['obsType', 'obsSetExpansion'], ['spot', [['Region']]]);
+  config.linkViewsByObject([featureList, heatmap, obsSets, spatialView, lcView], {
+    obsType: 'spot',
+    obsSetExpansion: [['Region']],
+  });
 
   featureList.useCoordination(featureSelectionScope);
   heatmap.useCoordination(featureSelectionScope);

--- a/packages/view-types/biomarker-select/src/BiomarkerSelectSubscriber.js
+++ b/packages/view-types/biomarker-select/src/BiomarkerSelectSubscriber.js
@@ -11,6 +11,7 @@ import {
   useComparisonMetadata,
   useMatchingLoader,
   useColumnNameMapping,
+  useCoordinationScopes,
 } from '@vitessce/vit-s';
 import { AsyncFunctionType, ViewType, COMPONENT_COORDINATION_TYPES, DataType } from '@vitessce/constants-internal';
 import { ScmdUi } from './scmd-ui.js';
@@ -23,11 +24,12 @@ import { ScmdUi } from './scmd-ui.js';
  */
 export function BiomarkerSelectSubscriber(props) {
   const {
-    coordinationScopes,
+    coordinationScopes: coordinationScopesRaw,
     stratificationOptions: stratificationOptionsProp, // TODO: Remove; Get from comparisonMetadata instead
   } = props;
 
   const loaders = useLoaders();
+  const coordinationScopes = useCoordinationScopes(coordinationScopesRaw);
 
   const [{
     dataset,

--- a/packages/view-types/biomarker-select/src/ComparativeHeadingSubscriber.js
+++ b/packages/view-types/biomarker-select/src/ComparativeHeadingSubscriber.js
@@ -1,6 +1,7 @@
 import React, { useCallback } from 'react';
 import {
   useCoordination,
+  useCoordinationScopes,
 } from '@vitessce/vit-s';
 import { ViewType, COMPONENT_COORDINATION_TYPES } from '@vitessce/constants-internal';
 import { makeStyles } from '@vitessce/styles';
@@ -38,8 +39,10 @@ const useStyles = makeStyles()(theme => ({
 
 export function ComparativeHeadingSubscriber(props) {
   const {
-    coordinationScopes,
+    coordinationScopes: coordinationScopesRaw,
   } = props;
+
+  const coordinationScopes = useCoordinationScopes(coordinationScopesRaw);
 
   const [{
     sampleSetSelection,

--- a/packages/view-types/biomarker-select/src/SampleSetPairManagerSubscriber.js
+++ b/packages/view-types/biomarker-select/src/SampleSetPairManagerSubscriber.js
@@ -10,6 +10,7 @@ import {
   useComparisonMetadata,
   useMatchingLoader,
   useColumnNameMapping,
+  useCoordinationScopes,
 } from '@vitessce/vit-s';
 import { ViewType, DataType, COMPONENT_COORDINATION_TYPES, ViewHelpMapping } from '@vitessce/constants-internal';
 
@@ -29,7 +30,7 @@ const useStyles = makeStyles()(() => ({
 
 export function SampleSetPairManagerSubscriber(props) {
   const {
-    coordinationScopes,
+    coordinationScopes: coordinationScopesRaw,
     removeGridComponent,
     theme,
     title = 'Sample Sets',
@@ -39,6 +40,7 @@ export function SampleSetPairManagerSubscriber(props) {
 
   const { classes } = useStyles();
   const loaders = useLoaders();
+  const coordinationScopes = useCoordinationScopes(coordinationScopesRaw);
 
   // Get "props" from the coordination space.
   const [{

--- a/packages/view-types/description/src/DescriptionSubscriber.js
+++ b/packages/view-types/description/src/DescriptionSubscriber.js
@@ -4,6 +4,7 @@ import {
   useReady,
   useCoordination, useLoaders,
   useDescription, useImageData,
+  useCoordinationScopes,
 } from '@vitessce/vit-s';
 import { ViewType, COMPONENT_COORDINATION_TYPES, ViewHelpMapping } from '@vitessce/constants-internal';
 import Description from './Description.js';
@@ -21,7 +22,7 @@ import Description from './Description.js';
  */
 export function DescriptionSubscriber(props) {
   const {
-    coordinationScopes,
+    coordinationScopes: coordinationScopesRaw,
     description: descriptionOverride,
     descriptionType,
     removeGridComponent,
@@ -32,6 +33,7 @@ export function DescriptionSubscriber(props) {
   } = props;
 
   const loaders = useLoaders();
+  const coordinationScopes = useCoordinationScopes(coordinationScopesRaw);
 
   // Get "props" from the coordination space.
   const [{

--- a/packages/view-types/feature-list/src/FeatureList.js
+++ b/packages/view-types/feature-list/src/FeatureList.js
@@ -114,7 +114,7 @@ export default function FeatureList(props) {
     ];
   }, [showFeatureTable, primaryColumnName, hasFeatureLabels]);
 
-  return (
+  return (width > 0 && height > 0) ? (
     <>
       <input
         className={classes.searchBar}
@@ -138,5 +138,5 @@ export default function FeatureList(props) {
         height={height - 34}
       />
     </>
-  );
+  ) : null;
 }

--- a/packages/view-types/feature-list/src/FeatureListSubscriber.js
+++ b/packages/view-types/feature-list/src/FeatureListSubscriber.js
@@ -6,6 +6,7 @@ import {
   useFeatureLabelsData, useObsFeatureMatrixIndices,
   useCoordination, useLoaders,
   useExpandedFeatureLabelsMap,
+  useCoordinationScopes,
 } from '@vitessce/vit-s';
 import { ViewType, COMPONENT_COORDINATION_TYPES, ViewHelpMapping } from '@vitessce/constants-internal';
 import { makeStyles } from '@vitessce/styles';
@@ -47,7 +48,7 @@ const useStyles = makeStyles()(theme => ({
  */
 export function FeatureListSubscriber(props) {
   const {
-    coordinationScopes,
+    coordinationScopes: coordinationScopesRaw,
     removeGridComponent,
     variablesLabelOverride,
     theme,
@@ -62,6 +63,7 @@ export function FeatureListSubscriber(props) {
   } = props;
 
   const loaders = useLoaders();
+  const coordinationScopes = useCoordinationScopes(coordinationScopesRaw);
   const [width, height, containerRef] = useGridItemSize();
   const { classes } = useStyles();
 

--- a/packages/view-types/genomic-profiles/src/GenomicProfilesSubscriber.js
+++ b/packages/view-types/genomic-profiles/src/GenomicProfilesSubscriber.js
@@ -7,6 +7,7 @@ import {
   useReady, useUrls, useGridItemSize,
   useCoordination, useLoaders,
   useGenomicProfilesData,
+  useCoordinationScopes,
 } from '@vitessce/vit-s';
 import { ViewType, COMPONENT_COORDINATION_TYPES, ViewHelpMapping } from '@vitessce/constants-internal';
 import HiGlassLazy, { setStoreRootForHiGlass } from './HiGlassLazy.js';
@@ -69,7 +70,7 @@ const REFERENCE_STATIC_FILES = {
  */
 export function GenomicProfilesSubscriber(props) {
   const {
-    coordinationScopes,
+    coordinationScopes: coordinationScopesRaw,
     theme,
     closeButtonVisible,
     downloadButtonVisible,
@@ -86,6 +87,7 @@ export function GenomicProfilesSubscriber(props) {
   // eslint-disable-next-line no-unused-vars
   const [width, height, containerRef] = useGridItemSize();
   const loaders = useLoaders();
+  const coordinationScopes = useCoordinationScopes(coordinationScopesRaw);
 
   // Get "props" from the coordination space.
   const [{

--- a/packages/view-types/genomic-profiles/src/HiGlassLazy.js
+++ b/packages/view-types/genomic-profiles/src/HiGlassLazy.js
@@ -3,7 +3,11 @@ import React, {
 } from 'react';
 import register from 'higlass-register';
 import { ZarrMultivecDataFetcher } from 'higlass-zarr-datafetchers';
-import { useGridItemSize, useCoordination } from '@vitessce/vit-s';
+import {
+  useGridItemSize,
+  useCoordination,
+  useCoordinationScopes,
+} from '@vitessce/vit-s';
 import { COMPONENT_COORDINATION_TYPES } from '@vitessce/constants-internal';
 import { useStyles } from './styles.js';
 
@@ -47,13 +51,15 @@ export function setStoreRootForHiGlass(url, storeRoot) {
    */
 export default function HiGlassLazy(props) {
   const {
-    coordinationScopes,
+    coordinationScopes: coordinationScopesRaw,
     theme,
     hgViewConfig: hgViewConfigProp,
     hgOptions: hgOptionsProp,
     genomeSize = 3100000000,
     height,
   } = props;
+
+  const coordinationScopes = useCoordinationScopes(coordinationScopesRaw);
 
   // Get "props" from the coordination space.
   const [{

--- a/packages/view-types/heatmap/src/HeatmapSubscriber.js
+++ b/packages/view-types/heatmap/src/HeatmapSubscriber.js
@@ -16,6 +16,7 @@ import {
   useCoordination, useLoaders,
   useSetComponentHover, useSetComponentViewInfo,
   useExpandedFeatureLabelsMap,
+  useCoordinationScopes,
 } from '@vitessce/vit-s';
 import { pluralize as plur, capitalize, commaNumber, cleanFeatureId } from '@vitessce/utils';
 import { mergeObsSets, findLongestCommonPath, getCellColors } from '@vitessce/sets-utils';
@@ -40,7 +41,7 @@ import HeatmapOptions from './HeatmapOptions.js';
 export function HeatmapSubscriber(props) {
   const {
     uuid,
-    coordinationScopes,
+    coordinationScopes: coordinationScopesRaw,
     closeButtonVisible,
     downloadButtonVisible,
     removeGridComponent,
@@ -53,6 +54,7 @@ export function HeatmapSubscriber(props) {
   } = props;
 
   const loaders = useLoaders();
+  const coordinationScopes = useCoordinationScopes(coordinationScopesRaw);
   const setComponentHover = useSetComponentHover();
   const setComponentViewInfo = useSetComponentViewInfo(uuid);
 

--- a/packages/view-types/neuroglancer/src/NeuroglancerSubscriber.js
+++ b/packages/view-types/neuroglancer/src/NeuroglancerSubscriber.js
@@ -6,6 +6,7 @@ import {
   useObsSetsData,
   useLoaders,
   useObsEmbeddingData,
+  useCoordinationScopes,
 } from '@vitessce/vit-s';
 import {
   ViewHelpMapping,
@@ -64,7 +65,7 @@ function normalizeQuaternion(q) {
 
 export function NeuroglancerSubscriber(props) {
   const {
-    coordinationScopes,
+    coordinationScopes: coordinationScopesRaw,
     closeButtonVisible,
     downloadButtonVisible,
     removeGridComponent,
@@ -107,6 +108,7 @@ export function NeuroglancerSubscriber(props) {
 
   const { classes } = useStyles();
   const loaders = useLoaders();
+  const coordinationScopes = useCoordinationScopes(coordinationScopesRaw);
 
   const [{ obsSets: cellSets }] = useObsSetsData(
     loaders, dataset, false,

--- a/packages/view-types/neuroglancer/src/NeuroglancerSubscriber.js
+++ b/packages/view-types/neuroglancer/src/NeuroglancerSubscriber.js
@@ -75,6 +75,9 @@ export function NeuroglancerSubscriber(props) {
     viewerState: initialViewerState,
   } = props;
 
+  const loaders = useLoaders();
+  const coordinationScopes = useCoordinationScopes(coordinationScopesRaw);
+
   const [{
     dataset,
     obsType,
@@ -107,8 +110,6 @@ export function NeuroglancerSubscriber(props) {
   }] = useCoordination(COMPONENT_COORDINATION_TYPES[ViewType.NEUROGLANCER], coordinationScopes);
 
   const { classes } = useStyles();
-  const loaders = useLoaders();
-  const coordinationScopes = useCoordinationScopes(coordinationScopesRaw);
 
   const [{ obsSets: cellSets }] = useObsSetsData(
     loaders, dataset, false,

--- a/packages/view-types/obs-sets-manager/src/ObsSetsManagerSubscriber.js
+++ b/packages/view-types/obs-sets-manager/src/ObsSetsManagerSubscriber.js
@@ -11,6 +11,7 @@ import {
   TitleInfo,
   useUrls, useReady,
   useObsSetsData,
+  useCoordinationScopes,
 } from '@vitessce/vit-s';
 import { COMPONENT_COORDINATION_TYPES, ViewType, ViewHelpMapping } from '@vitessce/constants-internal';
 import {
@@ -68,7 +69,7 @@ const packageJson = { name: 'vitessce' };
  */
 export function ObsSetsManagerSubscriber(props) {
   const {
-    coordinationScopes,
+    coordinationScopes: coordinationScopesRaw,
     closeButtonVisible,
     downloadButtonVisible,
     removeGridComponent,
@@ -78,6 +79,7 @@ export function ObsSetsManagerSubscriber(props) {
   } = props;
 
   const loaders = useLoaders();
+  const coordinationScopes = useCoordinationScopes(coordinationScopesRaw);
   const setWarning = useSetWarning();
 
   // Get "props" from the coordination space.

--- a/packages/view-types/scatterplot-embedding/src/DualEmbeddingScatterplotSubscriber.js
+++ b/packages/view-types/scatterplot-embedding/src/DualEmbeddingScatterplotSubscriber.js
@@ -1,6 +1,7 @@
 import React, { useMemo } from 'react';
 import {
   useCoordination,
+  useCoordinationScopes,
 } from '@vitessce/vit-s';
 import { ViewType, COMPONENT_COORDINATION_TYPES } from '@vitessce/constants-internal';
 import { EmbeddingScatterplotSubscriber } from './EmbeddingScatterplotSubscriber.js';
@@ -25,8 +26,10 @@ import { EmbeddingScatterplotSubscriber } from './EmbeddingScatterplotSubscriber
 export function DualEmbeddingScatterplotSubscriber(props) {
   const {
     uuid,
-    coordinationScopes,
+    coordinationScopes: coordinationScopesRaw,
   } = props;
+
+  const coordinationScopes = useCoordinationScopes(coordinationScopesRaw);
 
   // Get "props" from the coordination space.
   const [{

--- a/packages/view-types/scatterplot-embedding/src/EmbeddingScatterplotSubscriber.js
+++ b/packages/view-types/scatterplot-embedding/src/EmbeddingScatterplotSubscriber.js
@@ -25,6 +25,7 @@ import {
   useSetComponentViewInfo,
   useInitialCoordination,
   useExpandedFeatureLabelsMap,
+  useCoordinationScopes,
 } from '@vitessce/vit-s';
 import {
   setObsSelection, mergeObsSets, getCellSetPolygons, getCellColors,
@@ -58,7 +59,7 @@ const DEFAULT_FEATURE_AGGREGATION_STRATEGY = 'first';
 export function EmbeddingScatterplotSubscriber(props) {
   const {
     uuid,
-    coordinationScopes,
+    coordinationScopes: coordinationScopesRaw,
     closeButtonVisible,
     downloadButtonVisible,
     removeGridComponent,
@@ -74,6 +75,7 @@ export function EmbeddingScatterplotSubscriber(props) {
   } = props;
 
   const loaders = useLoaders();
+  const coordinationScopes = useCoordinationScopes(coordinationScopesRaw);
   const setComponentHover = useSetComponentHover();
   const setComponentViewInfo = useSetComponentViewInfo(uuid);
 

--- a/packages/view-types/scatterplot-gating/src/GatingSubscriber.js
+++ b/packages/view-types/scatterplot-gating/src/GatingSubscriber.js
@@ -20,6 +20,7 @@ import {
   useLoaders,
   useSetComponentHover,
   useSetComponentViewInfo,
+  useCoordinationScopes,
 } from '@vitessce/vit-s';
 import {
   getCellSetPolygons, mergeObsSets, setObsSelection, getCellColors,
@@ -49,7 +50,7 @@ import GatingScatterplotOptions from './GatingScatterplotOptions.js';
 export function GatingSubscriber(props) {
   const {
     uuid,
-    coordinationScopes,
+    coordinationScopes: coordinationScopesRaw,
     closeButtonVisible,
     downloadButtonVisible,
     removeGridComponent,
@@ -62,6 +63,7 @@ export function GatingSubscriber(props) {
   } = props;
 
   const loaders = useLoaders();
+  const coordinationScopes = useCoordinationScopes(coordinationScopesRaw);
   const setComponentHover = useSetComponentHover();
   const setComponentViewInfo = useSetComponentViewInfo(uuid);
 

--- a/packages/view-types/statistical-plots/src/CellSetCompositionBarPlotSubscriber.js
+++ b/packages/view-types/statistical-plots/src/CellSetCompositionBarPlotSubscriber.js
@@ -9,6 +9,7 @@ import {
   useObsSetStatsData,
   useMatchingLoader,
   useColumnNameMapping,
+  useCoordinationScopes,
 } from '@vitessce/vit-s';
 import {
   ViewType,
@@ -24,7 +25,7 @@ import { useRawSetPaths } from './utils.js';
 
 export function CellSetCompositionBarPlotSubscriber(props) {
   const {
-    coordinationScopes,
+    coordinationScopes: coordinationScopesRaw,
     removeGridComponent,
     theme,
     helpText = ViewHelpMapping.OBS_SET_COMPOSITION_BAR_PLOT,
@@ -32,6 +33,7 @@ export function CellSetCompositionBarPlotSubscriber(props) {
 
   const { classes } = useStyles();
   const loaders = useLoaders();
+  const coordinationScopes = useCoordinationScopes(coordinationScopesRaw);
 
   // Get "props" from the coordination space.
   const [{

--- a/packages/view-types/statistical-plots/src/CellSetExpressionPlotSubscriber.js
+++ b/packages/view-types/statistical-plots/src/CellSetExpressionPlotSubscriber.js
@@ -9,6 +9,7 @@ import {
   useSampleSetsData,
   useSampleEdgesData,
   useExpandedFeatureLabelsMap,
+  useCoordinationScopes,
 } from '@vitessce/vit-s';
 import { ViewType, COMPONENT_COORDINATION_TYPES, ViewHelpMapping } from '@vitessce/constants-internal';
 import { VALUE_TRANSFORM_OPTIONS, capitalize, cleanFeatureId } from '@vitessce/utils';
@@ -132,7 +133,7 @@ function useExpressionByCellSet(
  */
 export function CellSetExpressionPlotSubscriber(props) {
   const {
-    coordinationScopes,
+    coordinationScopes: coordinationScopesRaw,
     closeButtonVisible,
     downloadButtonVisible,
     removeGridComponent,
@@ -147,6 +148,7 @@ export function CellSetExpressionPlotSubscriber(props) {
 
   const { classes } = useStyles();
   const loaders = useLoaders();
+  const coordinationScopes = useCoordinationScopes(coordinationScopesRaw);
 
   // Get "props" from the coordination space.
   const [{

--- a/packages/view-types/statistical-plots/src/CellSetSizesPlotSubscriber.js
+++ b/packages/view-types/statistical-plots/src/CellSetSizesPlotSubscriber.js
@@ -4,6 +4,7 @@ import {
   useCoordination, useLoaders,
   useUrls, useReady, useGridItemSize,
   useObsSetsData,
+  useCoordinationScopes,
 } from '@vitessce/vit-s';
 import { isEqual } from 'lodash-es';
 import { ViewType, COMPONENT_COORDINATION_TYPES, ViewHelpMapping } from '@vitessce/constants-internal';
@@ -27,7 +28,7 @@ import { useStyles } from './styles.js';
  */
 export function CellSetSizesPlotSubscriber(props) {
   const {
-    coordinationScopes,
+    coordinationScopes: coordinationScopesRaw,
     closeButtonVisible,
     downloadButtonVisible,
     removeGridComponent,
@@ -39,6 +40,7 @@ export function CellSetSizesPlotSubscriber(props) {
   const { classes } = useStyles();
 
   const loaders = useLoaders();
+  const coordinationScopes = useCoordinationScopes(coordinationScopesRaw);
 
   // Get "props" from the coordination space.
   const [{

--- a/packages/view-types/statistical-plots/src/DotPlotSubscriber.js
+++ b/packages/view-types/statistical-plots/src/DotPlotSubscriber.js
@@ -8,6 +8,7 @@ import {
   useFeatureLabelsData,
   useSampleSetsData,
   useSampleEdgesData,
+  useCoordinationScopes,
 } from '@vitessce/vit-s';
 import { ViewType, COMPONENT_COORDINATION_TYPES, ViewHelpMapping } from '@vitessce/constants-internal';
 import { VALUE_TRANSFORM_OPTIONS } from '@vitessce/utils';
@@ -27,7 +28,7 @@ import { useExpressionSummaries } from './dot-plot-hook.js';
  */
 export function DotPlotSubscriber(props) {
   const {
-    coordinationScopes,
+    coordinationScopes: coordinationScopesRaw,
     removeGridComponent,
     theme,
     title = 'Dot Plot',
@@ -37,6 +38,7 @@ export function DotPlotSubscriber(props) {
 
   const { classes } = useStyles();
   const loaders = useLoaders();
+  const coordinationScopes = useCoordinationScopes(coordinationScopesRaw);
 
   // Get "props" from the coordination space.
   const [{

--- a/packages/view-types/statistical-plots/src/ExpressionHistogramSubscriber.js
+++ b/packages/view-types/statistical-plots/src/ExpressionHistogramSubscriber.js
@@ -7,6 +7,7 @@ import {
   useCoordination, useLoaders,
   useUrls, useReady, useGridItemSize,
   useObsFeatureMatrixData, useFeatureSelection,
+  useCoordinationScopes,
 } from '@vitessce/vit-s';
 import { ViewType, COMPONENT_COORDINATION_TYPES, ViewHelpMapping } from '@vitessce/constants-internal';
 import { setObsSelection, getObsInfoFromDataWithinRange } from '@vitessce/sets-utils';
@@ -24,7 +25,7 @@ import { useStyles } from './styles.js';
  */
 export function ExpressionHistogramSubscriber(props) {
   const {
-    coordinationScopes,
+    coordinationScopes: coordinationScopesRaw,
     closeButtonVisible,
     downloadButtonVisible,
     removeGridComponent,
@@ -34,6 +35,7 @@ export function ExpressionHistogramSubscriber(props) {
 
   const { classes } = useStyles();
   const loaders = useLoaders();
+  const coordinationScopes = useCoordinationScopes(coordinationScopesRaw);
 
   // Get "props" from the coordination space.
   const [{

--- a/packages/view-types/statistical-plots/src/FeatureBarPlotSubscriber.js
+++ b/packages/view-types/statistical-plots/src/FeatureBarPlotSubscriber.js
@@ -9,6 +9,7 @@ import {
   useFeatureSelection,
   useObsFeatureMatrixIndices,
   useFeatureLabelsData,
+  useCoordinationScopes,
 } from '@vitessce/vit-s';
 import { ViewType, COMPONENT_COORDINATION_TYPES, ViewHelpMapping } from '@vitessce/constants-internal';
 import { setObsSelection } from '@vitessce/sets-utils';
@@ -18,7 +19,7 @@ import { useStyles } from './styles.js';
 
 export function FeatureBarPlotSubscriber(props) {
   const {
-    coordinationScopes,
+    coordinationScopes: coordinationScopesRaw,
     removeGridComponent,
     theme,
     yMin = 0,
@@ -28,6 +29,7 @@ export function FeatureBarPlotSubscriber(props) {
 
   const { classes } = useStyles();
   const loaders = useLoaders();
+  const coordinationScopes = useCoordinationScopes(coordinationScopesRaw);
 
   // Get "props" from the coordination space.
   const [{

--- a/packages/view-types/statistical-plots/src/FeatureSetEnrichmentBarPlotSubscriber.js
+++ b/packages/view-types/statistical-plots/src/FeatureSetEnrichmentBarPlotSubscriber.js
@@ -10,6 +10,7 @@ import {
   useMatchingLoader,
   useColumnNameMapping,
   useAsyncFunction,
+  useCoordinationScopes,
 } from '@vitessce/vit-s';
 import {
   ViewType,
@@ -26,7 +27,7 @@ import { useRawSetPaths } from './utils.js';
 
 export function FeatureSetEnrichmentBarPlotSubscriber(props) {
   const {
-    coordinationScopes,
+    coordinationScopes: coordinationScopesRaw,
     removeGridComponent,
     theme,
     helpText = ViewHelpMapping.FEATURE_SET_ENRICHMENT_BAR_PLOT,
@@ -34,6 +35,7 @@ export function FeatureSetEnrichmentBarPlotSubscriber(props) {
 
   const { classes } = useStyles();
   const loaders = useLoaders();
+  const coordinationScopes = useCoordinationScopes(coordinationScopesRaw);
   const transformFeature = useAsyncFunction(AsyncFunctionType.TRANSFORM_FEATURE);
 
   // Get "props" from the coordination space.

--- a/packages/view-types/statistical-plots/src/FeatureStatsTableSubscriber.js
+++ b/packages/view-types/statistical-plots/src/FeatureStatsTableSubscriber.js
@@ -8,6 +8,7 @@ import {
   useFeatureStatsData,
   useMatchingLoader,
   useColumnNameMapping,
+  useCoordinationScopes,
 } from '@vitessce/vit-s';
 import {
   ViewType,
@@ -21,13 +22,14 @@ import { useRawSetPaths } from './utils.js';
 export function FeatureStatsTableSubscriber(props) {
   const {
     title = 'Differential Expression Results',
-    coordinationScopes,
+    coordinationScopes: coordinationScopesRaw,
     removeGridComponent,
     theme,
     helpText = ViewHelpMapping.FEATURE_STATS_TABLE,
   } = props;
 
   const loaders = useLoaders();
+  const coordinationScopes = useCoordinationScopes(coordinationScopesRaw);
 
   // Get "props" from the coordination space.
   const [{

--- a/packages/view-types/statistical-plots/src/TreemapSubscriber.js
+++ b/packages/view-types/statistical-plots/src/TreemapSubscriber.js
@@ -11,6 +11,7 @@ import {
   useObsSetsData,
   useSampleEdgesData,
   useSampleSetsData,
+  useCoordinationScopes,
 } from '@vitessce/vit-s';
 import { ViewType, COMPONENT_COORDINATION_TYPES, ViewHelpMapping } from '@vitessce/constants-internal';
 import { treeToSelectedSetMap, treeToSetSizesBySetNames, mergeObsSets } from '@vitessce/sets-utils';
@@ -25,7 +26,7 @@ const DEFAULT_HIERARCHY_LEVELS = ['obsSet', 'sampleSet'];
 
 export function TreemapSubscriber(props) {
   const {
-    coordinationScopes,
+    coordinationScopes: coordinationScopesRaw,
     removeGridComponent,
     theme,
     helpText = ViewHelpMapping.TREEMAP,
@@ -33,6 +34,7 @@ export function TreemapSubscriber(props) {
 
   const { classes } = useStyles();
   const loaders = useLoaders();
+  const coordinationScopes = useCoordinationScopes(coordinationScopesRaw);
 
   // Get "props" from the coordination space.
   const [{

--- a/packages/view-types/statistical-plots/src/VolcanoPlotSubscriber.js
+++ b/packages/view-types/statistical-plots/src/VolcanoPlotSubscriber.js
@@ -9,6 +9,7 @@ import {
   useFeatureStatsData,
   useMatchingLoader,
   useColumnNameMapping,
+  useCoordinationScopes,
 } from '@vitessce/vit-s';
 import {
   ViewType,
@@ -24,7 +25,7 @@ import { useRawSetPaths } from './utils.js';
 export function VolcanoPlotSubscriber(props) {
   const {
     title = 'Volcano Plot',
-    coordinationScopes,
+    coordinationScopes: coordinationScopesRaw,
     removeGridComponent,
     theme,
     helpText = ViewHelpMapping.VOLCANO_PLOT,
@@ -32,6 +33,7 @@ export function VolcanoPlotSubscriber(props) {
 
   const { classes } = useStyles();
   const loaders = useLoaders();
+  const coordinationScopes = useCoordinationScopes(coordinationScopesRaw);
 
   // Get "props" from the coordination space.
   const [{

--- a/packages/view-types/status/src/StatusSubscriber.js
+++ b/packages/view-types/status/src/StatusSubscriber.js
@@ -1,6 +1,7 @@
 import React from 'react';
 import {
   TitleInfo, useCoordination, useWarning,
+  useCoordinationScopes,
 } from '@vitessce/vit-s';
 import { ViewType, COMPONENT_COORDINATION_TYPES, ViewHelpMapping } from '@vitessce/constants-internal';
 import Status from './Status.js';
@@ -19,13 +20,15 @@ import Status from './Status.js';
  */
 export function StatusSubscriber(props) {
   const {
-    coordinationScopes,
+    coordinationScopes: coordinationScopesRaw,
     closeButtonVisible,
     removeGridComponent,
     theme,
     title = 'Status',
     helpText = ViewHelpMapping.STATUS,
   } = props;
+
+  const coordinationScopes = useCoordinationScopes(coordinationScopesRaw);
 
   // Get "props" from the coordination space.
   const [{

--- a/scripts/create-view-template-functions.mjs
+++ b/scripts/create-view-template-functions.mjs
@@ -126,13 +126,14 @@ import {
   useCoordination,
   useLoaders,
   useObsFeatureMatrixIndices,
+  useCoordinationScopes,
 } from '@vitessce/vit-s';
 import { ViewType, COMPONENT_COORDINATION_TYPES, ViewHelpMapping } from '@vitessce/constants-internal';
 import { ${pascalName} } from './${pascalName}.js';
 
 export function ${pascalName}Subscriber(props) {
   const {
-    coordinationScopes,
+    coordinationScopes: coordinationScopesRaw,
     removeGridComponent,
     theme,
     title = '${pascalName}',
@@ -141,6 +142,7 @@ export function ${pascalName}Subscriber(props) {
   } = props;
 
   const loaders = useLoaders();
+  const coordinationScopes = useCoordinationScopes(coordinationScopesRaw);
 
   // Get "props" from the coordination space.
   const [{


### PR DESCRIPTION
<!-- Credit (as a starting template): https://github.com/visgl/deck.gl/blob/master/.github/pull_request_template.md -->
<!-- For feature, feature enhancement or bug fix, create an issue first and finish To Do List there -->
<!-- Anything doesn't work as expected is a bug, including code, doc and test -->
Fixes #
<!-- For other PRs without open issue -->
#### Background

This is intended to prevent confusion when using linkViewsByObject (or link_views_by_dict in Python), as currently only spatialBeta/layerControllerBeta support meta=True (and the default value for `meta` is True in linkViewsByObject). After this PR, linkViewsByObject can be used with any view type, regardless of whether `meta` is True or False.

Note: In this PR i have not added support for meta-coordination in `spatial`/`layerController` as this would add extra complexity to https://github.com/vitessce/vitessce/pull/2234


<!-- For all the PRs -->
#### Change List
-
#### Checklist
 - [ ] Have tested PR with one or more demo configurations
 - [ ] Documentation added, updated, or not applicable
