### PR TITLE
Tkakar/ng opacity fix 2460

### DIFF
--- a/.changeset/wet-shrimps-cough.md
+++ b/.changeset/wet-shrimps-cough.md
@@ -2,4 +2,4 @@
 "@vitessce/neuroglancer": patch
 ---
 
-Enable opacity change in Neuroglancer segmentation layer using the opacity slider in layerController
+Enable opacity change in Neuroglancer segmentation and annotation layers using their respective opacity sliders in layerController.

--- a/.changeset/wet-shrimps-cough.md
+++ b/.changeset/wet-shrimps-cough.md
@@ -1,0 +1,5 @@
+---
+"@vitessce/neuroglancer": patch
+---
+
+Enable opacity change in Neuroglancer segmentation layer using the opacity slider in layerController

--- a/examples/configs/src/view-configs/3d-maps/neuroglancer-merfish.js
+++ b/examples/configs/src/view-configs/3d-maps/neuroglancer-merfish.js
@@ -55,6 +55,7 @@ function generateNeuroglancerMerfish() {
       url: pointsUrl,
       options: {
         projectionAnnotationSpacing: 2.4544585683772735,
+        pointMarkerBorderWidth: 0.0, // controls border width of the points
 
         // Note: tissue-map-tools creates an AnnotationProperty
         // for every column in the sdata Points element dask dataframe.
@@ -107,7 +108,6 @@ function generateNeuroglancerMerfish() {
         4469.5,
         7.5,
       ],
-      showAxisLines: false,
       projectionScale: 11521.115426462216,
       projectionOrientation: [
         -0.0017234950792044401,
@@ -116,6 +116,7 @@ function generateNeuroglancerMerfish() {
         0.999148964881897,
       ],
     },
+    showAxisLines: true,
   });
   const lcView = config.addView(dataset, 'layerControllerBeta');
   const geneList = config.addView(dataset, 'featureList').setProps({ enableMultiSelect: true });

--- a/examples/configs/src/view-configs/3d-maps/neuroglancer-merfish.js
+++ b/examples/configs/src/view-configs/3d-maps/neuroglancer-merfish.js
@@ -55,7 +55,6 @@ function generateNeuroglancerMerfish() {
       url: pointsUrl,
       options: {
         projectionAnnotationSpacing: 2.4544585683772735,
-        pointMarkerBorderWidth: 0.0, // controls border width of the points
 
         // Note: tissue-map-tools creates an AnnotationProperty
         // for every column in the sdata Points element dask dataframe.
@@ -167,6 +166,7 @@ function generateNeuroglancerMerfish() {
           featureColor: [
             { name: 'Ada', color: [255, 0, 0] },
           ],
+          spatialPointStrokeWidth: 0.0,
         },
       ]),
     }, { scopePrefix: getInitialCoordinationScopePrefix('A', 'obsPoints') });

--- a/examples/configs/src/view-configs/3d-maps/neuroglancer-merfish.js
+++ b/examples/configs/src/view-configs/3d-maps/neuroglancer-merfish.js
@@ -35,6 +35,14 @@ function generateNeuroglancerMerfish() {
   dataset.addFile({
     fileType: 'obsSegmentations.ng-precomputed',
     url: segmentationsUrl,
+    options: {
+        subsources: {
+          default: true,
+          bounds: false,
+          mesh: true,
+        },
+        enableDefaultSubsources: false,
+    },
     coordinationValues: {
       fileUid: 'merfish-meshes',
       obsType: 'cell',
@@ -99,6 +107,7 @@ function generateNeuroglancerMerfish() {
         4469.5,
         7.5,
       ],
+      showAxisLines: false,
       projectionScale: 11521.115426462216,
       projectionOrientation: [
         -0.0017234950792044401,
@@ -164,6 +173,7 @@ function generateNeuroglancerMerfish() {
 
   config.layout(hconcat(neuroglancerView, vconcat(lcView, geneList, obsSets)));
   const configJSON = config.toJSON();
+  console.log(JSON.stringify(configJSON.datasets[0].files[0], null, 2));
   return configJSON;
 }
 

--- a/examples/configs/src/view-configs/3d-maps/neuroglancer-merfish.js
+++ b/examples/configs/src/view-configs/3d-maps/neuroglancer-merfish.js
@@ -36,12 +36,12 @@ function generateNeuroglancerMerfish() {
     fileType: 'obsSegmentations.ng-precomputed',
     url: segmentationsUrl,
     options: {
-        subsources: {
-          default: true,
-          bounds: false,
-          mesh: true,
-        },
-        enableDefaultSubsources: false,
+      subsources: {
+        default: true,
+        bounds: false,
+        mesh: true,
+      },
+      enableDefaultSubsources: false,
     },
     coordinationValues: {
       fileUid: 'merfish-meshes',
@@ -174,7 +174,6 @@ function generateNeuroglancerMerfish() {
 
   config.layout(hconcat(neuroglancerView, vconcat(lcView, geneList, obsSets)));
   const configJSON = config.toJSON();
-  console.log(JSON.stringify(configJSON.datasets[0].files[0], null, 2));
   return configJSON;
 }
 

--- a/packages/constants-internal/src/constants.ts
+++ b/packages/constants-internal/src/constants.ts
@@ -327,6 +327,7 @@ export const CoordinationType = {
   SPATIAL_LAYER_MODEL_MATRIX: 'spatialLayerModelMatrix',
   SPATIAL_SEGMENTATION_FILLED: 'spatialSegmentationFilled',
   SPATIAL_SEGMENTATION_STROKE_WIDTH: 'spatialSegmentationStrokeWidth',
+  SPATIAL_POINT_STROKE_WIDTH: 'spatialPointStrokeWidth',
   SPATIAL_CHANNEL_COLOR: 'spatialChannelColor',
   SPATIAL_CHANNEL_VISIBLE: 'spatialChannelVisible',
   SPATIAL_CHANNEL_OPACITY: 'spatialChannelOpacity',

--- a/packages/constants-internal/src/coordination.ts
+++ b/packages/constants-internal/src/coordination.ts
@@ -88,6 +88,7 @@ export const COMPONENT_COORDINATION_TYPES = {
     CoordinationType.SPATIAL_CHANNEL_OPACITY,
     CoordinationType.SPATIAL_CHANNEL_VISIBLE,
     CoordinationType.LEGEND_VISIBLE,
+    CoordinationType.SPATIAL_POINT_STROKE_WIDTH,
   ],
   [ViewType.SCATTERPLOT]: [
     CoordinationType.DATASET,
@@ -471,6 +472,7 @@ export const COMPONENT_COORDINATION_TYPES = {
     CoordinationType.SPATIAL_CHANNEL_COLOR,
     CoordinationType.SPATIAL_SEGMENTATION_FILLED,
     CoordinationType.SPATIAL_SEGMENTATION_STROKE_WIDTH,
+    CoordinationType.SPATIAL_POINT_STROKE_WIDTH,
     CoordinationType.IMAGE_CHANNEL,
     CoordinationType.IMAGE_LAYER,
     CoordinationType.SEGMENTATION_CHANNEL,

--- a/packages/main/all/src/base-plugins.ts
+++ b/packages/main/all/src/base-plugins.ts
@@ -594,6 +594,7 @@ export const baseCoordinationTypes = [
   new PluginCoordinationType(CoordinationType.SPATIAL_CHANNEL_COLOR, [255, 255, 255], z.array(z.number()).length(3).nullable()),
   new PluginCoordinationType(CoordinationType.SPATIAL_SEGMENTATION_FILLED, true, z.boolean()),
   new PluginCoordinationType(CoordinationType.SPATIAL_SEGMENTATION_STROKE_WIDTH, 1.0, z.number()),
+  new PluginCoordinationType(CoordinationType.SPATIAL_POINT_STROKE_WIDTH, 0.0, z.number()),
   new PluginCoordinationType(CoordinationType.SPATIAL_LOD_FACTOR, 1.0, z.number()),
   // Reference: https://www.awaresystems.be/imaging/tiff/tifftags/photometricinterpretation.html
   new PluginCoordinationType(CoordinationType.PHOTOMETRIC_INTERPRETATION, null, z.enum(['BlackIsZero', 'RGB']).nullable()),

--- a/packages/schemas/src/file-def-options.ts
+++ b/packages/schemas/src/file-def-options.ts
@@ -290,7 +290,7 @@ export const meshGlbSchema = z.object({
   materialSide: z.enum(['front', 'back']),
 }).partial().nullable();
 
-// NG
+// NG SegmentationLayer
 export const ngPrecomputedMeshSchema = z.object({
   // TODO: Should this explicitly specify sharded vs. unsharded?
   // Or can/should that be inferred from the data?
@@ -310,6 +310,8 @@ export const ngPrecomputedMeshSchema = z.object({
   subsources: z.record(z.boolean()).optional(),
   enableDefaultSubsources: z.boolean().optional(),
 }).partial().nullable();
+
+// Annotation Layer
 export const ngPointAnnotationSchema = z.object({
   projectionAnnotationSpacing: z.number(),
   featureIndexProp: z.string()
@@ -318,6 +320,9 @@ export const ngPointAnnotationSchema = z.object({
   pointIndexProp: z.string()
     .optional()
     .describe('The name of the Neuroglancer AnnotationProperty containing point IDs. For example, specify \'point_id\' to use prop_point_id() in the Neuroglancer shader code.'),
+  pointMarkerBorderWidth: z.number()
+    .optional()
+    .describe('A decimal/float number >= 0.0 to adjust the border width of the points on the Annotation layer'),
 }).partial().nullable();
 
 /**

--- a/packages/schemas/src/file-def-options.ts
+++ b/packages/schemas/src/file-def-options.ts
@@ -320,9 +320,6 @@ export const ngPointAnnotationSchema = z.object({
   pointIndexProp: z.string()
     .optional()
     .describe('The name of the Neuroglancer AnnotationProperty containing point IDs. For example, specify \'point_id\' to use prop_point_id() in the Neuroglancer shader code.'),
-  pointMarkerBorderWidth: z.number()
-    .optional()
-    .describe('A decimal/float number >= 0.0 to adjust the border width of the points on the Annotation layer'),
 }).partial().nullable();
 
 /**

--- a/packages/schemas/src/file-def-options.ts
+++ b/packages/schemas/src/file-def-options.ts
@@ -307,10 +307,13 @@ export const ngPrecomputedMeshSchema = z.object({
   // projectionScale: z.number(),
   // position: z.array(z.number()).length(3),
   // projectionOrientation: z.array(z.number()).length(4),
-  subsources: z.record(z.boolean()).optional(),
-  enableDefaultSubsources: z.boolean().optional(),
+  subsources: z.record(z.boolean())
+    .describe('Subsources are the individual data components of a source (e.g. meshes, skeletons, etc.). Each entry explicitly enables or disables a subsource.')
+    .optional(),
+  enableDefaultSubsources: z.boolean()
+    .describe('When true (default), automatically loads all subsources (defined in mesh metadata), when false loads what is explicitly enabled in `subsources`.')
+    .optional(),
 }).partial().nullable();
-
 // Annotation Layer
 export const ngPointAnnotationSchema = z.object({
   projectionAnnotationSpacing: z.number(),

--- a/packages/schemas/src/file-def-options.ts
+++ b/packages/schemas/src/file-def-options.ts
@@ -307,6 +307,8 @@ export const ngPrecomputedMeshSchema = z.object({
   // projectionScale: z.number(),
   // position: z.array(z.number()).length(3),
   // projectionOrientation: z.array(z.number()).length(4),
+  subsources: z.record(z.boolean()).optional(),
+  enableDefaultSubsources: z.boolean().optional(),
 }).partial().nullable();
 export const ngPointAnnotationSchema = z.object({
   projectionAnnotationSpacing: z.number(),

--- a/packages/view-types/neuroglancer/src/NeuroglancerSubscriber.js
+++ b/packages/view-types/neuroglancer/src/NeuroglancerSubscriber.js
@@ -208,6 +208,7 @@ export function NeuroglancerSubscriber(props) {
       CoordinationType.TOOLTIPS_VISIBLE,
       CoordinationType.TOOLTIP_CROSSHAIRS_VISIBLE,
       CoordinationType.LEGEND_VISIBLE,
+      CoordinationType.SPATIAL_POINT_STROKE_WIDTH,
     ],
     coordinationScopes,
     coordinationScopesBy,

--- a/packages/view-types/neuroglancer/src/NeuroglancerSubscriber.js
+++ b/packages/view-types/neuroglancer/src/NeuroglancerSubscriber.js
@@ -722,10 +722,15 @@ export function NeuroglancerSubscriber(props) {
       const layerScope = segmentationLayerScopes?.[idx];
       const layerColorMapping = cellColorMappingByLayer?.[layerScope] ?? {};
       const layerSegments = Object.keys(layerColorMapping);
+      const channelScope = segmentationChannelScopesByLayer?.[layerScope]?.[0];
+      // TODO: Fix assumption for one segmentation layer in the future
+      const layerOpacity = segmentationChannelCoordination[0]
+        ?.[layerScope]?.[channelScope]?.spatialChannelOpacity ?? 1.0;
       return {
         ...layer,
         segments: layerSegments,
         segmentColors: layerColorMapping,
+        objectAlpha: layerOpacity,
       };
     }) ?? [];
 
@@ -752,7 +757,7 @@ export function NeuroglancerSubscriber(props) {
     return updated;
   }, [cellColorMappingByLayer, spatialZoom, spatialRotationX, spatialRotationY,
     spatialRotationZ, spatialTargetX, spatialTargetY, initalViewerState,
-    latestViewerStateIteration]);
+    latestViewerStateIteration, segmentationChannelCoordination, segmentationChannelScopesByLayer]);
 
   const onSegmentHighlight = useCallback((obsId) => {
     setCellHighlight(String(obsId));

--- a/packages/view-types/neuroglancer/src/NeuroglancerSubscriber.js
+++ b/packages/view-types/neuroglancer/src/NeuroglancerSubscriber.js
@@ -289,8 +289,8 @@ export function NeuroglancerSubscriber(props) {
           obsSetSelection,
           additionalObsSets,
           spatialChannelColor,
+          spatialChannelOpacity,
         } = segmentationChannelCoordination[0][layerScope][channelScope];
-
         if (obsColorEncoding === 'spatialChannelColor') {
           // All segments get the same static channel color
           if (layerIndex && spatialChannelColor) {
@@ -315,6 +315,7 @@ export function NeuroglancerSubscriber(props) {
               });
             }
             result[layerScope][channelScope] = ngCellColors;
+            result[layerScope].opacity = spatialChannelOpacity ?? 1.0;
           }
         } else if (layerSets && layerIndex) {
           const mergedCellSets = mergeObsSets(layerSets, additionalObsSets);
@@ -331,6 +332,7 @@ export function NeuroglancerSubscriber(props) {
             ngCellColors[i] = rgbToHex(color);
           });
           result[layerScope][channelScope] = ngCellColors;
+          result[layerScope].opacity = spatialChannelOpacity ?? 1.0;
         }
       });
     });
@@ -566,7 +568,10 @@ export function NeuroglancerSubscriber(props) {
     const result = {};
     segmentationLayerScopes?.forEach((layerScope) => {
       const channelScope = segmentationChannelScopesByLayer?.[layerScope]?.[0];
-      result[layerScope] = segmentationColorMapping?.[layerScope]?.[channelScope] ?? {};
+      result[layerScope] = {
+        colors: segmentationColorMapping?.[layerScope]?.[channelScope] ?? {},
+        opacity: segmentationColorMapping?.[layerScope]?.opacity ?? 1.0,
+      };
     });
     return result;
   }, [segmentationColorMapping, segmentationLayerScopes, segmentationChannelScopesByLayer]);
@@ -720,17 +725,13 @@ export function NeuroglancerSubscriber(props) {
 
     const updatedLayers = current?.layers?.map((layer, idx) => {
       const layerScope = segmentationLayerScopes?.[idx];
-      const layerColorMapping = cellColorMappingByLayer?.[layerScope] ?? {};
+      const layerColorMapping = cellColorMappingByLayer?.[layerScope]?.colors ?? {};
       const layerSegments = Object.keys(layerColorMapping);
-      const channelScope = segmentationChannelScopesByLayer?.[layerScope]?.[0];
-      // TODO: Fix assumption for one segmentation layer in the future
-      const layerOpacity = segmentationChannelCoordination[0]
-        ?.[layerScope]?.[channelScope]?.spatialChannelOpacity ?? 1.0;
       return {
         ...layer,
         segments: layerSegments,
         segmentColors: layerColorMapping,
-        objectAlpha: layerOpacity,
+        objectAlpha: cellColorMappingByLayer?.[layerScope]?.opacity ?? 1.0,
       };
     }) ?? [];
 
@@ -757,7 +758,7 @@ export function NeuroglancerSubscriber(props) {
     return updated;
   }, [cellColorMappingByLayer, spatialZoom, spatialRotationX, spatialRotationY,
     spatialRotationZ, spatialTargetX, spatialTargetY, initalViewerState,
-    latestViewerStateIteration, segmentationChannelCoordination, segmentationChannelScopesByLayer]);
+    latestViewerStateIteration]);
 
   const onSegmentHighlight = useCallback((obsId) => {
     setCellHighlight(String(obsId));

--- a/packages/view-types/neuroglancer/src/NeuroglancerSubscriber.js
+++ b/packages/view-types/neuroglancer/src/NeuroglancerSubscriber.js
@@ -79,6 +79,7 @@ export function NeuroglancerSubscriber(props) {
     downloadButtonVisible,
     removeGridComponent,
     theme,
+    showAxisLines = false,
     title = 'Spatial',
     subtitle = 'Powered by Neuroglancer',
     helpText = ViewHelpMapping.NEUROGLANCER,
@@ -351,6 +352,7 @@ export function NeuroglancerSubscriber(props) {
   // Obtain the Neuroglancer viewerState object.
   const initalViewerState = useNeuroglancerViewerState(
     theme,
+    showAxisLines,
     segmentationLayerScopes,
     segmentationChannelScopesByLayer,
     segmentationLayerCoordination,

--- a/packages/view-types/neuroglancer/src/ReactNeuroglancer.js
+++ b/packages/view-types/neuroglancer/src/ReactNeuroglancer.js
@@ -625,7 +625,7 @@ export default class Neuroglancer extends React.Component {
       viewerNoKey = this.viewer;
     }
 
-    // TODO: This is purely for debugging and we need to remove it.
+    // TODO: This is purely for debugging - exposes the NG viewer to be tested via xonsole
     // window.viewer = this.viewer;
   }
 

--- a/packages/view-types/neuroglancer/src/ReactNeuroglancer.js
+++ b/packages/view-types/neuroglancer/src/ReactNeuroglancer.js
@@ -707,7 +707,6 @@ export default class Neuroglancer extends React.Component {
     // updates NG's viewerstate by calling `restoreState() for segment and position changes separately
     const prevVS = prevProps.viewerState;
     const camState = diffCameraState(prevVS, viewerState);
-    console.log('shader changed', prevVS?.layers?.[0]?.shader !== viewerState?.layers?.[0]?.shader);
     // Restore pose ONLY if it actually changed
     if (camState.changed) {
       const patch = {};
@@ -737,11 +736,11 @@ export default class Neuroglancer extends React.Component {
     // If colors changed (but layers didn’t): re-apply colors
     // this was to avid NG randomly assigning colors to the segments by resetting them
     const prevSize = prevProps.cellColorMapping
-    ? Object.values(prevProps.cellColorMapping)
+      ? Object.values(prevProps.cellColorMapping)
         .reduce((acc, v) => acc + Object.keys(v?.colors || {}).length, 0) : 0;
     const currSize = cellColorMappingByLayer
       ? Object.values(cellColorMappingByLayer)
-          .reduce((acc, v) => acc + Object.keys(v?.colors || {}).length, 0) : 0;
+        .reduce((acc, v) => acc + Object.keys(v?.colors || {}).length, 0) : 0;
     const mappingRefChanged = prevProps.cellColorMapping !== this.props.cellColorMapping;
     if (!this.didLayersChange(prevVS, viewerState)
       && (mappingRefChanged || prevSize !== currSize)) {

--- a/packages/view-types/neuroglancer/src/ReactNeuroglancer.js
+++ b/packages/view-types/neuroglancer/src/ReactNeuroglancer.js
@@ -488,7 +488,7 @@ export default class Neuroglancer extends React.Component {
       // "obsSegmentations-init_A_obsSegmentations_0-init_A_obsSegmentations_0"
       const layerScope = Object.keys(cellColorMappingByLayer).find(scope => layer.name?.includes(scope));
 
-      const selected = { ...(cellColorMappingByLayer[layerScope] || {}) };
+      const selected = { ...(cellColorMappingByLayer[layerScope]?.colors || {}) };
 
       // Track all known IDs for this layer scope
       if (!this.allKnownIdsByLayer) this.allKnownIdsByLayer = {};
@@ -641,6 +641,13 @@ export default class Neuroglancer extends React.Component {
       if (layer.layer instanceof SegmentationUserLayer) {
         const { segmentSelectionState } = layer.layer.displayState;
         selectedSegments[layer.name] = segmentSelectionState.selectedSegment;
+        const layerScope = Object.keys(cellColorMappingByLayer).find(
+          scope => layer.name?.includes(scope),
+        );
+        if (layerScope) {
+          const opacity = cellColorMappingByLayer[layerScope]?.opacity ?? 1.0;
+          layer.layer.displayState.objectAlpha.value = opacity;
+        }
       }
     }
     // if (viewerState) {
@@ -717,9 +724,11 @@ export default class Neuroglancer extends React.Component {
     // If colors changed (but layers didn’t): re-apply colors
     // this was to avid NG randomly assigning colors to the segments by resetting them
     const prevSize = prevProps.cellColorMapping
-      ? Object.keys(prevProps.cellColorMapping).length : 0;
+    ? Object.values(prevProps.cellColorMapping)
+        .reduce((acc, v) => acc + Object.keys(v?.colors || {}).length, 0) : 0;
     const currSize = cellColorMappingByLayer
-      ? Object.keys(cellColorMappingByLayer).length : 0;
+      ? Object.values(cellColorMappingByLayer)
+          .reduce((acc, v) => acc + Object.keys(v?.colors || {}).length, 0) : 0;
     const mappingRefChanged = prevProps.cellColorMapping !== this.props.cellColorMapping;
     if (!this.didLayersChange(prevVS, viewerState)
       && (mappingRefChanged || prevSize !== currSize)) {
@@ -732,7 +741,7 @@ export default class Neuroglancer extends React.Component {
     // We only restore layers (not pose) when sources change OR on the first time segments appear.
     const stripSegFields = layers => (layers || []).map((l) => {
       if (!l) return l;
-      const { segments, segmentColors, ...rest } = l;
+      const { segments, segmentColors, objectAlpha, ...rest } = l;
       return rest; // ignore segments + segmentColors for comparison
     });
 

--- a/packages/view-types/neuroglancer/src/ReactNeuroglancer.js
+++ b/packages/view-types/neuroglancer/src/ReactNeuroglancer.js
@@ -641,13 +641,6 @@ export default class Neuroglancer extends React.Component {
       if (layer.layer instanceof SegmentationUserLayer) {
         const { segmentSelectionState } = layer.layer.displayState;
         selectedSegments[layer.name] = segmentSelectionState.selectedSegment;
-        const layerScope = Object.keys(cellColorMappingByLayer).find(
-          scope => layer.name?.includes(scope),
-        );
-        if (layerScope) {
-          const opacity = cellColorMappingByLayer[layerScope]?.opacity ?? 1.0;
-          layer.layer.displayState.objectAlpha.value = opacity;
-        }
       }
     }
     // if (viewerState) {
@@ -674,6 +667,25 @@ export default class Neuroglancer extends React.Component {
       if (layer.layer instanceof SegmentationUserLayer) {
         const { segmentSelectionState } = layer.layer.displayState;
         segmentSelectionState.set(selectedSegments[layer.name]);
+        const layerScope = Object.keys(cellColorMappingByLayer).find(
+          scope => layer.name?.includes(scope),
+        );
+        if (layerScope) {
+          const opacity = cellColorMappingByLayer[layerScope]?.opacity ?? 1.0;
+          layer.layer.displayState.objectAlpha.value = opacity;
+        }
+      }
+      if (layer.layer instanceof AnnotationUserLayer) {
+        const matchingLayer = (viewerState?.layers || []).find(
+          l => l.name === layer.name,
+        );
+        if (matchingLayer?.shader) {
+          /* eslint-disable-next-line no-underscore-dangle */
+          const currentShader = layer.layer.annotationDisplayState.shader.value_;
+          if (currentShader !== matchingLayer.shader) {
+            layer.layer.annotationDisplayState.shader.value = matchingLayer.shader;
+          }
+        }
       }
     }
 
@@ -695,6 +707,7 @@ export default class Neuroglancer extends React.Component {
     // updates NG's viewerstate by calling `restoreState() for segment and position changes separately
     const prevVS = prevProps.viewerState;
     const camState = diffCameraState(prevVS, viewerState);
+    console.log('shader changed', prevVS?.layers?.[0]?.shader !== viewerState?.layers?.[0]?.shader);
     // Restore pose ONLY if it actually changed
     if (camState.changed) {
       const patch = {};

--- a/packages/view-types/neuroglancer/src/ReactNeuroglancer.js
+++ b/packages/view-types/neuroglancer/src/ReactNeuroglancer.js
@@ -675,6 +675,8 @@ export default class Neuroglancer extends React.Component {
           layer.layer.displayState.objectAlpha.value = opacity;
         }
       }
+      // Update annotation layer shaders from viewerState config,
+      // skipping update if shader is unchanged to avoid costly re-renders
       if (layer.layer instanceof AnnotationUserLayer) {
         const matchingLayer = (viewerState?.layers || []).find(
           l => l.name === layer.name,

--- a/packages/view-types/neuroglancer/src/data-hook-ng-utils.js
+++ b/packages/view-types/neuroglancer/src/data-hook-ng-utils.js
@@ -140,20 +140,35 @@ export function useNeuroglancerViewerState(
           const {
             spatialChannelVisible,
           } = channelCoordination || {};
+          const { source: ngSource, ...otherNgOptions } = layerData.neuroglancerOptions ?? {};
+
+          // Build source: if neuroglancerOptions has subsources
+          const hasNgSourceOptions = layerData.neuroglancerOptions?.subsources
+            || layerData.neuroglancerOptions?.enableDefaultSubsources !== undefined;
+
+          const source = hasNgSourceOptions
+            ? {
+                url: toPrecomputedSource(layerUrl),
+                subsources: layerData.neuroglancerOptions.subsources,
+                enableDefaultSubsources: layerData.neuroglancerOptions.enableDefaultSubsources
+                  ?? false,
+              }
+            : toPrecomputedSource(layerUrl);
+
           result = {
             ...result,
             layers: [
               ...result.layers,
               {
                 type: 'segmentation',
-                source: toPrecomputedSource(layerUrl),
+                source,
                 segments: [],
                 name: toNgLayerName(DataType.OBS_SEGMENTATIONS, layerScope, channelScope),
                 visible: spatialLayerVisible && spatialChannelVisible, // Both layer and channel
                 // visibility must be true for the layer to be visible.
                 // TODO: update this to extract specific properties from
                 // neuroglancerOptions as needed.
-                ...(layerData.neuroglancerOptions ?? {}),
+                ...otherNgOptions,
               },
             ],
           };

--- a/packages/view-types/neuroglancer/src/data-hook-ng-utils.js
+++ b/packages/view-types/neuroglancer/src/data-hook-ng-utils.js
@@ -211,6 +211,7 @@ export function useNeuroglancerViewerState(
 
           featureIndexProp: layerData.neuroglancerOptions?.featureIndexProp,
           pointIndexProp: layerData.neuroglancerOptions?.pointIndexProp,
+          pointMarkerBorderWidth: layerData.neuroglancerOptions?.pointMarkerBorderWidth ?? 0.0,
         });
 
         result = {

--- a/packages/view-types/neuroglancer/src/data-hook-ng-utils.js
+++ b/packages/view-types/neuroglancer/src/data-hook-ng-utils.js
@@ -120,7 +120,7 @@ export function useNeuroglancerViewerState(
   pointMultiIndicesData,
 ) {
   const viewerState = useMemoCustomComparison(() => {
-    let result = { ...cloneDeep(DEFAULT_NG_PROPS), showAxisLines };
+    let result = cloneDeep(DEFAULT_NG_PROPS);
 
     // ======= SEGMENTATIONS =======
 
@@ -196,6 +196,7 @@ export function useNeuroglancerViewerState(
           featureSelection,
           featureFilterMode,
           featureColor,
+          spatialPointStrokeWidth,
         } = layerCoordination || {};
 
         // Dynamically construct the shader based on the color encoding
@@ -212,7 +213,7 @@ export function useNeuroglancerViewerState(
 
           featureIndexProp: layerData.neuroglancerOptions?.featureIndexProp,
           pointIndexProp: layerData.neuroglancerOptions?.pointIndexProp,
-          pointMarkerBorderWidth: layerData.neuroglancerOptions?.pointMarkerBorderWidth ?? 0.0,
+          pointMarkerBorderWidth: spatialPointStrokeWidth ?? 0.0,
         });
 
         result = {
@@ -252,6 +253,7 @@ export function useNeuroglancerViewerState(
     return result;
   }, {
     theme,
+    showAxisLines,
     segmentationLayerScopes,
     segmentationChannelScopesByLayer,
     segmentationLayerCoordination,

--- a/packages/view-types/neuroglancer/src/data-hook-ng-utils.js
+++ b/packages/view-types/neuroglancer/src/data-hook-ng-utils.js
@@ -149,11 +149,11 @@ export function useNeuroglancerViewerState(
 
           const source = hasNgSourceOptions
             ? {
-                url: toPrecomputedSource(layerUrl),
-                subsources: layerData.neuroglancerOptions.subsources,
-                enableDefaultSubsources: layerData.neuroglancerOptions.enableDefaultSubsources
+              url: toPrecomputedSource(layerUrl),
+              subsources: layerData.neuroglancerOptions.subsources,
+              enableDefaultSubsources: layerData.neuroglancerOptions.enableDefaultSubsources
                   ?? false,
-              }
+            }
             : toPrecomputedSource(layerUrl);
 
           result = {

--- a/packages/view-types/neuroglancer/src/data-hook-ng-utils.js
+++ b/packages/view-types/neuroglancer/src/data-hook-ng-utils.js
@@ -106,6 +106,7 @@ export function toNgLayerName(dataType, layerScope, channelScope = null) {
  */
 export function useNeuroglancerViewerState(
   theme,
+  showAxisLines,
   segmentationLayerScopes,
   segmentationChannelScopesByLayer,
   segmentationLayerCoordination,
@@ -119,7 +120,7 @@ export function useNeuroglancerViewerState(
   pointMultiIndicesData,
 ) {
   const viewerState = useMemoCustomComparison(() => {
-    let result = cloneDeep(DEFAULT_NG_PROPS);
+    let result = { ...cloneDeep(DEFAULT_NG_PROPS), showAxisLines };
 
     // ======= SEGMENTATIONS =======
 

--- a/packages/view-types/neuroglancer/src/shader-utils.js
+++ b/packages/view-types/neuroglancer/src/shader-utils.js
@@ -158,7 +158,7 @@ export function getSpatialLayerColorFilteredShader(
  * @param {number} opacity Opacity (0-1).
  * @returns {string} A GLSL shader string.
  */
-export function getGeneSelectionNoSelectionShader(staticColor, opacity, borderWidth = 0.0,) {
+export function getGeneSelectionNoSelectionShader(staticColor, opacity, borderWidth = 0.0) {
   const norm = normalizeColor(staticColor);
   // lang: glsl
   return `
@@ -185,7 +185,13 @@ export function getGeneSelectionNoSelectionShader(staticColor, opacity, borderWi
  * @returns {string} A GLSL shader string.
  */
 export function getGeneSelectionWithSelectionShader(
-  featureIndices, featureColors, staticColor, defaultColor, opacity, featureIndexProp, borderWidth=0.0,
+  featureIndices,
+  featureColors,
+  staticColor,
+  defaultColor,
+  opacity,
+  featureIndexProp,
+  borderWidth = 0.0,
 ) {
   const numFeatures = featureIndices.length;
   const normDefault = normalizeColor(defaultColor);
@@ -348,7 +354,12 @@ export function getRandomByFeatureWithSelectionShader(
  * @param {string} featureIndexProp The property name for the feature index in the shader.
  * @returns {string} A GLSL shader string.
  */
-export function getRandomByFeatureFilteredShader(featureIndices, opacity, featureIndexProp, borderWidth = 0.0,) {
+export function getRandomByFeatureFilteredShader(
+  featureIndices,
+  opacity,
+  featureIndexProp,
+  borderWidth = 0.0,
+) {
   const paletteSize = PALETTE.length;
   const normPalette = PALETTE.map(c => normalizeColor(c));
   const numFeatures = featureIndices.length;
@@ -408,7 +419,12 @@ function hashToFloatGlsl() {
  * @param {string} pointIndexProp The property name for the point index in the shader.
  * @returns {string} A GLSL shader string.
  */
-export function getRandomPerPointShader(opacity, featureIndexProp, pointIndexProp, borderWidth = 0.0) {
+export function getRandomPerPointShader(
+  opacity,
+  featureIndexProp,
+  pointIndexProp,
+  borderWidth = 0.0,
+) {
   // lang: glsl
   return `
         ${hashToFloatGlsl()}
@@ -524,8 +540,6 @@ export function getPointsShader(layerCoordination) {
     pointIndexProp,
   } = layerCoordination;
 
-  console.log('getPointsShader', obsColorEncoding, spatialLayerColor, spatialLayerOpacity);
-
   const defaultColor = getDefaultColor(theme);
   const opacity = spatialLayerOpacity ?? 1.0;
   const staticColor = (
@@ -627,7 +641,7 @@ export function getPointsShader(layerCoordination) {
       throw new Error('In order to use gene-based color encoding for Neuroglancer Points, options.featureIndexProp must be specified for the obsPoints.ng-annotations fileType in the Vitessce configuration.');
     }
     if (!hasFeatureSelection || !hasResolvedIndices) {
-      return getGeneSelectionNoSelectionShader(staticColor, opacity, pointMarkerBorderWidth,);
+      return getGeneSelectionNoSelectionShader(staticColor, opacity, pointMarkerBorderWidth);
     }
     if (isFiltered) {
       return getGeneSelectionFilteredShader(
@@ -665,16 +679,26 @@ export function getPointsShader(layerCoordination) {
       throw new Error('In order to use per-point color encoding for Neuroglancer Points, options.pointIndexProp must be specified for the obsPoints.ng-annotations fileType in the Vitessce configuration.');
     }
     if (!hasFeatureSelection || !hasResolvedIndices) {
-      return getRandomPerPointShader(opacity, featureIndexProp, pointIndexProp, pointMarkerBorderWidth,);
+      return getRandomPerPointShader(
+        opacity,
+        featureIndexProp,
+        pointIndexProp,
+        pointMarkerBorderWidth,
+      );
     }
     if (isFiltered) {
       return getRandomPerPointFilteredShader(
         featureIndices, opacity, featureIndexProp, pointIndexProp, pointMarkerBorderWidth,
       );
     }
-    return getRandomPerPointWithSelectionShader(
-      featureIndices, defaultColor, opacity, featureIndexProp, pointIndexProp, pointMarkerBorderWidth,
-    );
+    if (!hasFeatureSelection || !hasResolvedIndices) {
+      return getRandomPerPointShader(
+        opacity,
+        featureIndexProp,
+        pointIndexProp,
+        pointMarkerBorderWidth,
+      );
+    }
   }
 
   // Fallback: static color.

--- a/packages/view-types/neuroglancer/src/shader-utils.js
+++ b/packages/view-types/neuroglancer/src/shader-utils.js
@@ -22,7 +22,8 @@ function normalizeColor(rgbColor) {
  * @returns {string}
  */
 function borderWidthGlsl(borderWidth = 0.0) {
-  return `setPointMarkerBorderWidth(${borderWidth});`;
+  // must be decimal/float value
+  return `setPointMarkerBorderWidth(${borderWidth.toFixed(1)});`;
 }
 
 
@@ -61,8 +62,8 @@ export function getSpatialLayerColorShader(staticColor, opacity, borderWidth = 0
   // lang: glsl
   return `
         void main() {
-            ${borderWidthGlsl(borderWidth)}
             setColor(${toVec4(norm, opacity)});
+            ${borderWidthGlsl(borderWidth)}
         }
     `;
 }
@@ -98,11 +99,11 @@ export function getSpatialLayerColorWithSelectionShader(
                 }
             }
             if (isSelected) {
-                ${borderWidthGlsl(borderWidth)}
                 setColor(${toVec4(normStatic, opacity)});
-            } else {
                 ${borderWidthGlsl(borderWidth)}
+            } else {
                 setColor(${toVec4(normDefault, opacity)});
+                ${borderWidthGlsl(borderWidth)}
             }
         }
     `;
@@ -139,8 +140,8 @@ export function getSpatialLayerColorFilteredShader(
             if (!isSelected) {
                 discard;
             }
-            ${borderWidthGlsl(borderWidth)}
             setColor(${toVec4(normStatic, opacity)});
+            ${borderWidthGlsl(borderWidth)}
         }
     `;
 }
@@ -162,8 +163,8 @@ export function getGeneSelectionNoSelectionShader(staticColor, opacity, borderWi
   // lang: glsl
   return `
         void main() {
-            ${borderWidthGlsl(borderWidth)}
             setColor(${toVec4(norm, opacity)});
+            ${borderWidthGlsl(borderWidth)}
         }
     `;
 }
@@ -209,8 +210,8 @@ export function getGeneSelectionWithSelectionShader(
                     color = vec4(featureColors[i], ${opacity});
                 }
             }
-            ${borderWidthGlsl(borderWidth)}
             setColor(color);
+            ${borderWidthGlsl(borderWidth)}
         }
     `;
 }
@@ -257,8 +258,8 @@ export function getGeneSelectionFilteredShader(
             if (!isSelected) {
                 discard;
             }
-            ${borderWidthGlsl(borderWidth)}
             setColor(vec4(matchedColor, ${opacity}));
+            ${borderWidthGlsl(borderWidth)}
         }
     `;
 }
@@ -287,8 +288,8 @@ export function getRandomByFeatureShader(opacity, featureIndexProp, borderWidth 
             int colorIdx = geneIndex - (geneIndex / ${paletteSize}) * ${paletteSize};
             if (colorIdx < 0) { colorIdx = -colorIdx; }
             vec3 color = palette[colorIdx];
-            ${borderWidthGlsl(borderWidth)}
             setColor(vec4(color, ${opacity}));
+            ${borderWidthGlsl(borderWidth)}
         }
     `;
 }
@@ -329,11 +330,11 @@ export function getRandomByFeatureWithSelectionShader(
             if (isSelected) {
                 int colorIdx = geneIndex - (geneIndex / ${paletteSize}) * ${paletteSize};
                 if (colorIdx < 0) { colorIdx = -colorIdx; }
-                ${borderWidthGlsl(borderWidth)}
                 setColor(vec4(palette[colorIdx], ${opacity}));
-            } else {
                 ${borderWidthGlsl(borderWidth)}
+            } else {
                 setColor(${toVec4(normDefault, opacity)});
+                ${borderWidthGlsl(borderWidth)}
             }
         }
     `;
@@ -372,8 +373,8 @@ export function getRandomByFeatureFilteredShader(featureIndices, opacity, featur
             }
             int colorIdx = geneIndex - (geneIndex / ${paletteSize}) * ${paletteSize};
             if (colorIdx < 0) { colorIdx = -colorIdx; }
-            ${borderWidthGlsl(borderWidth)}
             setColor(vec4(palette[colorIdx], ${opacity}));
+            ${borderWidthGlsl(borderWidth)}
         }
     `;
 }
@@ -417,8 +418,8 @@ export function getRandomPerPointShader(opacity, featureIndexProp, pointIndexPro
             float r = hashToFloat(pointIndex, 0);
             float g = hashToFloat(pointIndex, 1);
             float b = hashToFloat(pointIndex, 2);
-            ${borderWidthGlsl(borderWidth)}
             setColor(vec4(r, g, b, ${opacity}));
+            ${borderWidthGlsl(borderWidth)}
         }
     `;
 }
@@ -457,11 +458,11 @@ export function getRandomPerPointWithSelectionShader(
                 float r = hashToFloat(pointIndex, 0);
                 float g = hashToFloat(pointIndex, 1);
                 float b = hashToFloat(pointIndex, 2);
-                ${borderWidthGlsl(borderWidth)}
                 setColor(vec4(r, g, b, ${opacity}));
-            } else {
                 ${borderWidthGlsl(borderWidth)}
+            } else {
                 setColor(${toVec4(normDefault, opacity)});
+                ${borderWidthGlsl(borderWidth)}
             }
         }
     `;
@@ -501,8 +502,8 @@ export function getRandomPerPointFilteredShader(
             float r = hashToFloat(pointIndex, 0);
             float g = hashToFloat(pointIndex, 1);
             float b = hashToFloat(pointIndex, 2);
-            ${borderWidthGlsl(borderWidth)}
             setColor(vec4(r, g, b, ${opacity}));
+            ${borderWidthGlsl(borderWidth)}
         }
     `;
 }

--- a/packages/view-types/neuroglancer/src/shader-utils.js
+++ b/packages/view-types/neuroglancer/src/shader-utils.js
@@ -691,14 +691,14 @@ export function getPointsShader(layerCoordination) {
         featureIndices, opacity, featureIndexProp, pointIndexProp, pointMarkerBorderWidth,
       );
     }
-    if (!hasFeatureSelection || !hasResolvedIndices) {
-      return getRandomPerPointShader(
-        opacity,
-        featureIndexProp,
-        pointIndexProp,
-        pointMarkerBorderWidth,
-      );
-    }
+    return getRandomPerPointWithSelectionShader(
+      featureIndices,
+      defaultColor,
+      opacity,
+      featureIndexProp,
+      pointIndexProp,
+      pointMarkerBorderWidth,
+    );
   }
 
   // Fallback: static color.

--- a/packages/view-types/neuroglancer/src/shader-utils.js
+++ b/packages/view-types/neuroglancer/src/shader-utils.js
@@ -16,6 +16,17 @@ function normalizeColor(rgbColor) {
 }
 
 /**
+ * GLSL call to set point marker border width.
+ * Set to 0.0 to remove the outline.
+ * @param {number} borderWidth
+ * @returns {string}
+ */
+function borderWidthGlsl(borderWidth = 0.0) {
+  return `setPointMarkerBorderWidth(${borderWidth});`;
+}
+
+
+/**
  * Format a normalized color as a GLSL vec3 literal.
  * @param {[number, number, number]} normalizedColor
  * @returns {string}
@@ -45,11 +56,12 @@ function toVec4(normalizedColor, alpha) {
  * @param {number} opacity Opacity (0-1).
  * @returns {string} A GLSL shader string.
  */
-export function getSpatialLayerColorShader(staticColor, opacity) {
+export function getSpatialLayerColorShader(staticColor, opacity, borderWidth = 0.0) {
   const norm = normalizeColor(staticColor);
   // lang: glsl
   return `
         void main() {
+            ${borderWidthGlsl(borderWidth)}
             setColor(${toVec4(norm, opacity)});
         }
     `;
@@ -67,7 +79,7 @@ export function getSpatialLayerColorShader(staticColor, opacity) {
  * @returns {string} A GLSL shader string.
  */
 export function getSpatialLayerColorWithSelectionShader(
-  staticColor, opacity, featureIndices, defaultColor, featureIndexProp,
+  staticColor, opacity, featureIndices, defaultColor, featureIndexProp, borderWidth = 0.0,
 ) {
   const normStatic = normalizeColor(staticColor);
   const normDefault = normalizeColor(defaultColor);
@@ -86,8 +98,10 @@ export function getSpatialLayerColorWithSelectionShader(
                 }
             }
             if (isSelected) {
+                ${borderWidthGlsl(borderWidth)}
                 setColor(${toVec4(normStatic, opacity)});
             } else {
+                ${borderWidthGlsl(borderWidth)}
                 setColor(${toVec4(normDefault, opacity)});
             }
         }
@@ -105,7 +119,7 @@ export function getSpatialLayerColorWithSelectionShader(
  * @returns {string} A GLSL shader string.
  */
 export function getSpatialLayerColorFilteredShader(
-  staticColor, opacity, featureIndices, featureIndexProp,
+  staticColor, opacity, featureIndices, featureIndexProp, borderWidth = 0.0,
 ) {
   const normStatic = normalizeColor(staticColor);
   const numFeatures = featureIndices.length;
@@ -125,6 +139,7 @@ export function getSpatialLayerColorFilteredShader(
             if (!isSelected) {
                 discard;
             }
+            ${borderWidthGlsl(borderWidth)}
             setColor(${toVec4(normStatic, opacity)});
         }
     `;
@@ -142,11 +157,12 @@ export function getSpatialLayerColorFilteredShader(
  * @param {number} opacity Opacity (0-1).
  * @returns {string} A GLSL shader string.
  */
-export function getGeneSelectionNoSelectionShader(staticColor, opacity) {
+export function getGeneSelectionNoSelectionShader(staticColor, opacity, borderWidth = 0.0,) {
   const norm = normalizeColor(staticColor);
   // lang: glsl
   return `
         void main() {
+            ${borderWidthGlsl(borderWidth)}
             setColor(${toVec4(norm, opacity)});
         }
     `;
@@ -168,7 +184,7 @@ export function getGeneSelectionNoSelectionShader(staticColor, opacity) {
  * @returns {string} A GLSL shader string.
  */
 export function getGeneSelectionWithSelectionShader(
-  featureIndices, featureColors, staticColor, defaultColor, opacity, featureIndexProp,
+  featureIndices, featureColors, staticColor, defaultColor, opacity, featureIndexProp, borderWidth=0.0,
 ) {
   const numFeatures = featureIndices.length;
   const normDefault = normalizeColor(defaultColor);
@@ -193,6 +209,7 @@ export function getGeneSelectionWithSelectionShader(
                     color = vec4(featureColors[i], ${opacity});
                 }
             }
+            ${borderWidthGlsl(borderWidth)}
             setColor(color);
         }
     `;
@@ -210,7 +227,7 @@ export function getGeneSelectionWithSelectionShader(
  * @returns {string} A GLSL shader string.
  */
 export function getGeneSelectionFilteredShader(
-  featureIndices, featureColors, staticColor, opacity, featureIndexProp,
+  featureIndices, featureColors, staticColor, opacity, featureIndexProp, borderWidth = 0.0,
 ) {
   const numFeatures = featureIndices.length;
   const normColors = featureColors.map(c => normalizeColor(c));
@@ -240,6 +257,7 @@ export function getGeneSelectionFilteredShader(
             if (!isSelected) {
                 discard;
             }
+            ${borderWidthGlsl(borderWidth)}
             setColor(vec4(matchedColor, ${opacity}));
         }
     `;
@@ -256,7 +274,7 @@ export function getGeneSelectionFilteredShader(
  * @param {string} featureIndexProp The property name for the feature index in the shader.
  * @returns {string} A GLSL shader string.
  */
-export function getRandomByFeatureShader(opacity, featureIndexProp) {
+export function getRandomByFeatureShader(opacity, featureIndexProp, borderWidth = 0.0) {
   const paletteSize = PALETTE.length;
   const normPalette = PALETTE.map(c => normalizeColor(c));
   const paletteDecl = `vec3 palette[${paletteSize}] = vec3[${paletteSize}](${normPalette.map(c => toVec3(c)).join(', ')});`;
@@ -269,6 +287,7 @@ export function getRandomByFeatureShader(opacity, featureIndexProp) {
             int colorIdx = geneIndex - (geneIndex / ${paletteSize}) * ${paletteSize};
             if (colorIdx < 0) { colorIdx = -colorIdx; }
             vec3 color = palette[colorIdx];
+            ${borderWidthGlsl(borderWidth)}
             setColor(vec4(color, ${opacity}));
         }
     `;
@@ -285,7 +304,7 @@ export function getRandomByFeatureShader(opacity, featureIndexProp) {
  * @returns {string} A GLSL shader string.
  */
 export function getRandomByFeatureWithSelectionShader(
-  featureIndices, defaultColor, opacity, featureIndexProp,
+  featureIndices, defaultColor, opacity, featureIndexProp, borderWidth = 0.0,
 ) {
   const paletteSize = PALETTE.length;
   const normPalette = PALETTE.map(c => normalizeColor(c));
@@ -310,8 +329,10 @@ export function getRandomByFeatureWithSelectionShader(
             if (isSelected) {
                 int colorIdx = geneIndex - (geneIndex / ${paletteSize}) * ${paletteSize};
                 if (colorIdx < 0) { colorIdx = -colorIdx; }
+                ${borderWidthGlsl(borderWidth)}
                 setColor(vec4(palette[colorIdx], ${opacity}));
             } else {
+                ${borderWidthGlsl(borderWidth)}
                 setColor(${toVec4(normDefault, opacity)});
             }
         }
@@ -326,7 +347,7 @@ export function getRandomByFeatureWithSelectionShader(
  * @param {string} featureIndexProp The property name for the feature index in the shader.
  * @returns {string} A GLSL shader string.
  */
-export function getRandomByFeatureFilteredShader(featureIndices, opacity, featureIndexProp) {
+export function getRandomByFeatureFilteredShader(featureIndices, opacity, featureIndexProp, borderWidth = 0.0,) {
   const paletteSize = PALETTE.length;
   const normPalette = PALETTE.map(c => normalizeColor(c));
   const numFeatures = featureIndices.length;
@@ -351,6 +372,7 @@ export function getRandomByFeatureFilteredShader(featureIndices, opacity, featur
             }
             int colorIdx = geneIndex - (geneIndex / ${paletteSize}) * ${paletteSize};
             if (colorIdx < 0) { colorIdx = -colorIdx; }
+            ${borderWidthGlsl(borderWidth)}
             setColor(vec4(palette[colorIdx], ${opacity}));
         }
     `;
@@ -385,7 +407,7 @@ function hashToFloatGlsl() {
  * @param {string} pointIndexProp The property name for the point index in the shader.
  * @returns {string} A GLSL shader string.
  */
-export function getRandomPerPointShader(opacity, featureIndexProp, pointIndexProp) {
+export function getRandomPerPointShader(opacity, featureIndexProp, pointIndexProp, borderWidth = 0.0) {
   // lang: glsl
   return `
         ${hashToFloatGlsl()}
@@ -395,6 +417,7 @@ export function getRandomPerPointShader(opacity, featureIndexProp, pointIndexPro
             float r = hashToFloat(pointIndex, 0);
             float g = hashToFloat(pointIndex, 1);
             float b = hashToFloat(pointIndex, 2);
+            ${borderWidthGlsl(borderWidth)}
             setColor(vec4(r, g, b, ${opacity}));
         }
     `;
@@ -411,7 +434,7 @@ export function getRandomPerPointShader(opacity, featureIndexProp, pointIndexPro
  * @returns {string} A GLSL shader string.
  */
 export function getRandomPerPointWithSelectionShader(
-  featureIndices, defaultColor, opacity, featureIndexProp, pointIndexProp,
+  featureIndices, defaultColor, opacity, featureIndexProp, pointIndexProp, borderWidth = 0.0,
 ) {
   const normDefault = normalizeColor(defaultColor);
   const numFeatures = featureIndices.length;
@@ -434,8 +457,10 @@ export function getRandomPerPointWithSelectionShader(
                 float r = hashToFloat(pointIndex, 0);
                 float g = hashToFloat(pointIndex, 1);
                 float b = hashToFloat(pointIndex, 2);
+                ${borderWidthGlsl(borderWidth)}
                 setColor(vec4(r, g, b, ${opacity}));
             } else {
+                ${borderWidthGlsl(borderWidth)}
                 setColor(${toVec4(normDefault, opacity)});
             }
         }
@@ -452,7 +477,7 @@ export function getRandomPerPointWithSelectionShader(
  * @returns {string} A GLSL shader string.
  */
 export function getRandomPerPointFilteredShader(
-  featureIndices, opacity, featureIndexProp, pointIndexProp,
+  featureIndices, opacity, featureIndexProp, pointIndexProp, borderWidth = 0.0,
 ) {
   const numFeatures = featureIndices.length;
   const indicesDecl = `int selectedIndices[${numFeatures}] = int[${numFeatures}](${featureIndices.join(', ')});`;
@@ -476,6 +501,7 @@ export function getRandomPerPointFilteredShader(
             float r = hashToFloat(pointIndex, 0);
             float g = hashToFloat(pointIndex, 1);
             float b = hashToFloat(pointIndex, 2);
+            ${borderWidthGlsl(borderWidth)}
             setColor(vec4(r, g, b, ${opacity}));
         }
     `;
@@ -492,10 +518,12 @@ export function getPointsShader(layerCoordination) {
     featureSelection,
     featureFilterMode,
     featureColor,
-
+    pointMarkerBorderWidth = 0.0,
     featureIndexProp,
     pointIndexProp,
   } = layerCoordination;
+
+  console.log('getPointsShader', obsColorEncoding, spatialLayerColor, spatialLayerOpacity);
 
   const defaultColor = getDefaultColor(theme);
   const opacity = spatialLayerOpacity ?? 1.0;
@@ -580,15 +608,15 @@ export function getPointsShader(layerCoordination) {
   // ---- spatialLayerColor ----
   if (obsColorEncoding === 'spatialLayerColor') {
     if (!hasFeatureSelection || !hasResolvedIndices) {
-      return getSpatialLayerColorShader(staticColor, opacity);
+      return getSpatialLayerColorShader(staticColor, opacity, pointMarkerBorderWidth);
     }
     if (isFiltered) {
       return getSpatialLayerColorFilteredShader(
-        staticColor, opacity, featureIndices, featureIndexProp,
+        staticColor, opacity, featureIndices, featureIndexProp, pointMarkerBorderWidth,
       );
     }
     return getSpatialLayerColorWithSelectionShader(
-      staticColor, opacity, featureIndices, defaultColor, featureIndexProp,
+      staticColor, opacity, featureIndices, defaultColor, featureIndexProp, pointMarkerBorderWidth,
     );
   }
 
@@ -598,17 +626,17 @@ export function getPointsShader(layerCoordination) {
       throw new Error('In order to use gene-based color encoding for Neuroglancer Points, options.featureIndexProp must be specified for the obsPoints.ng-annotations fileType in the Vitessce configuration.');
     }
     if (!hasFeatureSelection || !hasResolvedIndices) {
-      return getGeneSelectionNoSelectionShader(staticColor, opacity);
+      return getGeneSelectionNoSelectionShader(staticColor, opacity, pointMarkerBorderWidth,);
     }
     if (isFiltered) {
       return getGeneSelectionFilteredShader(
         featureIndices, resolvedFeatureColors,
-        staticColor, opacity, featureIndexProp,
+        staticColor, opacity, featureIndexProp, pointMarkerBorderWidth,
       );
     }
     return getGeneSelectionWithSelectionShader(
       featureIndices, resolvedFeatureColors,
-      staticColor, defaultColor, opacity, featureIndexProp,
+      staticColor, defaultColor, opacity, featureIndexProp, pointMarkerBorderWidth,
     );
   }
 
@@ -618,15 +646,15 @@ export function getPointsShader(layerCoordination) {
       throw new Error('In order to use gene-based color encoding for Neuroglancer Points, options.featureIndexProp must be specified for the obsPoints.ng-annotations fileType in the Vitessce configuration.');
     }
     if (!hasFeatureSelection || !hasResolvedIndices) {
-      return getRandomByFeatureShader(opacity, featureIndexProp);
+      return getRandomByFeatureShader(opacity, featureIndexProp, pointMarkerBorderWidth);
     }
     if (isFiltered) {
       return getRandomByFeatureFilteredShader(
-        featureIndices, opacity, featureIndexProp,
+        featureIndices, opacity, featureIndexProp, pointMarkerBorderWidth,
       );
     }
     return getRandomByFeatureWithSelectionShader(
-      featureIndices, defaultColor, opacity, featureIndexProp,
+      featureIndices, defaultColor, opacity, featureIndexProp, pointMarkerBorderWidth,
     );
   }
 
@@ -636,18 +664,18 @@ export function getPointsShader(layerCoordination) {
       throw new Error('In order to use per-point color encoding for Neuroglancer Points, options.pointIndexProp must be specified for the obsPoints.ng-annotations fileType in the Vitessce configuration.');
     }
     if (!hasFeatureSelection || !hasResolvedIndices) {
-      return getRandomPerPointShader(opacity, featureIndexProp, pointIndexProp);
+      return getRandomPerPointShader(opacity, featureIndexProp, pointIndexProp, pointMarkerBorderWidth,);
     }
     if (isFiltered) {
       return getRandomPerPointFilteredShader(
-        featureIndices, opacity, featureIndexProp, pointIndexProp,
+        featureIndices, opacity, featureIndexProp, pointIndexProp, pointMarkerBorderWidth,
       );
     }
     return getRandomPerPointWithSelectionShader(
-      featureIndices, defaultColor, opacity, featureIndexProp, pointIndexProp,
+      featureIndices, defaultColor, opacity, featureIndexProp, pointIndexProp, pointMarkerBorderWidth,
     );
   }
 
   // Fallback: static color.
-  return getSpatialLayerColorShader(staticColor, opacity);
+  return getSpatialLayerColorShader(staticColor, opacity, pointMarkerBorderWidth);
 }

--- a/packages/view-types/neuroglancer/src/shader-utils.test.js
+++ b/packages/view-types/neuroglancer/src/shader-utils.test.js
@@ -47,6 +47,7 @@ describe('getSpatialLayerColorShader', () => {
     const expected = `
 void main() {
     setColor(vec4(1, 0.5019607843137255, 0, 0.8));
+    setPointMarkerBorderWidth(0.0);
 }
 `;
     expectShaderEqual(result, expected);
@@ -57,6 +58,7 @@ void main() {
     const expected = `
 void main() {
     setColor(vec4(0, 0, 0, 0));
+    setPointMarkerBorderWidth(0.0);
 }
 `;
     expectShaderEqual(result, expected);
@@ -67,6 +69,7 @@ void main() {
     const expected = `
 void main() {
     setColor(vec4(1, 1, 1, 1));
+    setPointMarkerBorderWidth(0.0);
 }
 `;
     expectShaderEqual(result, expected);
@@ -90,8 +93,10 @@ void main() {
     }
     if (isSelected) {
         setColor(vec4(1, 0, 0, 0.5));
+        setPointMarkerBorderWidth(0.0);
     } else {
         setColor(vec4(0.5019607843137255, 0.5019607843137255, 0.5019607843137255, 0.5));
+        setPointMarkerBorderWidth(0.0);
     }
 }
 `;
@@ -114,8 +119,10 @@ void main() {
     }
     if (isSelected) {
         setColor(vec4(0, 1, 0, 1));
+        setPointMarkerBorderWidth(0.0);
     } else {
         setColor(vec4(0, 0, 0, 1));
+        setPointMarkerBorderWidth(0.0);
     }
 }
 `;
@@ -142,6 +149,7 @@ void main() {
         discard;
     }
     setColor(vec4(0, 0, 1, 0.9));
+    setPointMarkerBorderWidth(0.0);
 }
 `;
     expectShaderEqual(result, expected);
@@ -158,6 +166,7 @@ describe('getGeneSelectionNoSelectionShader', () => {
     const expected = `
 void main() {
     setColor(vec4(0.39215686274509803, 0.7843137254901961, 0.19607843137254902, 0.7));
+    setPointMarkerBorderWidth(0.0);
 }
 `;
     expectShaderEqual(result, expected);
@@ -186,6 +195,7 @@ void main() {
         }
     }
     setColor(color);
+    setPointMarkerBorderWidth(0.0);
 }
 `;
     expectShaderEqual(result, expected);
@@ -216,6 +226,7 @@ void main() {
         }
     }
     setColor(color);
+    setPointMarkerBorderWidth(0.0);
 }
 `;
     expectShaderEqual(result, expected);
@@ -248,6 +259,7 @@ void main() {
         discard;
     }
     setColor(vec4(matchedColor, 0.75));
+    setPointMarkerBorderWidth(0.0);
 }
 `;
     expectShaderEqual(result, expected);
@@ -269,6 +281,7 @@ void main() {
     if (colorIdx < 0) { colorIdx = -colorIdx; }
     vec3 color = palette[colorIdx];
     setColor(vec4(color, 0.5));
+    setPointMarkerBorderWidth(0.0);
 }
 `;
     expectShaderEqual(result, expected);
@@ -295,8 +308,10 @@ void main() {
         int colorIdx = geneIndex - (geneIndex / 3) * 3;
         if (colorIdx < 0) { colorIdx = -colorIdx; }
         setColor(vec4(palette[colorIdx], 0.8));
+        setPointMarkerBorderWidth(0.0);
     } else {
         setColor(vec4(0.19607843137254902, 0.19607843137254902, 0.19607843137254902, 0.8));
+        setPointMarkerBorderWidth(0.0);
     }
 }
 `;
@@ -324,6 +339,7 @@ void main() {
     int colorIdx = geneIndex - (geneIndex / 3) * 3;
     if (colorIdx < 0) { colorIdx = -colorIdx; }
     setColor(vec4(palette[colorIdx], 1));
+    setPointMarkerBorderWidth(0.0);
 }
 `;
     expectShaderEqual(result, expected);
@@ -352,6 +368,7 @@ void main() {
     float g = hashToFloat(pointIndex, 1);
     float b = hashToFloat(pointIndex, 2);
     setColor(vec4(r, g, b, 0.9));
+    setPointMarkerBorderWidth(0.0);
 }
 `;
     expectShaderEqual(result, expected);
@@ -386,8 +403,10 @@ void main() {
         float g = hashToFloat(pointIndex, 1);
         float b = hashToFloat(pointIndex, 2);
         setColor(vec4(r, g, b, 0.5));
+        setPointMarkerBorderWidth(0.0);
     } else {
         setColor(vec4(0.39215686274509803, 0.39215686274509803, 0.39215686274509803, 0.5));
+        setPointMarkerBorderWidth(0.0);
     }
 }
 `;
@@ -425,6 +444,7 @@ void main() {
     float g = hashToFloat(pointIndex, 1);
     float b = hashToFloat(pointIndex, 2);
     setColor(vec4(r, g, b, 1));
+    setPointMarkerBorderWidth(0.0);
 }
 `;
     expectShaderEqual(result, expected);

--- a/packages/view-types/neuroglancer/src/use-memo-custom-comparison.js
+++ b/packages/view-types/neuroglancer/src/use-memo-custom-comparison.js
@@ -128,6 +128,10 @@ export function customIsEqualForInitialViewerState(prevDeps, nextDeps) {
   const curriedShallowDiffByLayerCoordinationWithKeys = (depName, layerScope, keys) => shallowDiffByLayerCoordinationWithKeys(prevDeps, nextDeps, depName, layerScope, keys);
   const curriedShallowDiffByChannelCoordination = (depName, layerScope, channelScope) => shallowDiffByChannelCoordination(prevDeps, nextDeps, depName, layerScope, channelScope);
   const curriedShallowDiffByChannelCoordinationWithKeys = (depName, layerScope, channelScope, keys) => shallowDiffByChannelCoordinationWithKeys(prevDeps, nextDeps, depName, layerScope, channelScope, keys);
+  
+  if (['theme', 'showAxisLines'].some(curriedShallowDiff)) {
+    forceUpdate = true;
+  }
 
   // Segmentation layers/channels.
   if (['segmentationLayerScopes', 'segmentationChannelScopesByLayer'].some(curriedShallowDiff)) {
@@ -173,6 +177,7 @@ export function customIsEqualForInitialViewerState(prevDeps, nextDeps) {
             'featureSelection',
             'featureFilterMode',
             'featureColor',
+            'spatialPointStrokeWidth',
           ])
           // For opacity, use an epsilon comparison to avoid too many re-renders, as it affects performance.
           || (

--- a/packages/view-types/neuroglancer/src/use-memo-custom-comparison.js
+++ b/packages/view-types/neuroglancer/src/use-memo-custom-comparison.js
@@ -101,6 +101,7 @@ export function customIsEqualForCellColors(prevDeps, nextDeps) {
               'obsSetSelection',
               'additionalObsSets',
               'spatialChannelColor',
+              'spatialChannelOpacity',
             ])
         ) {
           forceUpdate = true;

--- a/packages/view-types/neuroglancer/src/use-memo-custom-comparison.js
+++ b/packages/view-types/neuroglancer/src/use-memo-custom-comparison.js
@@ -128,7 +128,7 @@ export function customIsEqualForInitialViewerState(prevDeps, nextDeps) {
   const curriedShallowDiffByLayerCoordinationWithKeys = (depName, layerScope, keys) => shallowDiffByLayerCoordinationWithKeys(prevDeps, nextDeps, depName, layerScope, keys);
   const curriedShallowDiffByChannelCoordination = (depName, layerScope, channelScope) => shallowDiffByChannelCoordination(prevDeps, nextDeps, depName, layerScope, channelScope);
   const curriedShallowDiffByChannelCoordinationWithKeys = (depName, layerScope, channelScope, keys) => shallowDiffByChannelCoordinationWithKeys(prevDeps, nextDeps, depName, layerScope, channelScope, keys);
-  
+
   if (['theme', 'showAxisLines'].some(curriedShallowDiff)) {
     forceUpdate = true;
   }


### PR DESCRIPTION
This PR enables the following
1.  Opacity change in Neuroglancer segmentation and annotation layers using their respective opacity sliders in layerController.
2. Points in the annotationLayer does not have a border now to have a clear view of the meshes
3. showAxisLines can be passed as prop to NeuroglancerView
4.  now accepts subsources which allow specifying bounds = false/true for the segmentation layer


Fixes #2460, #2458, #2462 

<img width="421" height="595" alt="Screenshot 2026-04-17 at 2 14 21 PM" src="https://github.com/user-attachments/assets/30a3e7e8-e5ab-4993-b5ff-d45f3891bd44" />

Bounds are the yellow box and axisLines are the xyz lines

<!-- For other PRs without open issue -->
#### Background
<!-- For all the PRs -->
#### Change List
-
#### Checklist
 - [ ] Have tested PR with one or more demo configurations
 - [ ] Documentation added, updated, or not applicable
