### PR TITLE
Tkakar/fix 2457 opacity slider; Neuroglancer: support for point opacity

### DIFF
--- a/.changeset/strange-boats-repair.md
+++ b/.changeset/strange-boats-repair.md
@@ -1,0 +1,8 @@
+---
+"@vitessce/layer-controller-beta": patch
+"@vitessce/neuroglancer": patch
+"@vitessce/spatial-beta": patch
+"@vitessce/all": patch
+---
+
+Adds per feature opactiy when genes are added as feature for points

--- a/packages/main/all/src/base-plugins.ts
+++ b/packages/main/all/src/base-plugins.ts
@@ -493,6 +493,7 @@ export const baseCoordinationTypes = [
     z.array(z.object({
       name: z.string(),
       color: rgbArray,
+      opacity: z.number().min(0).max(1).optional(),
     })).nullable(),
   ),
   new PluginCoordinationType(

--- a/packages/view-types/layer-controller-beta/src/LayerPerFeatureController.js
+++ b/packages/view-types/layer-controller-beta/src/LayerPerFeatureController.js
@@ -61,13 +61,31 @@ export default function LayerPerFeatureController(props) {
     featureIndex,
     obsColorEncoding,
     loadingDoneFraction,
-    opacity,
-    handleOpacityChange,
   } = props;
 
   const featureColorIndex = useMemo(() => (
     featureColor?.findIndex(fc => fc.name === featureName) ?? -1
   ), [featureColor, featureName]);
+
+  const featureOpacity = featureColor?.[featureColorIndex]?.opacity ?? 1.0;
+
+  const handleFeatureOpacityChange = useCallback((e, newValue) => {
+    if (featureColorIndex >= 0) {
+      const nextFeatureColor = [...featureColor];
+      nextFeatureColor[featureColorIndex] = {
+        ...nextFeatureColor[featureColorIndex],
+        opacity: newValue,
+      };
+      setFeatureColor(nextFeatureColor);
+    } else {
+      // No entry yet — create one with the opacity
+      setFeatureColor([
+        ...(featureColor ?? []),
+        { name: featureName, color: spatialLayerColor ?? [255, 255, 255], opacity: newValue },
+      ]);
+    }
+  }, [featureName, featureColor, setFeatureColor, featureColorIndex, spatialLayerColor]);
+
 
   const varIndex = useMemo(() => (
     featureIndex?.indexOf(featureName) ?? -1
@@ -197,11 +215,11 @@ export default function LayerPerFeatureController(props) {
           </Grid>
           <Grid size={2} sx={{ paddingRight: '12px', overflow: 'visible' }}>
             <Slider
-              value={opacity}
+              value={featureOpacity}
               min={0}
               max={1}
               step={0.001}
-              onChange={handleOpacityChange}
+              onChange={handleFeatureOpacityChange}
               className={menuClasses.imageLayerOpacitySlider}
               orientation="horizontal"
               aria-label={`Adjust opacity for layer ${featureName}`}

--- a/packages/view-types/layer-controller-beta/src/PointLayerController.js
+++ b/packages/view-types/layer-controller-beta/src/PointLayerController.js
@@ -500,8 +500,6 @@ export default function PointLayerController(props) {
               setFeatureSelection={setFeatureSelection}
               obsColorEncoding={obsColorEncoding}
               loadingDoneFraction={loadingDoneFraction}
-              opacity={opacity}
-              handleOpacityChange={handleOpacityChange}
             />
           ))}
           <Grid className={lcClasses.layerControllerGrid}>

--- a/packages/view-types/neuroglancer/src/shader-utils.js
+++ b/packages/view-types/neuroglancer/src/shader-utils.js
@@ -46,6 +46,8 @@ function toVec4(normalizedColor, alpha) {
   return `vec4(${normalizedColor.join(', ')}, ${alpha})`;
 }
 
+
+
 // ============================================================
 // Case 1: spatialLayerColor
 // ============================================================
@@ -186,6 +188,7 @@ export function getGeneSelectionNoSelectionShader(staticColor, opacity, borderWi
  */
 export function getGeneSelectionWithSelectionShader(
   featureIndices,
+  featureOpacities,
   featureColors,
   staticColor,
   defaultColor,
@@ -201,19 +204,23 @@ export function getGeneSelectionWithSelectionShader(
   const colorArr = normColors.map(
     c => (c ? toVec3(c) : toVec3(normStatic)),
   );
+  const opacityArr = featureOpacities.map(o => o.toFixed(4));
 
   const indicesDecl = `int selectedIndices[${numFeatures}] = int[${numFeatures}](${featureIndices.join(', ')});`;
   const colorsDecl = `vec3 featureColors[${numFeatures}] = vec3[${numFeatures}](${colorArr.join(', ')});`;
+  const opacitiesDecl = `float featureOpacities[${numFeatures}] = float[${numFeatures}](${opacityArr.join(', ')});`;
+
   // lang: glsl
   return `
         void main() {
             int geneIndex = prop_${featureIndexProp}();
             ${indicesDecl}
             ${colorsDecl}
+            ${opacitiesDecl}
             vec4 color = ${toVec4(normDefault, opacity)};
             for (int i = 0; i < ${numFeatures}; ++i) {
                 if (geneIndex == selectedIndices[i]) {
-                    color = vec4(featureColors[i], ${opacity});
+                    color = vec4(featureColors[i], featureOpacities[i]);
                 }
             }
             setColor(color);
@@ -234,7 +241,8 @@ export function getGeneSelectionWithSelectionShader(
  * @returns {string} A GLSL shader string.
  */
 export function getGeneSelectionFilteredShader(
-  featureIndices, featureColors, staticColor, opacity, featureIndexProp, borderWidth = 0.0,
+  featureIndices, featureColors, featureOpacities, staticColor, opacity, featureIndexProp,
+  borderWidth = 0.0,
 ) {
   const numFeatures = featureIndices.length;
   const normColors = featureColors.map(c => normalizeColor(c));
@@ -243,9 +251,11 @@ export function getGeneSelectionFilteredShader(
   const colorArr = normColors.map(
     c => (c ? toVec3(c) : toVec3(normStatic)),
   );
+  const opacityArr = featureOpacities.map(o => o.toFixed(4));
 
   const indicesDecl = `int selectedIndices[${numFeatures}] = int[${numFeatures}](${featureIndices.join(', ')});`;
   const colorsDecl = `vec3 featureColors[${numFeatures}] = vec3[${numFeatures}](${colorArr.join(', ')});`;
+  const opacitiesDecl = `float featureOpacities[${numFeatures}] = float[${numFeatures}](${opacityArr.join(', ')});`;
 
   // lang: glsl
   return `
@@ -253,18 +263,21 @@ export function getGeneSelectionFilteredShader(
             int geneIndex = prop_${featureIndexProp}();
             ${indicesDecl}
             ${colorsDecl}
+            ${opacitiesDecl}
             bool isSelected = false;
             vec3 matchedColor = vec3(0.0);
+            float matchedOpacity = ${opacity.toFixed(4)}; 
             for (int i = 0; i < ${numFeatures}; ++i) {
                 if (geneIndex == selectedIndices[i]) {
                     isSelected = true;
                     matchedColor = featureColors[i];
+                    matchedOpacity = featureOpacities[i];
                 }
             }
             if (!isSelected) {
                 discard;
             }
-            setColor(vec4(matchedColor, ${opacity}));
+            setColor(vec4(matchedColor, matchedOpacity));
             ${borderWidthGlsl(borderWidth)}
         }
     `;
@@ -574,6 +587,17 @@ export function getPointsShader(layerCoordination) {
       })
     : [];
 
+  const resolvedFeatureOpacities = hasResolvedIndices
+  ? featureSelection
+    .filter(name => featureIndex?.indexOf(name) >= 0)
+    .map((name) => {
+      const match = Array.isArray(featureColor)
+        ? featureColor.find(fc => fc.name === name)
+        : null;
+      return match?.opacity ?? opacity;
+    })
+  : [];
+
   // Points coloring cases:
   // (See `createPointLayer` in spatial-beta/Spatial.js for more background.)
 
@@ -645,12 +669,12 @@ export function getPointsShader(layerCoordination) {
     }
     if (isFiltered) {
       return getGeneSelectionFilteredShader(
-        featureIndices, resolvedFeatureColors,
+        featureIndices, resolvedFeatureColors, resolvedFeatureOpacities,
         staticColor, opacity, featureIndexProp, pointMarkerBorderWidth,
       );
     }
     return getGeneSelectionWithSelectionShader(
-      featureIndices, resolvedFeatureColors,
+      featureIndices, resolvedFeatureOpacities, resolvedFeatureColors,
       staticColor, defaultColor, opacity, featureIndexProp, pointMarkerBorderWidth,
     );
   }

--- a/packages/view-types/neuroglancer/src/shader-utils.js
+++ b/packages/view-types/neuroglancer/src/shader-utils.js
@@ -47,7 +47,6 @@ function toVec4(normalizedColor, alpha) {
 }
 
 
-
 // ============================================================
 // Case 1: spatialLayerColor
 // ============================================================
@@ -588,15 +587,15 @@ export function getPointsShader(layerCoordination) {
     : [];
 
   const resolvedFeatureOpacities = hasResolvedIndices
-  ? featureSelection
-    .filter(name => featureIndex?.indexOf(name) >= 0)
-    .map((name) => {
-      const match = Array.isArray(featureColor)
-        ? featureColor.find(fc => fc.name === name)
-        : null;
-      return match?.opacity ?? opacity;
-    })
-  : [];
+    ? featureSelection
+      .filter(name => featureIndex?.indexOf(name) >= 0)
+      .map((name) => {
+        const match = Array.isArray(featureColor)
+          ? featureColor.find(fc => fc.name === name)
+          : null;
+        return match?.opacity ?? opacity;
+      })
+    : [];
 
   // Points coloring cases:
   // (See `createPointLayer` in spatial-beta/Spatial.js for more background.)

--- a/packages/view-types/neuroglancer/src/shader-utils.js
+++ b/packages/view-types/neuroglancer/src/shader-utils.js
@@ -12,6 +12,9 @@ import { PALETTE, getDefaultColor } from '@vitessce/utils';
  * @returns {[number, number, number]}
  */
 function normalizeColor(rgbColor) {
+  if (!Array.isArray(rgbColor)) {
+    return [0, 0, 0];
+  }
   return rgbColor.map(c => c / 255);
 }
 

--- a/packages/view-types/neuroglancer/src/shader-utils.test.js
+++ b/packages/view-types/neuroglancer/src/shader-utils.test.js
@@ -185,20 +185,21 @@ describe('getGeneSelectionWithSelectionShader', () => {
       'gene_index',
     );
     const expected = `
-void main() {
-    int geneIndex = prop_gene_index();
-    int selectedIndices[2] = int[2](1, 4);
-    vec3 featureColors[2] = vec3[2](vec3(1, 0, 0), vec3(0, 1, 0));
-    vec4 color = vec4(0.19607843137254902, 0.19607843137254902, 0.19607843137254902, 0.6);
-    for (int i = 0; i < 2; ++i) {
-        if (geneIndex == selectedIndices[i]) {
-            color = vec4(featureColors[i], 0.6);
+    void main() {
+        int geneIndex = prop_gene_index();
+        int selectedIndices[2] = int[2](1, 4);
+        vec3 featureColors[2] = vec3[2](vec3(1, 0, 0), vec3(0, 1, 0));
+        float featureOpacities[2] = float[2](1.0000, 0.5000);
+        vec4 color = vec4(0.19607843137254902, 0.19607843137254902, 0.19607843137254902, 0.6);
+        for (int i = 0; i < 2; ++i) {
+            if (geneIndex == selectedIndices[i]) {
+                color = vec4(featureColors[i], featureOpacities[i]);
+            }
         }
+        setColor(color);
+        setPointMarkerBorderWidth(0.0);
     }
-    setColor(color);
-    setPointMarkerBorderWidth(0.0);
-}
-`;
+    `;
     expectShaderEqual(result, expected);
   });
 
@@ -246,25 +247,28 @@ describe('getGeneSelectionFilteredShader', () => {
       'gene_index',
     );
     const expected = `
-void main() {
-    int geneIndex = prop_gene_index();
-    int selectedIndices[2] = int[2](2, 8);
-    vec3 featureColors[2] = vec3[2](vec3(1, 0, 0), vec3(0, 0, 1));
-    bool isSelected = false;
-    vec3 matchedColor = vec3(0.0);
-    for (int i = 0; i < 2; ++i) {
-        if (geneIndex == selectedIndices[i]) {
-            isSelected = true;
-            matchedColor = featureColors[i];
-        }
-    }
-    if (!isSelected) {
-        discard;
-    }
-    setColor(vec4(matchedColor, 0.75));
-    setPointMarkerBorderWidth(0.0);
-}
-`;
+      void main() {
+          int geneIndex = prop_gene_index();
+          int selectedIndices[2] = int[2](2, 8);
+          vec3 featureColors[2] = vec3[2](vec3(1, 0, 0), vec3(0, 0, 1));
+          float featureOpacities[2] = float[2](0.8000, 0.3000);
+          bool isSelected = false;
+          vec3 matchedColor = vec3(0.0);
+          float matchedOpacity = 0.7500;
+          for (int i = 0; i < 2; ++i) {
+              if (geneIndex == selectedIndices[i]) {
+                  isSelected = true;
+                  matchedColor = featureColors[i];
+                  matchedOpacity = featureOpacities[i];
+              }
+          }
+          if (!isSelected) {
+              discard;
+          }
+          setColor(vec4(matchedColor, matchedOpacity));
+          setPointMarkerBorderWidth(0.0);
+      }
+      `;
     expectShaderEqual(result, expected);
   });
 });

--- a/packages/view-types/neuroglancer/src/shader-utils.test.js
+++ b/packages/view-types/neuroglancer/src/shader-utils.test.js
@@ -177,6 +177,7 @@ describe('getGeneSelectionWithSelectionShader', () => {
   it('generates a shader with per-feature colors for selected and default for unselected', () => {
     const result = getGeneSelectionWithSelectionShader(
       [1, 4],
+      [1.0, 0.5],
       [[255, 0, 0], [0, 255, 0]],
       [128, 128, 128],
       [50, 50, 50],
@@ -208,6 +209,7 @@ void main() {
     // Since featureColors are always normalized, we just check the normal path.
     const result = getGeneSelectionWithSelectionShader(
       [0],
+      [1.0],
       [[0, 0, 255]],
       [255, 255, 255],
       [0, 0, 0],
@@ -238,6 +240,7 @@ describe('getGeneSelectionFilteredShader', () => {
     const result = getGeneSelectionFilteredShader(
       [2, 8],
       [[255, 0, 0], [0, 0, 255]],
+      [0.8, 0.3],
       [128, 128, 128],
       0.75,
       'gene_index',

--- a/packages/view-types/neuroglancer/src/shader-utils.test.js
+++ b/packages/view-types/neuroglancer/src/shader-utils.test.js
@@ -222,10 +222,11 @@ void main() {
     int geneIndex = prop_fi();
     int selectedIndices[1] = int[1](0);
     vec3 featureColors[1] = vec3[1](vec3(0, 0, 1));
+    float featureOpacities[1] = float[1](1.0000);
     vec4 color = vec4(0, 0, 0, 1);
     for (int i = 0; i < 1; ++i) {
         if (geneIndex == selectedIndices[i]) {
-            color = vec4(featureColors[i], 1);
+            color = vec4(featureColors[i], featureOpacities[i]);
         }
     }
     setColor(color);

--- a/packages/view-types/spatial-beta/src/Spatial.js
+++ b/packages/view-types/spatial-beta/src/Spatial.js
@@ -494,8 +494,14 @@ class Spatial extends AbstractSpatialOrScatterplot {
           target[1] = staticColor[1];
           // eslint-disable-next-line no-param-reassign
           target[2] = staticColor[2];
+
+          const featureName = pointFeatureIndex?.[data.src.featureIndices[index]];
+          const featureColorMatch = Array.isArray(featureColor)
+            ? featureColor.find(fc => fc.name === featureName)
+            : null;
+          const featureOpacity = featureColorMatch?.opacity ?? spatialLayerOpacity ?? 1.0;
           // eslint-disable-next-line no-param-reassign
-          target[3] = 255;
+          target[3] = Math.round(featureOpacity * 255);
           return target;
         }
         if (!showUnselected) {
@@ -541,6 +547,7 @@ class Spatial extends AbstractSpatialOrScatterplot {
           const featureColorMatch = Array.isArray(featureColor)
             ? featureColor.find(fc => fc.name === featureName)?.color
             : null;
+          const featureOpacity = featureColorMatch?.opacity ?? spatialLayerOpacity ?? 1.0;
           if (featureColorMatch) {
             // eslint-disable-next-line no-param-reassign
             target[0] = featureColorMatch[0];
@@ -549,7 +556,7 @@ class Spatial extends AbstractSpatialOrScatterplot {
             // eslint-disable-next-line no-param-reassign
             target[2] = featureColorMatch[2];
             // eslint-disable-next-line no-param-reassign
-            target[3] = 255;
+            target[3] = Math.round(featureOpacity * 255);
             return target;
           }
           // No color found for this feature: use static color.
@@ -606,8 +613,14 @@ class Spatial extends AbstractSpatialOrScatterplot {
             target[1] = color[1];
             // eslint-disable-next-line no-param-reassign
             target[2] = color[2];
+    
+            const featureName = pointFeatureIndex?.[data.src.featureIndices[index]];
+            const featureColorMatch = Array.isArray(featureColor)
+              ? featureColor.find(fc => fc.name === featureName)
+              : null;
+            const featureOpacity = featureColorMatch?.opacity ?? spatialLayerOpacity ?? 1.0;
             // eslint-disable-next-line no-param-reassign
-            target[3] = 255;
+            target[3] = Math.round(featureOpacity * 255);
             return target;
           }
           if (!showUnselected) {

--- a/packages/view-types/spatial-beta/src/Spatial.js
+++ b/packages/view-types/spatial-beta/src/Spatial.js
@@ -613,7 +613,7 @@ class Spatial extends AbstractSpatialOrScatterplot {
             target[1] = color[1];
             // eslint-disable-next-line no-param-reassign
             target[2] = color[2];
-    
+
             const featureName = pointFeatureIndex?.[data.src.featureIndices[index]];
             const featureColorMatch = Array.isArray(featureColor)
               ? featureColor.find(fc => fc.name === featureName)


### PR DESCRIPTION
Adds independent opacity slider for each gene added as a feature for points. 

Fixes #2457 
<!-- For other PRs without open issue -->
#### Background
<!-- For all the PRs -->
#### Change List
-
#### Checklist
 - [ ] Have tested PR with one or more demo configurations
 - [ ] Documentation added, updated, or not applicable
