### PR TITLE
PR into support on demand mesh loading branch

### DIFF
--- a/examples/configs/src/view-configs/3d-maps/neuroglancer-sorger.js
+++ b/examples/configs/src/view-configs/3d-maps/neuroglancer-sorger.js
@@ -22,12 +22,10 @@ function generateNeuroglancerSorgerOnDemandLoadingConfig() {
       obsType: 'cell',
     },
     options: {
-      neuroglancerOptions: {
-        dimensions: {
-          x: [0.000001, 'm'],
-          y: [0.000001, 'm'],
-          z: [0.000001, 'm'],
-        },
+      dimensions: {
+        x: [0.000001, 'm'],
+        y: [0.000001, 'm'],
+        z: [0.000001, 'm'],
       },
     },
   });
@@ -78,21 +76,27 @@ function generateNeuroglancerSorgerOnDemandLoadingConfig() {
     url: 'https://data-2.vitessce.io/data/sorger/3dtm/MIS_cells_corrected/cells',
     options: {
       projectionAnnotationSpacing: 1,
-      useForSegmentationCulling: true,
       featureIndexProp: 'mx1spots',
+      transform: {
+        matrix: [
+          [7148.09960682, 0, 0, 0],
+          [0, 7148.09960682, 0, 0],
+          [0, 0, 3803.92156863, 0],
+        ],
+        outputDimensions: {
+          x: [0.000001, 'm'],
+          y: [0.000001, 'm'],
+          z: [0.000001, 'm'],
+        },
+      },
+      /*
+      This has a single quantitative feature hard-coded in the config, and a hard-coded maximum feature value for normalization. What happens when there are multiple genes?
+        - Can we assume that the annotation value will always be prop_{geneId}(); in the shader? Then, we could remove qualitativeColorProp from the config
+        - Can we assume the annotation values will always be normalized already?
+      */
       quantitativeColorProp: 'mx1spots',
       // max value for mx1spots from binary chunks - used to normalize the colormap scale
       quantitativeColorMax: 58,
-      matrix: [
-        [7148.09960682, 0, 0, 0],
-        [0, 7148.09960682, 0, 0],
-        [0, 0, 3803.92156863, 0],
-      ],
-      outputDimensions: {
-        x: [0.000001, 'm'],
-        y: [0.000001, 'm'],
-        z: [0.000001, 'm'],
-      },
     },
     coordinationValues: {
       fileUid: 'sorger-cells',
@@ -172,7 +176,7 @@ function generateNeuroglancerSorgerOnDemandLoadingConfig() {
         spatialLayerVisible: true,
         spatialLayerColor: [0, 255, 0],
         spatialPointStrokeWidth: 0.2,
-        obsColorEncoding: 'quantitativeColormap',
+        obsColorEncoding: 'geneSelection',
         featureValueColormap: 'plasma',
         featureSelection: ['MX1_SPOTS'],
         featureValueColormapRange: [0.0, 1.0],

--- a/examples/configs/src/view-configs/3d-maps/neuroglancer-sorger.js
+++ b/examples/configs/src/view-configs/3d-maps/neuroglancer-sorger.js
@@ -90,9 +90,12 @@ function generateNeuroglancerSorgerOnDemandLoadingConfig() {
         },
       },
       /*
-      This has a single quantitative feature hard-coded in the config, and a hard-coded maximum feature value for normalization. What happens when there are multiple genes?
-        - Can we assume that the annotation value will always be prop_{geneId}(); in the shader? Then, we could remove qualitativeColorProp from the config
-        - Can we assume the annotation values will always be normalized already?
+      This has a single quantitative feature hard-coded in the config,
+      and a hard-coded maximum feature value for normalization.
+      What happens when there are multiple genes?
+      - Can we assume that the annotation value will always be prop_{geneId}();
+      in the shader? Then, we could remove qualitativeColorProp from the config
+      - Can we assume the annotation values will always be normalized already?
       */
       quantitativeColorProp: 'mx1spots',
       // max value for mx1spots from binary chunks - used to normalize the colormap scale

--- a/packages/main/all/src/base-plugins.ts
+++ b/packages/main/all/src/base-plugins.ts
@@ -501,7 +501,7 @@ export const baseCoordinationTypes = [
     z.enum([
       'geneSelection', 'cellSetSelection', 'spatialChannelColor', 'spatialLayerColor', 'obsLabels',
       // For point coloring.
-      'random', 'randomByFeature', 'quantitativeColormap',
+      'random', 'randomByFeature',
     ]),
   ),
   new PluginCoordinationType(CoordinationType.FEATURE_FILTER, null, z.array(z.string()).nullable()),

--- a/packages/schemas/src/file-def-options.ts
+++ b/packages/schemas/src/file-def-options.ts
@@ -323,13 +323,15 @@ export const ngPointAnnotationSchema = z.object({
   pointIndexProp: z.string()
     .optional()
     .describe('The name of the Neuroglancer AnnotationProperty containing point IDs. For example, specify \'point_id\' to use prop_point_id() in the Neuroglancer shader code.'),
-  transform: z.object({
+    transform: z.object({
     matrix: z.array(z.array(z.number())),
     outputDimensions: z.record(z.tuple([z.number(), z.string()])),
   }).optional()
     .describe('A coordinate transformation matrix to apply to the annotation layer source to map annotation coordinates to the global coordinate space.'),
-// passthrough as the schema validation was stripping the transform option
-}).partial().passthrough().nullable();
+  // TODO: See comments in neuroglancer-sorger.js
+  quantitativeColorProp: z.string().optional(),
+  quantitativeColorMax: z.number().optional(),
+}).partial().nullable();
 
 /**
  * Options schemas for atomic file types.

--- a/packages/schemas/src/file-def-options.ts
+++ b/packages/schemas/src/file-def-options.ts
@@ -323,7 +323,7 @@ export const ngPointAnnotationSchema = z.object({
   pointIndexProp: z.string()
     .optional()
     .describe('The name of the Neuroglancer AnnotationProperty containing point IDs. For example, specify \'point_id\' to use prop_point_id() in the Neuroglancer shader code.'),
-    transform: z.object({
+  transform: z.object({
     matrix: z.array(z.array(z.number())),
     outputDimensions: z.record(z.tuple([z.number(), z.string()])),
   }).optional()

--- a/packages/view-types/layer-controller-beta/src/PointLayerController.js
+++ b/packages/view-types/layer-controller-beta/src/PointLayerController.js
@@ -140,7 +140,6 @@ function PointLayerEllipsisMenu(props) {
           <option value="geneSelection">Feature Color</option>
           <option value="randomByFeature">Random Color per Feature</option>
           <option value="random">Random Color per Point</option>
-          <option value="quantitativeColormap">Quantitative Colormap</option>
         </NativeSelect>
       </MenuItem>
       <MenuItem dense disableGutters>
@@ -160,7 +159,7 @@ function PointLayerEllipsisMenu(props) {
           Colormap Range:&nbsp;
         </label>
         <Slider
-          disabled={obsColorEncoding !== 'geneSelection' && obsColorEncoding !== 'quantitativeColormap'}
+          disabled={obsColorEncoding !== 'geneSelection'}
           value={featureValueColormapRange}
           min={0.0}
           max={1.0}
@@ -300,7 +299,7 @@ export default function PointLayerController(props) {
     obsColorEncoding === 'spatialLayerColor'
     || (obsColorEncoding === 'geneSelection' && hasUnspecifiedFeatureColors)
   );
-  const isColormap = obsColorEncoding === 'quantitativeColormap';
+  const isColormap = obsColorEncoding === 'geneSelection';
 
   // If the feature color encoding is "geneSelection" and there is only one feature selected,
   // we can use the first feature's color as the static color, and hook up the featureColor setter

--- a/packages/view-types/layer-controller-beta/src/SegmentationCentroidsController.js
+++ b/packages/view-types/layer-controller-beta/src/SegmentationCentroidsController.js
@@ -334,7 +334,7 @@ export default function SegmentationCentroidsController(props) {
     setObsColorEncoding(val);
     // Map seg encoding to the equivalent point encoding
     if (val === 'geneSelection') {
-      setPointObsColorEncoding?.('quantitativeColormap');
+      setPointObsColorEncoding?.('geneSelection');
     } else if (val === 'cellSetSelection') {
       // TODO: Need to implement this
       setPointObsColorEncoding?.('cellSetSelection');
@@ -353,8 +353,7 @@ export default function SegmentationCentroidsController(props) {
   const isColormap = obsColorEncoding === 'geneSelection';
 
   const pointIsStaticColor = pointObsColorEncoding === 'spatialChannelColor';
-  const pointIsColormap = pointObsColorEncoding === 'geneSelection'
-                             || pointObsColorEncoding === 'quantitativeColormap';
+  const pointIsColormap = pointObsColorEncoding === 'geneSelection';
 
 
   return (

--- a/packages/view-types/neuroglancer/src/NeuroglancerSubscriber.js
+++ b/packages/view-types/neuroglancer/src/NeuroglancerSubscriber.js
@@ -33,7 +33,7 @@ import { Chip } from '@vitessce/styles';
 import { mergeObsSets, getCellColors, setObsSelection } from '@vitessce/sets-utils';
 import { MultiLegend } from '@vitessce/legend';
 import { NeuroglancerComp } from './Neuroglancer.js';
-import { useNeuroglancerViewerState } from './data-hook-ng-utils.js';
+import { useNeuroglancerViewerState, pointsHaveMatchingSegmentation } from './data-hook-ng-utils.js';
 import {
   useMemoCustomComparison,
   customIsEqualForCellColors,
@@ -820,15 +820,18 @@ export function NeuroglancerSubscriber(props) {
   }, [pointLayerScopes, obsPointsUrls]);
 
 
-  // Whether the points layer has opted in to viewport-based mesh culling (useForSegmentationCulling: true).
-  // To avoid datasets like MERFISH (where points are molecules, not cells)
-  // from incorrectly driving mesh culling.
+  // Check whether the (first) point layer's obsType matches any segmentation channel's obsType.
+  // TODO: generalize to multiple point layers?
   const hasMatchingAnnotationSource = useMemo(() => {
     if (!cellsUrl) return false;
     const firstPointScope = pointLayerScopes?.[0];
-    const firstPointData = obsPointsData?.[firstPointScope];
-    return !!(firstPointData?.neuroglancerOptions?.useForSegmentationCulling);
-  }, [cellsUrl, pointLayerScopes, obsPointsData]);
+    return pointsHaveMatchingSegmentation({
+      pointObsType: pointLayerCoordination[0]?.[firstPointScope]?.obsType,
+      segmentationLayerScopes,
+      segmentationChannelScopesByLayer,
+      segmentationChannelCoordination,
+    });
+  }, [cellsUrl, pointLayerScopes, segmentationLayerScopes, segmentationChannelScopesByLayer]);
 
 
   // URL of the annotation source for the points layer.
@@ -1272,6 +1275,9 @@ export function NeuroglancerSubscriber(props) {
   // }
   const hasLayers = derivedViewerState?.layers?.length > 0;
 
+  // TODO: generalize to support multiple point layers.
+  const showPointsLegend = !hasMatchingAnnotationSource;
+
   return (
 
     <TitleInfo
@@ -1302,7 +1308,7 @@ export function NeuroglancerSubscriber(props) {
               segmentationChannelCoordination={segmentationChannelCoordination}
 
               // Points
-              pointLayerScopes={pointLayerScopes}
+              pointLayerScopes={showPointsLegend ? pointLayerScopes : undefined}
               pointLayerCoordination={pointLayerCoordination}
               pointMultiIndicesData={pointMultiIndicesData}
             />

--- a/packages/view-types/neuroglancer/src/data-hook-ng-utils.js
+++ b/packages/view-types/neuroglancer/src/data-hook-ng-utils.js
@@ -93,29 +93,46 @@ export function toNgLayerName(dataType, layerScope, channelScope = null) {
   throw new Error(`Unsupported data type: ${dataType}`);
 }
 
-export function pointsHaveMatchingSegmentation({ pointObsType, segmentationLayerScopes, segmentationChannelScopesByLayer, segmentationChannelCoordination }) {
+export function pointsHaveMatchingSegmentation({
+  pointObsType,
+  segmentationLayerScopes,
+  segmentationChannelScopesByLayer,
+  segmentationChannelCoordination,
+}) {
   // Check if there are segmentations with the same obsType.
-  // If so, we infer that the points represent the centroids of the segmentations.
-  // We pass this down to the getPointsShader, to determine whether to interpret
-  // `obsColorEncoding === 'geneSelection'` as a quantitative color encoding or a categorical color encoding.
-  const pointsHaveMatchingSegmentation = segmentationLayerScopes.some((segmentationLayerScope) => {
-    const segmentationChannelScopes = segmentationChannelScopesByLayer[segmentationLayerScope] || [];
+  // If so, infer that the points represent centroids of the segmentations.
+  // We pass this down to the getPointsShader, to determine whether to
+  // interpret `obsColorEncoding === 'geneSelection'` as a quantitative
+  // color encoding or a categorical color encoding.
+  return segmentationLayerScopes.some((segmentationLayerScope) => {
+    const segmentationChannelScopes = segmentationChannelScopesByLayer?.
+      [segmentationLayerScope] || [];
     return segmentationChannelScopes.some((segmentationChannelScope) => {
-      const segmentationObsType = segmentationChannelCoordination?.[0]?.[segmentationLayerScope]?.[segmentationChannelScope]?.obsType;
-      return segmentationObsType && pointObsType && segmentationObsType === pointObsType;
+      const segmentationObsType = segmentationChannelCoordination?.[0]
+        ?.[segmentationLayerScope]?.[segmentationChannelScope]?.obsType;
+      return (
+        segmentationObsType && pointObsType
+        && segmentationObsType === pointObsType
+      );
     });
   });
-  return pointsHaveMatchingSegmentation;
 }
 
-export function segmentationsHaveMatchingPoints({ segmentationObsType, pointLayerScopes, pointLayerCoordination }) {
+export function segmentationsHaveMatchingPoints({
+  segmentationObsType,
+  pointLayerScopes,
+  pointLayerCoordination,
+}) {
   // Check if there are points with the same obsType.
   // If so, we infer that the segmentations have matching points.
-  const segmentationHasMatchingPoints = pointLayerScopes.some((pointLayerScope) => {
-    const pointObsType = pointLayerCoordination?.[0]?.[pointLayerScope]?.obsType;
-    return segmentationObsType && pointObsType && segmentationObsType === pointObsType;
+  return pointLayerScopes.some((pointLayerScope) => {
+    const pointObsType = pointLayerCoordination?.
+      [0]?.[pointLayerScope]?.obsType;
+    return (
+      segmentationObsType && pointObsType
+      && segmentationObsType === pointObsType
+    );
   });
-  return segmentationHasMatchingPoints;
 }
 
 /**
@@ -223,12 +240,13 @@ export function useNeuroglancerViewerState(
       // Check if there are segmentations with the same obsType.
       // If so, we infer that the points represent the centroids of the segmentations.
       // We pass this down to the getPointsShader, to determine whether to interpret
-      // `obsColorEncoding === 'geneSelection'` as a quantitative color encoding or a categorical color encoding.
+      // `obsColorEncoding === 'geneSelection'` as a
+      // quantitative color encoding or a categorical color encoding.
       const pointsAreSegmentationCentroids = pointsHaveMatchingSegmentation({
         pointObsType: layerCoordination?.obsType,
         segmentationLayerScopes,
         segmentationChannelScopesByLayer,
-        segmentationChannelCoordination
+        segmentationChannelCoordination,
       });
 
       const featureIndex = pointMultiIndicesData[layerScope]?.featureIndex;

--- a/packages/view-types/neuroglancer/src/data-hook-ng-utils.js
+++ b/packages/view-types/neuroglancer/src/data-hook-ng-utils.js
@@ -93,6 +93,31 @@ export function toNgLayerName(dataType, layerScope, channelScope = null) {
   throw new Error(`Unsupported data type: ${dataType}`);
 }
 
+export function pointsHaveMatchingSegmentation({ pointObsType, segmentationLayerScopes, segmentationChannelScopesByLayer, segmentationChannelCoordination }) {
+  // Check if there are segmentations with the same obsType.
+  // If so, we infer that the points represent the centroids of the segmentations.
+  // We pass this down to the getPointsShader, to determine whether to interpret
+  // `obsColorEncoding === 'geneSelection'` as a quantitative color encoding or a categorical color encoding.
+  const pointsHaveMatchingSegmentation = segmentationLayerScopes.some((segmentationLayerScope) => {
+    const segmentationChannelScopes = segmentationChannelScopesByLayer[segmentationLayerScope] || [];
+    return segmentationChannelScopes.some((segmentationChannelScope) => {
+      const segmentationObsType = segmentationChannelCoordination?.[0]?.[segmentationLayerScope]?.[segmentationChannelScope]?.obsType;
+      return segmentationObsType && pointObsType && segmentationObsType === pointObsType;
+    });
+  });
+  return pointsHaveMatchingSegmentation;
+}
+
+export function segmentationsHaveMatchingPoints({ segmentationObsType, pointLayerScopes, pointLayerCoordination }) {
+  // Check if there are points with the same obsType.
+  // If so, we infer that the segmentations have matching points.
+  const segmentationHasMatchingPoints = pointLayerScopes.some((pointLayerScope) => {
+    const pointObsType = pointLayerCoordination?.[0]?.[pointLayerScope]?.obsType;
+    return segmentationObsType && pointObsType && segmentationObsType === pointObsType;
+  });
+  return segmentationHasMatchingPoints;
+}
+
 /**
  * Get the parameters for NG's viewerstate.
  * @param {object} loaders The object mapping
@@ -188,12 +213,23 @@ export function useNeuroglancerViewerState(
       const layerData = obsPointsData[layerScope];
       const layerUrl = obsPointsUrls[layerScope]?.[0]?.url;
       const ngOptions = layerData?.neuroglancerOptions;
-      if (ngOptions?.matrix && ngOptions?.outputDimensions) {
+      if (ngOptions?.transform?.matrix && ngOptions?.transform?.outputDimensions) {
         result = {
           ...result,
-          dimensions: ngOptions.outputDimensions ?? DEFAULT_NG_DIMENSIONS,
+          dimensions: ngOptions.transform.outputDimensions ?? DEFAULT_NG_DIMENSIONS,
         };
       }
+
+      // Check if there are segmentations with the same obsType.
+      // If so, we infer that the points represent the centroids of the segmentations.
+      // We pass this down to the getPointsShader, to determine whether to interpret
+      // `obsColorEncoding === 'geneSelection'` as a quantitative color encoding or a categorical color encoding.
+      const pointsAreSegmentationCentroids = pointsHaveMatchingSegmentation({
+        pointObsType: layerCoordination?.obsType,
+        segmentationLayerScopes,
+        segmentationChannelScopesByLayer,
+        segmentationChannelCoordination
+      });
 
       const featureIndex = pointMultiIndicesData[layerScope]?.featureIndex;
 
@@ -211,7 +247,7 @@ export function useNeuroglancerViewerState(
           featureValueColormapRange,
         } = layerCoordination || {};
         const quantitativeColorMax = layerData.neuroglancerOptions?.quantitativeColorMax;
-        if (!quantitativeColorMax && obsColorEncoding === 'quantitativeColormap') {
+        if (!quantitativeColorMax && obsColorEncoding === 'geneSelection') {
           console.warn('quantitativeColorMax not specified in options — defaulting to 1.0 (no normalization)');
         }
         const quantitativeColorMaxSelected = quantitativeColorMax ?? 1.0;
@@ -237,6 +273,7 @@ export function useNeuroglancerViewerState(
           obsSetSelection: layerCoordination.obsSetSelection,
           additionalObsSets: layerCoordination.additionalObsSets,
           quantitativeColorMax: quantitativeColorMaxSelected,
+          pointsAreSegmentationCentroids,
         });
         result = {
           ...result,
@@ -250,11 +287,11 @@ export function useNeuroglancerViewerState(
                   default: true,
                 },
                 enableDefaultSubsources: false,
-                ...(ngOptions?.matrix
+                ...(ngOptions?.transform?.matrix
                   ? {
                     transform: {
-                      matrix: ngOptions.matrix,
-                      outputDimensions: ngOptions.outputDimensions ?? result.dimensions,
+                      matrix: ngOptions.transform.matrix,
+                      outputDimensions: ngOptions.transform?.outputDimensions ?? result.dimensions,
                     },
                   }
                   : {}),

--- a/packages/view-types/neuroglancer/src/shader-utils.js
+++ b/packages/view-types/neuroglancer/src/shader-utils.js
@@ -648,6 +648,7 @@ export function getPointsShader(layerCoordination) {
     obsSetColor,
     obsSetSelection,
     quantitativeColorMax,
+    pointsAreSegmentationCentroids,
   } = layerCoordination;
 
   const defaultColor = getDefaultColor(theme);
@@ -745,8 +746,10 @@ export function getPointsShader(layerCoordination) {
     );
   }
 
+  console.log(obsColorEncoding, pointsAreSegmentationCentroids);
+
   // ---- geneSelection ----
-  if (obsColorEncoding === 'geneSelection') {
+  if (obsColorEncoding === 'geneSelection' && !pointsAreSegmentationCentroids) {
     if (!featureIndexProp) {
       throw new Error('In order to use gene-based color encoding for Neuroglancer Points, options.featureIndexProp must be specified for the obsPoints.ng-annotations fileType in the Vitessce configuration.');
     }
@@ -811,7 +814,8 @@ export function getPointsShader(layerCoordination) {
     );
   }
 
-  if (obsColorEncoding === 'quantitativeColormap') {
+  // Quantitative color encoding for points when pointsAreSegmentationCentroids is true (e.g., for segmentation centroids).
+  if (obsColorEncoding === 'geneSelection' && pointsAreSegmentationCentroids) {
     if (!quantitativeColorProp) {
       console.warn(
         'In order to use quantitative colormap encoding for Neuroglancer Points, '

--- a/packages/view-types/neuroglancer/src/shader-utils.js
+++ b/packages/view-types/neuroglancer/src/shader-utils.js
@@ -746,8 +746,6 @@ export function getPointsShader(layerCoordination) {
     );
   }
 
-  console.log(obsColorEncoding, pointsAreSegmentationCentroids);
-
   // ---- geneSelection ----
   if (obsColorEncoding === 'geneSelection' && !pointsAreSegmentationCentroids) {
     if (!featureIndexProp) {
@@ -814,7 +812,8 @@ export function getPointsShader(layerCoordination) {
     );
   }
 
-  // Quantitative color encoding for points when pointsAreSegmentationCentroids is true (e.g., for segmentation centroids).
+  // Quantitative color encoding for points when
+  // pointsAreSegmentationCentroids is true (e.g., for segmentation centroids).
   if (obsColorEncoding === 'geneSelection' && pointsAreSegmentationCentroids) {
     if (!quantitativeColorProp) {
       console.warn(


### PR DESCRIPTION
This PR contains changes for the support on demand mesh loading branch in #2470

Since we already have `geneSelection` which colors cells using a quantitative colormap, I think it is best if we reuse this, and for the points, infer whether it means to use a categorical colormap (when each point represents a transcript) vs. a quantitative colormap (when points are segmentation centroids) based on checking for a match between the point and segmentation `obsType` values. I also removed the `useForSegmentationCulling` option, replacing it with the same `obsType` matching logic.

The main remaining question I have is regarding `quantitativeColorProp` and `quantitativeColorMax`. If the quantitative values correspond to gene expression quantities, then we do not want to hard-code a single gene and its maximum value in the config. Instead, can we make assumptions about how the data has been normalized and about the `prop_something()` naming conventions (e.g., how the `prop_{featureId}` can be derived from the selected gene names, to convert `MX1_SPOTS` to `prop_mx1spots`), based on the logic in `tissue-map-tools` and the output ng-annotations files it generates? If we cannot make assumptions about how the data has been normalized, then perhaps we could compute the min/max from the corresponding obsFeatureMatrix column upon loading it when a user has selected a gene. These are both probably questions for @EricMoerthVis and @LucaMarconato regarding `tissue-map-tools`