### PR TITLE
Tkakar/fix 2437 dapi channels range

### DIFF
--- a/.changeset/shiny-crabs-occur.md
+++ b/.changeset/shiny-crabs-occur.md
@@ -1,0 +1,7 @@
+---
+"@vitessce/layer-controller-beta": patch
+"@vitessce/spatial-utils": patch
+"@vitessce/example-configs": patch
+---
+
+Allow channel slider to initialize with a small range for uint8 images when contrastLimits spans the full data domain (0–255).

--- a/packages/utils/spatial-utils/src/layer-controller.js
+++ b/packages/utils/spatial-utils/src/layer-controller.js
@@ -32,7 +32,17 @@ async function getSingleSelectionStats2D({ loader, selection }) {
   const filteredSelection = filterSelection(loader, selection);
   const raster = await data.getRaster({ selection: filteredSelection });
   const selectionStats = viv.getChannelStats(raster.data);
-  const { domain, contrastLimits: slider } = selectionStats;
+  const { domain, contrastLimits, mean, sd } = selectionStats;
+  // If contrastLimits already gives a useful range (not equal to domain),
+  // use it directly. Otherwise fall back to mean + 2*sd.
+  let slider;
+  const contrastLimitsUseful = contrastLimits[1] < domain[1];
+  if (contrastLimitsUseful) {
+    slider = contrastLimits;
+  } else {
+    const upperBound = Math.min(Math.round(mean + 2 * sd), domain[1]);
+    slider = upperBound > domain[0] ? [contrastLimits[0], upperBound] : contrastLimits;
+  }
   return { domain, slider };
 }
 

--- a/packages/view-types/layer-controller-beta/src/ChannelSlider.js
+++ b/packages/view-types/layer-controller-beta/src/ChannelSlider.js
@@ -36,6 +36,7 @@ export default function ChannelSlider(props) {
     minMaxDomain,
     colormapOn,
     theme,
+    minimizedSlider,
   } = props;
 
   const rgbColor = toRgbUIString(colormapOn, color, theme);
@@ -49,9 +50,9 @@ export default function ChannelSlider(props) {
     // auto-initialized using the min/max domain. This can occur
     // upon first load, or when the channel is changed.
     if (!window && !disabled && Array.isArray(minMaxDomain)) {
-      setWindow(minMaxDomain);
+      setWindow(minimizedSlider || minMaxDomain);
     }
-  }, [minMaxDomain, window, disabled]);
+  }, [minMaxDomain, window, disabled, minimizedSlider]);
 
   const [min, max] = (showValueExtent ? minMaxDomain : fullDomain) || [0, 0];
   const step = max - min < 500 && dtype?.startsWith('Float') ? (max - min) / 500 : 1;

--- a/packages/view-types/layer-controller-beta/src/ImageChannelController.js
+++ b/packages/view-types/layer-controller-beta/src/ImageChannelController.js
@@ -78,13 +78,13 @@ export default function ImageChannelController(props) {
       // eslint-disable-next-line prefer-destructuring
       const [newDomain] = stats.domains;
       const [newSlider] = stats.sliders;
-      return {domain: newDomain, slider: newSlider};
+      return { domain: newDomain, slider: newSlider };
     },
     meta: { image },
   });
 
   const minMaxDomain = minMaxQuery.data?.domain;
-  const minimizedSlider = minMaxQuery.data?.slider
+  const minimizedSlider = minMaxQuery.data?.slider;
   const disabled = isLoading || minMaxQuery.isLoading;
 
   function handleResetWindowUsingIQR() {

--- a/packages/view-types/layer-controller-beta/src/ImageChannelController.js
+++ b/packages/view-types/layer-controller-beta/src/ImageChannelController.js
@@ -77,12 +77,14 @@ export default function ImageChannelController(props) {
       });
       // eslint-disable-next-line prefer-destructuring
       const [newDomain] = stats.domains;
-      return newDomain;
+      const [newSlider] = stats.sliders;
+      return {domain: newDomain, slider: newSlider};
     },
     meta: { image },
   });
 
-  const minMaxDomain = minMaxQuery.data;
+  const minMaxDomain = minMaxQuery.data?.domain;
+  const minimizedSlider = minMaxQuery.data?.slider
   const disabled = isLoading || minMaxQuery.isLoading;
 
   function handleResetWindowUsingIQR() {
@@ -140,6 +142,7 @@ export default function ImageChannelController(props) {
           colormapOn={colormapOn}
           showValueExtent={showValueExtent}
           minMaxDomain={minMaxDomain}
+          minimizedSlider={minimizedSlider}
         />
       </Grid>
       <Grid size={1}>


### PR DESCRIPTION
This PR allows channel slider to initialize with a small range for uint8 images when contrastLimits spans the full data domain (0–255).
For the unit16 images the domain is [0, 28643] and contrastLimit is [1, 18659] which is picked by the slider handles, hence showing smaller ranges compared to full domain.

Fixes #2437 
<!-- For other PRs without open issue -->
#### Background
<!-- For all the PRs -->
#### Change List
-
#### Checklist
 - [ ] Have tested PR with one or more demo configurations
 - [ ] Documentation added, updated, or not applicable
 - [ ]
After
<img width="853" height="276" alt="Screenshot 2026-06-23 at 7 21 14 PM" src="https://github.com/user-attachments/assets/0afb54ae-70a4-4858-bc55-51b752a1586a" />
Before
<img width="853" height="273" alt="Screenshot 2026-06-23 at 7 21 24 PM" src="https://github.com/user-attachments/assets/b822ee2a-5793-496a-be56-ff2c5a96147f" />
