### PR TITLE
NickAkhmetov/Fix build errors related to optional @react-three/xr dependency by using dynamic imports

### DIFF
--- a/.changeset/wild-planets-relax.md
+++ b/.changeset/wild-planets-relax.md
@@ -1,0 +1,5 @@
+---
+"@vitessce/spatial-three": patch
+---
+
+Fix build errors in consumer bundlers when the optional `@react-three/xr` peer dependency is not installed. XR modules previously used static named imports of `@react-three/xr`, which bundlers resolve at build time even for lazy-loaded chunks (Vite stubs the missing optional peer, causing MISSING_EXPORT). All XR access now goes through a single dynamic namespace import, so the non-XR 3D view works without `@react-three/xr`.

--- a/packages/view-types/spatial-three/src/GeometryAndMeshXR.tsx
+++ b/packages/view-types/spatial-three/src/GeometryAndMeshXR.tsx
@@ -6,11 +6,13 @@ import type { Group, Scene } from 'three';
 import { useFrame, useThree } from '@react-three/fiber';
 import type { ThreeEvent } from '@react-three/fiber';
 import { Bvh } from '@react-three/drei';
-import { useXR, useXRInputSourceState } from '@react-three/xr';
 import { FrontSide, Vector3, Box3, Matrix4 } from 'three';
+import { getXRModule } from './xr/xrModule.js';
 import { MeasureLine } from './xr/MeasureLine.js';
 import type { GeometryAndMeshProps, MeasureLineData, ClickEvent, PointerOverEvent } from './types.js';
 import { isValidGeometrySize, stringifyLineData } from './three-utils.js';
+
+const { useXR, useXRInputSourceState } = getXRModule();
 
 // XRHand is typed as Map<number, XRJointSpace> in TS lib, but the WebXR spec
 // and runtime use string joint names. This helper casts for string-keyed access.

--- a/packages/view-types/spatial-three/src/SpatialWrapper.tsx
+++ b/packages/view-types/spatial-three/src/SpatialWrapper.tsx
@@ -1,6 +1,7 @@
 import React, { forwardRef, useState, useEffect, Suspense } from 'react';
 import { Canvas } from '@react-three/fiber';
 import { SpatialThree } from './SpatialThree.js';
+import { loadXRModule } from './xr/xrModule.js';
 import type { SpatialThreeProps } from './types.js';
 
 // Lazy-load XR components. If @react-three/xr is not installed,
@@ -24,7 +25,7 @@ export const SpatialWrapper = forwardRef<HTMLCanvasElement, SpatialThreeProps>(
     const [xrAvailable, setXrAvailable] = useState(false);
 
     useEffect(() => {
-      import('@react-three/xr')
+      loadXRModule()
         .then(() => setXrAvailable(true))
         // eslint-disable-next-line @typescript-eslint/no-empty-function
         .catch(() => {});

--- a/packages/view-types/spatial-three/src/xr/HandBbox.tsx
+++ b/packages/view-types/spatial-three/src/xr/HandBbox.tsx
@@ -1,8 +1,10 @@
 /* eslint-disable react/no-unknown-property */
 import React, { useRef } from 'react';
 import type { Mesh } from 'three';
-import { useXRInputSourceState } from '@react-three/xr';
 import { useFrame, useThree } from '@react-three/fiber';
+import { getXRModule } from './xrModule.js';
+
+const { useXRInputSourceState } = getXRModule();
 
 // XRHand is typed as Map<number, XRJointSpace> in TS lib, but the WebXR spec
 // and runtime use string joint names. This helper casts for string-keyed access.

--- a/packages/view-types/spatial-three/src/xr/HandDecorate.ts
+++ b/packages/view-types/spatial-three/src/xr/HandDecorate.ts
@@ -1,6 +1,8 @@
 import type { BufferGeometry, Mesh, MeshStandardMaterial } from 'three';
 import { useFrame, useThree } from '@react-three/fiber';
-import { useXR } from '@react-three/xr';
+import { getXRModule } from './xrModule.js';
+
+const { useXR } = getXRModule();
 
 // Modifies the auto-rendered hand model materials to make fingertips semi-transparent.
 // In xr v6, hands are auto-rendered. We traverse the scene to find hand meshes.

--- a/packages/view-types/spatial-three/src/xr/XRWrapper.tsx
+++ b/packages/view-types/spatial-three/src/xr/XRWrapper.tsx
@@ -1,7 +1,9 @@
 /* eslint-disable react/no-unknown-property */
 import React from 'react';
-import { XR } from '@react-three/xr';
+import { getXRModule } from './xrModule.js';
 import { xrStore } from './xrStore.js';
+
+const { XR } = getXRModule();
 
 export default function XRWrapper({ children }: { children: React.ReactNode }) {
   return (

--- a/packages/view-types/spatial-three/src/xr/xrModule.ts
+++ b/packages/view-types/spatial-three/src/xr/xrModule.ts
@@ -1,0 +1,22 @@
+import type * as XRModuleType from '@react-three/xr';
+
+// @react-three/xr is an optional peer dependency. This dynamic namespace
+// import must remain the ONLY runtime reference to the package: static named
+// imports (e.g. `import { useXR } from '@react-three/xr'`) end up in dist
+// chunks and fail consumer builds when the package is not installed, because
+// bundlers resolve them at build time regardless of lazy loading.
+let xrModule: typeof XRModuleType | null = null;
+
+export async function loadXRModule(): Promise<typeof XRModuleType> {
+  xrModule = await import('@react-three/xr');
+  return xrModule;
+}
+
+// Only call from modules that are lazy-loaded after loadXRModule() resolves
+// (i.e., gated behind the xrAvailable state in SpatialWrapper).
+export function getXRModule(): typeof XRModuleType {
+  if (!xrModule) {
+    throw new Error('@react-three/xr is not loaded; call loadXRModule() first.');
+  }
+  return xrModule;
+}

--- a/packages/view-types/spatial-three/src/xr/xrStore.ts
+++ b/packages/view-types/spatial-three/src/xr/xrStore.ts
@@ -1,7 +1,7 @@
-import { createXRStore } from '@react-three/xr';
 import type { XRStore } from '@react-three/xr';
+import { getXRModule } from './xrModule.js';
 
-export const xrStore: XRStore = createXRStore({
+export const xrStore: XRStore = getXRModule().createXRStore({
   handTracking: true,
   emulate: false,
 });


### PR DESCRIPTION
<!-- Credit (as a starting template): https://github.com/visgl/deck.gl/blob/master/.github/pull_request_template.md -->
<!-- For feature, feature enhancement or bug fix, create an issue first and finish To Do List there -->
<!-- Anything doesn't work as expected is a bug, including code, doc and test -->
Fixes #
<!-- For other PRs without open issue -->

I ran into an issue building the portal UI due to the optional XR dependency not being actually optional in the code - this PR fixes this by lazy-loading all XR module code.

<!-- For all the PRs -->
#### Change List
-
#### Checklist
 - [x] Have tested PR with one or more demo configurations
 - [x] Documentation added, updated, or not applicable
