### PR TITLE
Multiselect sort fixed

### DIFF
--- a/.changeset/little-lizards-brake.md
+++ b/.changeset/little-lizards-brake.md
@@ -3,4 +3,5 @@
 "@vitessce/example-configs": patch
 ---
 
-Fixed sort-order gene selection to click-based when FeatureList multi-select is enabled
+- Fixed sort-order gene selection to click-based when FeatureList multi-select is enabled
+- Added the FeatureAggregateStrategy option for the spatial view to match the scatterplot view.

--- a/.changeset/little-lizards-brake.md
+++ b/.changeset/little-lizards-brake.md
@@ -1,0 +1,6 @@
+---
+"@vitessce/feature-list": patch
+"@vitessce/example-configs": patch
+---
+
+Fixed sort-order gene selection to click-based when FeatureList multi-select is enabled

--- a/examples/configs/src/view-configs/marshall_2022_iscience.js
+++ b/examples/configs/src/view-configs/marshall_2022_iscience.js
@@ -139,6 +139,9 @@ export const marshall2022iScience = {
       obsType: 'A',
       featureType: 'A',
     },
+    props: {
+      enableMultiSelect: true,
+    },
     uid: 'G',
   },
   {

--- a/packages/view-types/feature-list/src/FeatureList.js
+++ b/packages/view-types/feature-list/src/FeatureList.js
@@ -60,14 +60,36 @@ export default function FeatureList(props) {
       const selectionArray = Array.isArray(selection)
         ? selection
         : [selection];
-      const selectedVisibleKeys = selectionArray.map(s => s.key).filter(
+      const incomingKeys = selectionArray.map(s => s.key).filter(
         key => searchResults.includes(key),
       );
 
-      const newSelection = enableMultiSelect ? (
-        [...selectedHiddenKeys, ...selectedVisibleKeys]
-          .filter(Boolean)
-      ) : selectionArray.map(s => s.key).filter(Boolean);
+      let newSelection;
+      if (enableMultiSelect) {
+        // Find which key was just clicked by diffing against current geneSelection.
+        // It's either a newly added key, or if a key was removed, we keep the order as is.
+        const currentVisibleSelection = (geneSelection || []).filter(
+          key => searchResults.includes(key),
+        );
+        const addedKey = incomingKeys.find(k => !currentVisibleSelection.includes(k));
+
+        let orderedVisibleKeys;
+        if (addedKey) {
+          // Keep previous order, move/append the newly clicked key to the end
+          // so featureAggregationStrategy:'last' always points to the most recent click.
+          orderedVisibleKeys = [
+            ...currentVisibleSelection.filter(k => incomingKeys.includes(k) && k !== addedKey),
+            addedKey,
+          ];
+        } else {
+          // A key was removed — preserve the existing click order, just drop the removed one
+          orderedVisibleKeys = currentVisibleSelection.filter(k => incomingKeys.includes(k));
+        }
+        // Safety net for any null/undefined values
+        newSelection = [...selectedHiddenKeys, ...orderedVisibleKeys].filter(Boolean);
+      } else {
+        newSelection = incomingKeys.filter(Boolean);
+      }
 
       if (newSelection.length > 0) {
         setGeneSelection(newSelection);

--- a/packages/view-types/feature-list/src/FeatureList.js
+++ b/packages/view-types/feature-list/src/FeatureList.js
@@ -60,36 +60,15 @@ export default function FeatureList(props) {
       const selectionArray = Array.isArray(selection)
         ? selection
         : [selection];
-      const incomingKeys = selectionArray.map(s => s.key).filter(
+      const selectedVisibleKeys = selectionArray.map(s => s.key).filter(
         key => searchResults.includes(key),
       );
 
-      let newSelection;
-      if (enableMultiSelect) {
-        // Find which key was just clicked by diffing against current geneSelection.
-        // It's either a newly added key, or if a key was removed, we keep the order as is.
-        const currentVisibleSelection = (geneSelection || []).filter(
-          key => searchResults.includes(key),
-        );
-        const addedKey = incomingKeys.find(k => !currentVisibleSelection.includes(k));
 
-        let orderedVisibleKeys;
-        if (addedKey) {
-          // Keep previous order, move/append the newly clicked key to the end
-          // so featureAggregationStrategy:'last' always points to the most recent click.
-          orderedVisibleKeys = [
-            ...currentVisibleSelection.filter(k => incomingKeys.includes(k) && k !== addedKey),
-            addedKey,
-          ];
-        } else {
-          // A key was removed — preserve the existing click order, just drop the removed one
-          orderedVisibleKeys = currentVisibleSelection.filter(k => incomingKeys.includes(k));
-        }
-        // Safety net for any null/undefined values
-        newSelection = [...selectedHiddenKeys, ...orderedVisibleKeys].filter(Boolean);
-      } else {
-        newSelection = incomingKeys.filter(Boolean);
-      }
+      const newSelection = enableMultiSelect ? (
+        [...selectedHiddenKeys, ...selectedVisibleKeys]
+          .filter(Boolean)
+      ) : selectionArray.map(s => s.key).filter(Boolean);
 
       if (newSelection.length > 0) {
         setGeneSelection(newSelection);
@@ -110,7 +89,6 @@ export default function FeatureList(props) {
             || featureLabelsMap?.get(cleanFeatureId(gene))
             || gene
           ),
-          value: (geneSelection ? geneSelection.includes(gene) : false),
         }),
       );
 
@@ -122,7 +100,7 @@ export default function FeatureList(props) {
 
     return preSortedData;
   }, [featureListSort, selectableTableSortKey, searchResults,
-    geneFilter, featureLabelsMap, geneSelection,
+    geneFilter, featureLabelsMap,
   ]);
 
   const handleChange = (event) => {
@@ -157,7 +135,7 @@ export default function FeatureList(props) {
         data={data}
         hasColorEncoding={hasColorEncoding}
         idKey="key"
-        valueKey="value"
+        selectedIds={geneSelection}
         onChange={onChange}
         allowMultiple={enableMultiSelect}
         allowUncheck={enableMultiSelect}

--- a/packages/view-types/feature-list/src/selectable-table/SelectableTable.js
+++ b/packages/view-types/feature-list/src/selectable-table/SelectableTable.js
@@ -37,7 +37,7 @@ export default function SelectableTable(props) {
     data,
     onChange,
     idKey = 'id',
-    valueKey = 'value',
+    selectedIds,
     allowMultiple = false,
     allowUncheck = false,
     showTableHead = true,
@@ -113,25 +113,27 @@ export default function SelectableTable(props) {
     Array.isArray(selectedRows) && selectedRows.includes(id)
   ), [selectedRows]);
 
-  /* eslint-disable react-hooks/exhaustive-deps */
+  // When selectedIds is provided, sync selectedRows from it while preserving
+  // existing click order: keep already-selected items first, append newly selected ones.
   useEffect(() => {
-    // Check whether an initial set of rows should be selected.
-    const initialSelectedRows = data
-      .map((d) => {
-        if (d[valueKey]) {
-          return d[idKey];
-        }
-        return null;
-      })
-      .filter(Boolean);
-    if (!isEqual(initialSelectedRows, selectedRows)) {
-      if (initialSelectedRows.length > 0) {
-        setSelectedRows(initialSelectedRows);
-      } else {
-        setSelectedRows(null);
+    if (selectedIds === undefined) return;
+    setSelectedRows((prev) => {
+      // Determine the next selected rows state.
+      // For newly selected items,
+      // we want them to appear at the end of the list,
+      // so that featureAggregationStrategy: 'last' means
+      // both "final" and "most-recent".
+      const prevList = prev || [];
+      const nextList = selectedIds || [];
+      const sharedList = prevList.filter(id => nextList.includes(id));
+      const nextUnique = nextList.filter(id => !prevList.includes(id));
+      const merged = [...sharedList, ...nextUnique];
+      if (isEqual(merged, prevList)) {
+        return prev;
       }
-    }
-  }, [data, idKey, valueKey]);
+      return merged.length > 0 ? merged : null;
+    });
+  }, [selectedIds]);
 
   /* eslint-disable react-hooks/exhaustive-deps */
   useEffect(() => {

--- a/packages/view-types/spatial/src/Spatial.js
+++ b/packages/view-types/spatial/src/Spatial.js
@@ -813,6 +813,7 @@ class Spatial extends AbstractSpatialOrScatterplot {
         'cellColorEncoding',
         'geneExpressionColormap',
         'segmentationLayerCallbacks',
+        'getExpressionValue',
       ].some(shallowDiff)
     ) {
       // Cells layer props changed.

--- a/packages/view-types/spatial/src/SpatialOptions.js
+++ b/packages/view-types/spatial/src/SpatialOptions.js
@@ -8,6 +8,7 @@ import {
   Slider,
   makeStyles,
 } from '@vitessce/styles';
+import { capitalize } from '@vitessce/utils';
 import {
   usePlotOptionsStyles, OptionsContainer, CellColorEncodingOption, OptionSelect,
 } from '@vitessce/vit-s';
@@ -21,6 +22,7 @@ const useToggleStyles = makeStyles()(() => ({
     padding: '0px',
   },
 }));
+const FEATURE_AGGREGATION_STRATEGIES = ['first', 'last', 'sum', 'mean'];
 
 const ToggleFixedAxisButton = ({
   setSpatialAxisFixed,
@@ -72,7 +74,6 @@ export default function SpatialOptions(props) {
     canShow3DOptions,
     featureAggregationStrategy,
     setFeatureAggregationStrategy,
-    featureSelection,
   } = props;
 
   const spatialOptionsId = useId();
@@ -206,8 +207,11 @@ export default function SpatialOptions(props) {
                   onChange={e => setFeatureAggregationStrategy(e.target.value)}
                   inputProps={{ id: `feature-aggregation-strategy-${spatialOptionsId}` }}
                 >
-                  <option value="first">First</option>
-                  <option value="last">Last</option>
+                  {FEATURE_AGGREGATION_STRATEGIES.map(opt => (
+                    <option key={opt} value={opt}>
+                    {capitalize(opt)}
+                  </option>
+                ))}
                 </OptionSelect>
               </TableCell>
             </TableRow>

--- a/packages/view-types/spatial/src/SpatialOptions.js
+++ b/packages/view-types/spatial/src/SpatialOptions.js
@@ -209,9 +209,9 @@ export default function SpatialOptions(props) {
                 >
                   {FEATURE_AGGREGATION_STRATEGIES.map(opt => (
                     <option key={opt} value={opt}>
-                    {capitalize(opt)}
-                  </option>
-                ))}
+                      {capitalize(opt)}
+                    </option>
+                  ))}
                 </OptionSelect>
               </TableCell>
             </TableRow>

--- a/packages/view-types/spatial/src/SpatialOptions.js
+++ b/packages/view-types/spatial/src/SpatialOptions.js
@@ -70,6 +70,9 @@ export default function SpatialOptions(props) {
     canShowExpressionOptions,
     canShowColorEncodingOption,
     canShow3DOptions,
+    featureAggregationStrategy,
+    setFeatureAggregationStrategy,
+    featureSelection,
   } = props;
 
   const spatialOptionsId = useId();
@@ -189,6 +192,26 @@ export default function SpatialOptions(props) {
               />
             </TableCell>
           </TableRow>
+          {setFeatureAggregationStrategy ? (
+            <TableRow>
+              <TableCell className={classes.labelCell} variant="head" scope="row">
+                <label htmlFor={`feature-aggregation-strategy-${spatialOptionsId}`}>
+                  Feature Aggregation Strategy
+                </label>
+              </TableCell>
+              <TableCell className={classes.inputCell} variant="body">
+                <OptionSelect
+                  className={classes.select}
+                  value={featureAggregationStrategy ?? 'first'}
+                  onChange={e => setFeatureAggregationStrategy(e.target.value)}
+                  inputProps={{ id: `feature-aggregation-strategy-${spatialOptionsId}` }}
+                >
+                  <option value="first">First</option>
+                  <option value="last">Last</option>
+                </OptionSelect>
+              </TableCell>
+            </TableRow>
+          ) : null}
         </>
       ) : null}
     </OptionsContainer>

--- a/packages/view-types/spatial/src/SpatialSubscriber.js
+++ b/packages/view-types/spatial/src/SpatialSubscriber.js
@@ -105,6 +105,7 @@ export function SpatialSubscriber(props) {
     featureValueColormapRange: geneExpressionColormapRange,
     tooltipsVisible,
     photometricInterpretation: photometricInterpretationFromCoordination,
+    featureAggregationStrategy,
   }, {
     setSpatialZoom: setZoom,
     setSpatialTargetX: setTargetX,
@@ -128,6 +129,7 @@ export function SpatialSubscriber(props) {
     setFeatureValueColormap: setGeneExpressionColormap,
     setFeatureValueColormapRange: setGeneExpressionColormapRange,
     setTooltipsVisible,
+    setFeatureAggregationStrategy,
   }] = useCoordination(COMPONENT_COORDINATION_TYPES[ViewType.SPATIAL], coordinationScopes);
 
   const {
@@ -542,6 +544,9 @@ export function SpatialSubscriber(props) {
             (hasLocationsData || hasSegmentationsData) && hasExpressionData
           }
           canShow3DOptions={canShow3DOptions}
+          featureSelection={geneSelection}
+          featureAggregationStrategy={featureAggregationStrategy}
+          setFeatureAggregationStrategy={setFeatureAggregationStrategy}
         />
       );
     }
@@ -552,6 +557,7 @@ export function SpatialSubscriber(props) {
     observationsLabel, setCellColorEncoding,
     setGeneExpressionColormapRange, setSpatialAxisFixed, spatialAxisFixed, use3d,
     tooltipsVisible, setTooltipsVisible,
+    geneSelection, featureAggregationStrategy, setFeatureAggregationStrategy,
   ]);
 
   useEffect(() => {

--- a/packages/view-types/spatial/src/SpatialSubscriber.js
+++ b/packages/view-types/spatial/src/SpatialSubscriber.js
@@ -25,6 +25,7 @@ import {
   useHasLoader,
   useExpandedFeatureLabelsMap,
 } from '@vitessce/vit-s';
+import { aggregateFeatureArrays } from '@vitessce/utils';
 import {
   setObsSelection,
   mergeObsSets,
@@ -477,10 +478,22 @@ export function SpatialSubscriber(props) {
     locationsCount,
   });
 
+  const DEFAULT_FEATURE_AGGREGATION_STRATEGY = 'first';
+  const featureAggregationStrategyToUse = featureAggregationStrategy
+  ?? DEFAULT_FEATURE_AGGREGATION_STRATEGY;
+
+  const aggregatedExpressionData = useMemo(() => {
+    if (featureAggregationStrategyToUse != null && expressionData && expressionData.length > 1) {
+      const aggregated = aggregateFeatureArrays(expressionData, featureAggregationStrategyToUse);
+      return [aggregated];
+    }
+    return expressionData;
+  }, [expressionData, featureAggregationStrategyToUse]);
+
   const {
     normData: uint8ExpressionData,
     extents: expressionExtents,
-  } = useUint8FeatureSelection(expressionData);
+  } = useUint8FeatureSelection(aggregatedExpressionData);
 
   // The bitmask layer needs access to a array (i.e a texture) lookup of cell -> expression value
   // where each cell id indexes into the array.
@@ -732,6 +745,7 @@ export function SpatialSubscriber(props) {
         featureValueColormapRange={geneExpressionColormapRange}
         setFeatureValueColormapRange={setGeneExpressionColormapRange}
         extent={expressionExtents?.[0]}
+        featureAggregationStrategy={featureAggregationStrategyToUse}
       />
     </TitleInfo>
   );

--- a/packages/view-types/spatial/src/SpatialSubscriber.js
+++ b/packages/view-types/spatial/src/SpatialSubscriber.js
@@ -42,6 +42,8 @@ import SpatialOptions from './SpatialOptions.js';
 import SpatialTooltipSubscriber from './SpatialTooltipSubscriber.js';
 import { makeSpatialSubtitle, getInitialSpatialTargets, HOVER_MODE } from './utils.js';
 
+const DEFAULT_FEATURE_AGGREGATION_STRATEGY = 'first';
+
 /**
  * A subscriber component for the spatial plot.
  * @param {object} props
@@ -478,7 +480,6 @@ export function SpatialSubscriber(props) {
     locationsCount,
   });
 
-  const DEFAULT_FEATURE_AGGREGATION_STRATEGY = 'first';
   const featureAggregationStrategyToUse = featureAggregationStrategy
   ?? DEFAULT_FEATURE_AGGREGATION_STRATEGY;
 


### PR DESCRIPTION
This PR fixes the reported bug, i.e., when the last strategy is selected in case of multi-select featurelist, the legend /scatterplot view should show the last (most recent) selected gene, rather than alphabetic sorted gene from the list.
It also provides the featureAggregateStrategy option in the spatial view.

Note: The scroll behavior seemed fine, that is, it always show the most recent selected gene (irrespective of the first/last aggregate strategy).

https://github.com/user-attachments/assets/9ca7c5d8-c1e2-4a19-8f08-aaf1c41d33e2






Fixes #2463 and #2501
<!-- For other PRs without open issue -->
#### Background
<!-- For all the PRs -->
#### Change List
-
#### Checklist
 - [ ] Have tested PR with one or more demo configurations
 - [ ] Documentation added, updated, or not applicable
