### PR TITLE
Dev mode for versioned docs site build

### DIFF
--- a/.changeset/wild-tips-wait.md
+++ b/.changeset/wild-tips-wait.md
@@ -1,0 +1,5 @@
+---
+"docs": patch
+---
+
+Use --dev and --no-minify options when building the "versioned" docs site that will live at legacy.vitessce.io/docs/{date}/{commit}/

--- a/sites/docs/package.json
+++ b/sites/docs/package.json
@@ -6,7 +6,7 @@
     "docusaurus": "docusaurus",
     "start": "docusaurus start --port 3001 --no-open",
     "build-root": "docusaurus build --out-dir dist-root",
-    "build-versioned": "docusaurus build --out-dir dist-versioned",
+    "build-versioned": "docusaurus build --out-dir dist-versioned --dev --no-minify",
     "swizzle": "docusaurus swizzle --danger",
     "serve": "docusaurus serve --port 3002 --dir dist-root",
     "clear": "docusaurus clear"


### PR DESCRIPTION
<!-- Credit (as a starting template): https://github.com/visgl/deck.gl/blob/master/.github/pull_request_template.md -->
<!-- For feature, feature enhancement or bug fix, create an issue first and finish To Do List there -->
<!-- Anything doesn't work as expected is a bug, including code, doc and test -->
Fixes https://github.com/vitessce/vitessce/issues/2266

<!-- For other PRs without open issue -->
#### Background

It is not a 100% ideal solution, but I think this is a good option for now. E.g., if an error is encountered on the production site at `vitessce.io`, the user can replace `vitessce.io` with `legacy.vitessce.io/docs/{date}/{commit}/` (link is listed in the latest github release) to view full error messages / non-minified function names, etc.


<!-- For all the PRs -->
#### Change List
-
#### Checklist
 - [ ] Have tested PR with one or more demo configurations
 - [ ] Documentation added, updated, or not applicable
