### PR TITLE
NickAkhmetov/Add support for zipped genomic profiles Zarr stores

### DIFF
--- a/.changeset/four-peas-taste.md
+++ b/.changeset/four-peas-taste.md
@@ -1,0 +1,7 @@
+---
+"@vitessce/constants-internal": patch
+"@vitessce/all": patch
+"@vitessce/config": patch
+---
+
+Add support for zipped multivec zarr stores for the genomic profiles view.

--- a/packages/config/src/generate-config.js
+++ b/packages/config/src/generate-config.js
@@ -24,6 +24,8 @@ const fileTypeToExtensions = {
   // Perhaps just assume one H5AD+one JSON (or .ref.json) file correspond to each other?
   [FileType.SPATIALDATA_ZARR]: ['.sd.zarr', '.sdata.zarr', '.spatialdata.zarr'],
   [FileType.SPATIALDATA_ZARR_ZIP]: ['.sd.zarr.zip', '.sdata.zarr.zip', '.spatialdata.zarr.zip'],
+  [FileType.GENOMIC_PROFILES_ZARR]: ['.multivec.zarr'],
+  [FileType.GENOMIC_PROFILES_ZARR_ZIP]: ['.multivec.zarr.zip'],
 };
 
 const fileTypeToClass = {
@@ -54,6 +56,8 @@ const ZARR_FILETYPES = [
   FileType.IMAGE_OME_ZARR_ZIP,
   FileType.OBS_SEGMENTATIONS_OME_ZARR,
   FileType.OBS_SEGMENTATIONS_OME_ZARR_ZIP,
+  FileType.GENOMIC_PROFILES_ZARR,
+  FileType.GENOMIC_PROFILES_ZARR_ZIP,
 ];
 
 function urlToFileType(url) {

--- a/packages/constants-internal/src/constant-relationships.ts
+++ b/packages/constants-internal/src/constant-relationships.ts
@@ -76,6 +76,7 @@ export const FILE_TYPE_DATA_TYPE_MAPPING = {
   [FileType.OBS_LABELS_MOLECULES_JSON]: DataType.OBS_LABELS,
   // For old file types
   [FileType.GENOMIC_PROFILES_ZARR]: DataType.GENOMIC_PROFILES,
+  [FileType.GENOMIC_PROFILES_ZARR_ZIP]: DataType.GENOMIC_PROFILES,
   [FileType.NEIGHBORHOODS_JSON]: DataType.NEIGHBORHOODS,
 };
 
@@ -252,5 +253,10 @@ export const ALT_ZARR_STORE_TYPES = {
   },
   [FileType.OBS_EMBEDDING_SPATIALDATA_ZARR]: {
     zip: FileType.OBS_EMBEDDING_SPATIALDATA_ZARR_ZIP,
+  },
+
+  // For genomic profiles:
+  [FileType.GENOMIC_PROFILES_ZARR]: {
+    zip: FileType.GENOMIC_PROFILES_ZARR_ZIP,
   },
 };

--- a/packages/constants-internal/src/constants.ts
+++ b/packages/constants-internal/src/constants.ts
@@ -187,6 +187,7 @@ export const FileType = {
   OBS_LABELS_MUDATA_ZARR: 'obsLabels.mudata.zarr',
   FEATURE_LABELS_MUDATA_ZARR: 'featureLabels.mudata.zarr',
   GENOMIC_PROFILES_ZARR: 'genomic-profiles.zarr',
+  GENOMIC_PROFILES_ZARR_ZIP: 'genomic-profiles.zarr.zip',
   NEIGHBORHOODS_JSON: 'neighborhoods.json',
   // OME-TIFF
   IMAGE_OME_TIFF: 'image.ome-tiff',

--- a/packages/main/all/src/base-plugins.ts
+++ b/packages/main/all/src/base-plugins.ts
@@ -366,6 +366,7 @@ export const baseFileTypes = [
   makeFileType(FileType.OBS_LABELS_MOLECULES_JSON, DataType.OBS_LABELS, MoleculesJsonAsObsLabelsLoader, JsonSource, z.null()),
   makeFileType(FileType.NEIGHBORHOODS_JSON, DataType.NEIGHBORHOODS, JsonLoader, JsonSource, z.null()),
   makeFileType(FileType.GENOMIC_PROFILES_ZARR, DataType.GENOMIC_PROFILES, GenomicProfilesZarrLoader, ZarrDataSource, z.null()),
+  makeFileType(FileType.GENOMIC_PROFILES_ZARR_ZIP, DataType.GENOMIC_PROFILES, GenomicProfilesZarrLoader, ZarrDataSource, z.null()),
 ];
 
 export const baseJointFileTypes = [


### PR DESCRIPTION
<!-- Credit (as a starting template): https://github.com/visgl/deck.gl/blob/master/.github/pull_request_template.md -->
<!-- For feature, feature enhancement or bug fix, create an issue first and finish To Do List there -->
<!-- Anything doesn't work as expected is a bug, including code, doc and test -->
Fixes ##2482

<!-- For other PRs without open issue -->
#### Background

The zarr stores powering the genomic profile view are not currently possible to zip up due to the necessary constants/mappings not being defined. This PR adds the necessary mappings to enable using zipped genomic profile zarr stores.

#### Change List
- Added `GENOMIC_PROFILES_ZARR_ZIP` constant, corresponding relationship in `constant-relationships`, and plugin.

#### Checklist
 - [x] Have tested PR with one or more demo configurations
 - [x] Documentation added, updated, or not applicable
