### PR TITLE
NickAkhmetov/Fix double-applied physical pixel size in spatialBeta 3D, restore camera-axis control

### DIFF
--- a/.changeset/lucky-volumes-rotate.md
+++ b/.changeset/lucky-volumes-rotate.md
@@ -1,0 +1,5 @@
+---
+"@vitessce/spatial-beta": patch
+---
+
+Fixed 3D volume rendering in the beta spatial view applying physical pixel size twice, which stretched anisotropic volumes along their coarsest axis by the anisotropy ratio (a 1x1x2 um voxel rendered twice as deep as it should). Restored the "Fix Camera Axis" control in the beta spatial view's plot options menu, so the orbit target can be pinned rather than drifting on every pan. The camera is also re-initialized when switching between 2D and 3D, so a volume is no longer left framed by (or panned out of view with) the camera from the previous mode, and spatialOrbitAxis now round-trips through the beta view's setViewState like the rest of the camera state.

--- a/examples/configs/src/index.js
+++ b/examples/configs/src/index.js
@@ -90,6 +90,7 @@ import { sorgerBiggerNeighborhood } from './view-configs/3d-maps/sorger-bigger.j
 import { cellNeighborhood } from './view-configs/3d-maps/cell-neighborhood-named.js';
 import { saGloria, saKingsnake, saLsp1, saLsp2, saLsp3 } from './view-configs/3d-maps/three-spatial-accelerated.js';
 import { threeMinimal } from './view-configs/3d-maps/three-minimal.js';
+import { anisotropicVolume } from './view-configs/3d-maps/anisotropic-volume.js';
 import { threeMinimalLight } from './view-configs/3d-maps/three-minimal-light.js';
 import { linkControllerDemo } from './view-configs/3d-maps/link-controller.js';
 import { linkControllerMinimal } from './view-configs/3d-maps/link-controller-minimal.js';
@@ -211,6 +212,7 @@ export const configs = {
   'sorger-2024-4': bloodVesselNeighborhood,
   'sorger-2024-5': cellNeighborhood,
   'kiemen-2024': threeMinimal,
+  'anisotropic-volume': anisotropicVolume,
   'hakimian-2021': threeMinimalLight,
   'link-controller': linkControllerDemo,
   'link-controller-minimal': linkControllerMinimal,

--- a/examples/configs/src/view-configs/3d-maps/anisotropic-volume.js
+++ b/examples/configs/src/view-configs/3d-maps/anisotropic-volume.js
@@ -2,6 +2,7 @@ import {
   VitessceConfig,
   CoordinationLevel as CL,
   hconcat,
+  getInitialCoordinationScopePrefix,
 } from '@vitessce/config';
 
 /**
@@ -57,7 +58,7 @@ function generateAnisotropicVolumeConfiguration() {
         }))),
       },
     ]),
-  });
+  }, { scopePrefix: getInitialCoordinationScopePrefix('A', 'image') });
 
   config.layout(hconcat(spatialView, lcView));
 

--- a/examples/configs/src/view-configs/3d-maps/anisotropic-volume.js
+++ b/examples/configs/src/view-configs/3d-maps/anisotropic-volume.js
@@ -1,0 +1,67 @@
+import {
+  VitessceConfig,
+  CoordinationLevel as CL,
+  hconcat,
+} from '@vitessce/config';
+
+/**
+ * Regression case for physical pixel size handling in 3D volume rendering.
+ *
+ * This is a public HuBMAP 3D Imaging Mass Cytometry dataset (HBM459.CGSD.533)
+ * whose voxels are deliberately anisotropic:
+ *
+ *   SizeX=452  SizeY=514  SizeZ=50
+ *   PhysicalSizeX=1.0um  PhysicalSizeY=1.0um  PhysicalSizeZ=2.0um
+ *
+ * so the correct physical extent of the volume is 452 x 514 x 100 um. Note that
+ * this config deliberately does NOT set `three: true` - it exercises the
+ * deck.gl/viv VolumeLayer path, which is the one that applied the physical pixel
+ * size twice and rendered the volume 452 x 514 x 200.
+ */
+function generateAnisotropicVolumeConfiguration() {
+  const config = new VitessceConfig({
+    schemaVersion: '1.0.16',
+    name: 'Anisotropic volume (1x1x2 um)',
+    description: 'HuBMAP 3DIMC HBM459.CGSD.533. Toggle 3D in the layer controller: the volume must be half as deep as it is wide, not as deep as it is wide.',
+  });
+  const dataset = config.addDataset('HBM459.CGSD.533').addFile({
+    fileType: 'image.ome-tiff',
+    url: 'https://assets.hubmapconsortium.org/30bc1823e0c19be58557fb979499bac2/ometiff-pyramids/data/3D_image_stack.ome.tif',
+    options: {
+      offsetsUrl: 'https://assets.hubmapconsortium.org/30bc1823e0c19be58557fb979499bac2/output_offsets/data/3D_image_stack.offsets.json',
+    },
+    coordinationValues: {
+      fileUid: 'imc',
+    },
+  });
+
+  const spatialView = config.addView(dataset, 'spatialBeta');
+  const lcView = config.addView(dataset, 'layerControllerBeta');
+  config.linkViewsByObject([spatialView, lcView], {
+    spatialTargetZ: 0,
+    spatialTargetT: 0,
+    imageLayer: CL([
+      {
+        fileUid: 'imc',
+        spatialLayerOpacity: 1,
+        spatialTargetResolution: null,
+        imageChannel: CL([0, 1, 2].map((targetC, i) => ({
+          spatialTargetC: targetC,
+          spatialChannelColor: [
+            [0, 0, 255],
+            [0, 255, 0],
+            [255, 0, 255],
+          ][i],
+          spatialChannelVisible: true,
+          spatialChannelOpacity: 1.0,
+        }))),
+      },
+    ]),
+  });
+
+  config.layout(hconcat(spatialView, lcView));
+
+  return config.toJSON();
+}
+
+export const anisotropicVolume = generateAnisotropicVolumeConfiguration();

--- a/packages/utils/image-utils/src/ImageWrapper.ts
+++ b/packages/utils/image-utils/src/ImageWrapper.ts
@@ -72,7 +72,35 @@ export default class ImageWrapper implements AbstractImageWrapper {
     return true;
   }
 
-  getData(): VivLoaderDataType {
+  // TODO: make stripPhysicalSizes the default behavior,
+  // and remove it as a parameter, once it is no longer
+  // used by spatial-accelerated and spatial-three.
+  getData(stripPhysicalSizes = true): VivLoaderDataType {
+    // Here, we strip the physical size information from the Viv loaders,
+    // since we instead pass it via the model matrix.
+    // If we keep it here AND the caller also uses getModelMatrix(),
+    // then the physical size information will be applied twice.
+    // Reference: https://github.com/hms-dbmi/viv/blob/ec590278f8f5591c64200be9ce189aa5c12215fc/packages/layers/src/utils.js#L162
+    if (stripPhysicalSizes) {
+      const { data } = this.vivLoader;
+      // Clone each pixel source rather than spreading it into a plain object,
+      // so that its prototype methods (e.g. getRaster, getTile) are preserved.
+      const newData = data.map((d) => {
+        if ('meta' in d) {
+          const { meta } = d;
+          if (meta && 'physicalSizes' in meta) {
+            // Undefined results in using the identity matrix.
+            const newMeta = { ...meta, physicalSizes: undefined };
+            const clone = Object.create(Object.getPrototypeOf(d));
+            Object.assign(clone, d, { meta: newMeta });
+            return clone;
+          }
+        }
+        return d;
+      });
+      return newData as VivLoaderDataType;
+    }
+
     return this.vivLoader.data;
   }
 

--- a/packages/view-types/spatial-accelerated/src/VolumeDataManager.js
+++ b/packages/view-types/spatial-accelerated/src/VolumeDataManager.js
@@ -755,8 +755,14 @@ export class VolumeDataManager {
 
       this.zarrStore.resolutions = resolutions;
 
+      // TODO: The code here should not rely on vivData.meta.physicalSizes,
+      // but should instead use imageWrapper.getModelMatrix() which is more general.
+      // Then, stripPhysicalSizes can be set to true and possibly removed as a parameter,
+      // making stripPhysicalSizes the default behavior in ImageWrapper.getData().
+      const stripPhysicalSizes = false;
+
       // TODO: filter to only those resolutions below the 16k x 16x x 4k limit?
-      const vivData = imageWrapper.getData();
+      const vivData = imageWrapper.getData(stripPhysicalSizes);
 
       if (!Array.isArray(vivData) || vivData.length < 1) {
         throw new Error('Not a multiresolution loader');

--- a/packages/view-types/spatial-beta/package.json
+++ b/packages/view-types/spatial-beta/package.json
@@ -48,9 +48,11 @@
     "math.gl": "catalog:",
     "mathjs": "catalog:",
     "plur": "^5.1.0",
+    "react-aria": "catalog:",
     "short-number": "^1.0.6"
   },
   "devDependencies": {
+    "@testing-library/react": "catalog:",
     "react": "catalog:",
     "react-dom": "catalog:",
     "vite": "catalog:",

--- a/packages/view-types/spatial-beta/src/Spatial.js
+++ b/packages/view-types/spatial-beta/src/Spatial.js
@@ -16,7 +16,7 @@ import {
 import { AbstractSpatialOrScatterplot, createQuadTree } from '@vitessce/scatterplot';
 import { CoordinationType } from '@vitessce/constants-internal';
 import { log } from '@vitessce/globals';
-import { getLayerLoaderTuple, getVolumeModelMatrix, renderSubBitmaskLayers } from './utils.js';
+import { getLayerLoaderTuple, renderSubBitmaskLayers } from './utils.js';
 
 const POINT_LAYER_PREFIX = 'point-layer-';
 const SPOT_LAYER_PREFIX = 'spot-layer-';
@@ -1198,13 +1198,7 @@ class Spatial extends AbstractSpatialOrScatterplot {
     }
 
     // TODO: support model matrix from coordination space also.
-    const imageModelMatrix = image?.image?.instance?.getModelMatrix();
-    // In 3D, viv's VolumeLayer applies its own physical size scaling matrix on
-    // top of whatever modelMatrix it is given, so the physical scaling has to be
-    // divided back out here to avoid applying it twice. See getVolumeModelMatrix.
-    const layerDefModelMatrix = is3dMode
-      ? getVolumeModelMatrix(data, imageModelMatrix)
-      : (imageModelMatrix || {});
+    const layerDefModelMatrix = image?.image?.instance?.getModelMatrix() || {};
 
     // We need to keep the same selections array reference,
     // otherwise the Viv layer will not be re-used as we want it to,

--- a/packages/view-types/spatial-beta/src/Spatial.js
+++ b/packages/view-types/spatial-beta/src/Spatial.js
@@ -16,7 +16,7 @@ import {
 import { AbstractSpatialOrScatterplot, createQuadTree } from '@vitessce/scatterplot';
 import { CoordinationType } from '@vitessce/constants-internal';
 import { log } from '@vitessce/globals';
-import { getLayerLoaderTuple, renderSubBitmaskLayers } from './utils.js';
+import { getLayerLoaderTuple, getVolumeModelMatrix, renderSubBitmaskLayers } from './utils.js';
 
 const POINT_LAYER_PREFIX = 'point-layer-';
 const SPOT_LAYER_PREFIX = 'spot-layer-';
@@ -1198,7 +1198,13 @@ class Spatial extends AbstractSpatialOrScatterplot {
     }
 
     // TODO: support model matrix from coordination space also.
-    const layerDefModelMatrix = image?.image?.instance?.getModelMatrix() || {};
+    const imageModelMatrix = image?.image?.instance?.getModelMatrix();
+    // In 3D, viv's VolumeLayer applies its own physical size scaling matrix on
+    // top of whatever modelMatrix it is given, so the physical scaling has to be
+    // divided back out here to avoid applying it twice. See getVolumeModelMatrix.
+    const layerDefModelMatrix = is3dMode
+      ? getVolumeModelMatrix(data, imageModelMatrix)
+      : (imageModelMatrix || {});
 
     // We need to keep the same selections array reference,
     // otherwise the Viv layer will not be re-used as we want it to,

--- a/packages/view-types/spatial-beta/src/SpatialOptions.js
+++ b/packages/view-types/spatial-beta/src/SpatialOptions.js
@@ -1,0 +1,68 @@
+import React from 'react';
+import { useId } from 'react-aria';
+import {
+  Checkbox,
+  TableCell,
+  TableRow,
+  makeStyles,
+} from '@vitessce/styles';
+import { OptionsContainer } from '@vitessce/vit-s';
+
+const useStyles = makeStyles()(() => ({
+  spatialBetaCameraLabel: {
+    padding: '0px 0px 0px 16px',
+  },
+  spatialBetaToggleBox: {
+    padding: '0px',
+  },
+}));
+
+/**
+ * Plot options for the beta spatial view.
+ *
+ * Currently just the camera-axis toggle, which the legacy spatial view exposed
+ * in the same place (see SpatialOptions in @vitessce/spatial). Without it,
+ * spatialAxisFixed cannot be set: the orbit target then moves on every pan while
+ * rotating a volume, and there is no way back to a previous orientation.
+ *
+ * This belongs to the spatial view rather than the layer controller because
+ * spatialAxisFixed describes *this* view's camera. It is in
+ * AUTO_INDEPENDENT_COORDINATION_TYPES, so under `initStrategy: 'auto'` every view
+ * gets its own scope for it, and a control living in the layer controller would
+ * write to a scope the spatial view never reads.
+ *
+ * It is read in AbstractSpatialOrScatterplot.onViewStateChange.
+ */
+export default function SpatialOptions(props) {
+  const {
+    spatialAxisFixed,
+    setSpatialAxisFixed,
+    use3d,
+  } = props;
+
+  const toggleAxisId = useId();
+  const { classes } = useStyles();
+
+  return (
+    <OptionsContainer>
+      <TableRow>
+        <TableCell className={classes.spatialBetaCameraLabel} variant="head" scope="row">
+          <label htmlFor={`spatial-camera-axis-${toggleAxisId}`}>
+            Fix Camera Axis
+          </label>
+        </TableCell>
+        <TableCell className={classes.spatialBetaToggleBox} variant="body">
+          <Checkbox
+            onClick={() => setSpatialAxisFixed(!spatialAxisFixed)}
+            disabled={!use3d}
+            checked={Boolean(spatialAxisFixed)}
+            slotProps={{ input: {
+              'aria-label': 'Fix or not fix spatial camera axis',
+              id: `spatial-camera-axis-${toggleAxisId}`,
+            } }}
+          />
+        </TableCell>
+      </TableRow>
+    </OptionsContainer>
+  );
+}

--- a/packages/view-types/spatial-beta/src/SpatialOptions.test.jsx
+++ b/packages/view-types/spatial-beta/src/SpatialOptions.test.jsx
@@ -1,0 +1,46 @@
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen, fireEvent } from '@testing-library/react';
+import React from 'react';
+
+import SpatialOptions from './SpatialOptions.js';
+
+const LABEL = 'Fix or not fix spatial camera axis';
+
+describe('SpatialOptions.js', () => {
+  describe('<SpatialOptions />', () => {
+    it('renders a labelled checkbox reflecting spatialAxisFixed', async () => {
+      render(<SpatialOptions spatialAxisFixed use3d setSpatialAxisFixed={() => {}} />);
+      expect(await screen.findByText('Fix Camera Axis'));
+      expect(screen.getByLabelText(LABEL).checked).toBe(true);
+    });
+
+    it('is unchecked when spatialAxisFixed is unset', () => {
+      render(<SpatialOptions
+        spatialAxisFixed={null}
+        use3d
+        setSpatialAxisFixed={() => {}}
+      />);
+      expect(screen.getByLabelText(LABEL).checked).toBe(false);
+    });
+
+    it('sets the coordination value on toggle', () => {
+      const setSpatialAxisFixed = vi.fn();
+      render(<SpatialOptions
+        spatialAxisFixed={false}
+        use3d
+        setSpatialAxisFixed={setSpatialAxisFixed}
+      />);
+      fireEvent.click(screen.getByLabelText(LABEL));
+      expect(setSpatialAxisFixed).toHaveBeenCalledWith(true);
+    });
+
+    it('is disabled outside of 3D, where the camera axis is meaningless', () => {
+      render(<SpatialOptions
+        spatialAxisFixed={false}
+        use3d={false}
+        setSpatialAxisFixed={() => {}}
+      />);
+      expect(screen.getByLabelText(LABEL).disabled).toBe(true);
+    });
+  });
+});

--- a/packages/view-types/spatial-beta/src/SpatialSubscriber.js
+++ b/packages/view-types/spatial-beta/src/SpatialSubscriber.js
@@ -1,7 +1,7 @@
 /* eslint-disable no-nested-ternary */
 /* eslint-disable max-len */
 /* eslint-disable no-unused-vars */
-import React, { useEffect, useMemo, useCallback, useState } from 'react';
+import React, { useEffect, useMemo, useCallback, useRef, useState } from 'react';
 import {
   TitleInfo,
   useDeckCanvasSize,
@@ -45,6 +45,7 @@ import SpatialTooltipSubscriber from './SpatialTooltipSubscriber.js';
 import { getInitialSpatialTargets } from './utils.js';
 import { SpatialThreeAdapter } from './SpatialThreeAdapter.js';
 import { SpatialAcceleratedAdapter } from './SpatialAcceleratedAdapter.js';
+import SpatialOptions from './SpatialOptions.js';
 import {
   useAggregatedNormalizedExpressionDataForLayers,
   useAggregatedNormalizedExpressionDataForChannels,
@@ -193,6 +194,8 @@ export function SpatialSubscriber(props) {
     setSpatialRotationY: setRotationY,
     setSpatialRotationZ: setRotationZ,
     setSpatialRotationOrbit: setRotationOrbit,
+    setSpatialOrbitAxis: setOrbitAxis,
+    setSpatialAxisFixed,
 
     // TODO: get obsSets per-layer or per-channel
     setAdditionalObsSets,
@@ -655,12 +658,44 @@ export function SpatialSubscriber(props) {
     initialTargetX, initialTargetY, initialTargetZ, initialZoom,
   ]);
 
+  // Re-initialize the camera when the user switches between 2D and 3D.
+  //
+  // The effect above deliberately does not re-run after a pan or zoom, so on its
+  // own it leaves the camera wherever the previous mode left it: switch to 3D
+  // after panning in 2D and the volume can be off-screen or framed for a
+  // completely different extent. The legacy layer controller did this reset
+  // explicitly whenever its resolution select moved between 2D and a 3D
+  // resolution (see LayerOptions in @vitessce/layer-controller).
+  const prevIs3dMode = useRef(is3dMode);
+  useEffect(() => {
+    if (prevIs3dMode.current === is3dMode) {
+      return;
+    }
+    if (typeof defaultTargetX !== 'number' || typeof defaultTargetY !== 'number') {
+      // Not computable yet. Leave the camera alone and re-run once the data for
+      // the new mode is ready, rather than resetting the target to null.
+      return;
+    }
+    prevIs3dMode.current = is3dMode;
+    setTargetX(defaultTargetX);
+    setTargetY(defaultTargetY);
+    setTargetZ(defaultTargetZ);
+    setZoom(defaultZoom);
+    // Rotation is meaningless outside of the OrbitView used in 3D.
+    setRotationX(is3dMode ? 0 : null);
+    setRotationOrbit(is3dMode ? 0 : null);
+    // Deliberate dependency omissions: the setters, which are not referentially
+    // stable across renders and would re-run this on every one.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [is3dMode, defaultTargetX, defaultTargetY, defaultTargetZ, defaultZoom]);
+
 
   const setViewState = ({
     zoom: newZoom,
     target,
     rotationX: newRotationX,
     rotationOrbit: newRotationOrbit,
+    orbitAxis: newOrbitAxis,
   }) => {
     setZoom(newZoom);
     setTargetX(target[0]);
@@ -671,6 +706,13 @@ export function SpatialSubscriber(props) {
       }
       setRotationX(newRotationX);
       setRotationOrbit(newRotationOrbit);
+      // spatialOrbitAxis is a declared camera coordination type for this view,
+      // so it has to round-trip through here like the rest of the camera state.
+      // DeckGL does not emit it (orbitAxis is an OrbitView prop rather than part
+      // of its viewState), but callers that reset the camera do supply it.
+      if (newOrbitAxis !== undefined) {
+        setOrbitAxis(newOrbitAxis);
+      }
     }
   };
 
@@ -905,6 +947,13 @@ export function SpatialSubscriber(props) {
       isReady={isReady}
       errors={errors}
       helpText={helpText}
+      options={(
+        <SpatialOptions
+          spatialAxisFixed={spatialAxisFixed}
+          setSpatialAxisFixed={setSpatialAxisFixed}
+          use3d={is3dMode}
+        />
+      )}
     >
       {
         shouldUseThree ? (

--- a/packages/view-types/spatial-beta/src/utils.js
+++ b/packages/view-types/spatial-beta/src/utils.js
@@ -1,8 +1,47 @@
 /* eslint-disable no-plusplus */
 import { Matrix4 } from 'math.gl';
 import { viv, BitmaskLayerBeta as BitmaskLayer } from '@vitessce/gl';
+import { getPhysicalSizeScalingMatrix } from '@vitessce/spatial-utils';
 import { extent } from 'd3-array';
 
+
+/**
+ * Get the modelMatrix to pass to viv's VolumeLayer for a given image.
+ *
+ * ImageWrapper.getModelMatrix() scales an image into absolute physical units
+ * (micrometers), which is the space the rest of the beta spatial stack works in
+ * (see ImageWrapper.getBoundingCube, which derives the clipping-plane ranges
+ * from it). But viv's VolumeLayer independently computes its own physical size
+ * scaling matrix from the same metadata, and the XR3DLayer vertex shader applies
+ * both of them:
+ *
+ *   gl_Position = proj * view * model * scale * resolution * vec4(positions, 1.);
+ *
+ * Passing the physical model matrix straight through therefore squares the
+ * anisotropy and stretches the volume along its coarsest axis by that ratio
+ * (e.g. a 1x1x2 um voxel renders twice as deep as it should). Divide viv's
+ * matrix out here so that `model * scale` still equals the physical model
+ * matrix, and 3D stays consistent with getBoundingCube() and with the legacy
+ * spatial view, which left modelMatrix as the identity and let viv do the
+ * scaling on its own.
+ *
+ * Note: viv compares the raw `physicalSizes[*].size` numbers and ignores units,
+ * whereas ImageWrapper normalizes them to micrometers. Deriving the inverse from
+ * those same `meta.physicalSizes` values keeps the cancellation exact even when
+ * the two disagree.
+ *
+ * @param {object|object[]} data PixelSource | PixelSource[]
+ * @param {number[]|undefined} modelMatrix The image's physical model matrix.
+ * @returns {Matrix4} The modelMatrix to pass to viv.VolumeLayer.
+ */
+export function getVolumeModelMatrix(data, modelMatrix) {
+  const source = Array.isArray(data) ? data[0] : data;
+  const vivPhysicalSizeScalingMatrix = getPhysicalSizeScalingMatrix(source);
+  const base = Array.isArray(modelMatrix) && modelMatrix.length === 16
+    ? new Matrix4(modelMatrix)
+    : new Matrix4().identity();
+  return base.multiplyRight(vivPhysicalSizeScalingMatrix.invert());
+}
 
 export function getInitialSpatialTargets({
   width,
@@ -33,12 +72,19 @@ export function getInitialSpatialTargets({
 
     if (imageLayerLoader) {
       const viewSize = { height, width };
+      // getDefaultInitialViewState composes modelMatrix with viv's own physical
+      // size scaling matrix, exactly like the VolumeLayer render path, so in 3D
+      // it needs the same corrected matrix or the camera will not frame the
+      // volume that actually gets drawn.
+      const viewStateModelMatrix = use3d
+        ? getVolumeModelMatrix(imageLayerLoader, modelMatrix)
+        : new Matrix4(modelMatrix);
       const { target, zoom: newViewStateZoom } = viv.getDefaultInitialViewState(
         imageLayerLoader,
         viewSize,
         zoomBackoff,
         use3d,
-        new Matrix4(modelMatrix),
+        viewStateModelMatrix,
       );
 
       const maxExtent = Math.max(

--- a/packages/view-types/spatial-beta/src/utils.test.js
+++ b/packages/view-types/spatial-beta/src/utils.test.js
@@ -1,0 +1,93 @@
+import { describe, it, expect } from 'vitest';
+import { Matrix4 } from 'math.gl';
+import { getPhysicalSizeScalingMatrix } from '@vitessce/spatial-utils';
+import { getVolumeModelMatrix } from './utils.js';
+
+/**
+ * Stand-in for a viv PixelSource. Only `meta.physicalSizes` is read.
+ */
+function fakeSource(x, y, z, unit = 'µm') {
+  return {
+    meta: {
+      physicalSizes: {
+        x: { size: x, unit },
+        y: { size: y, unit },
+        z: { size: z, unit },
+      },
+    },
+  };
+}
+
+/**
+ * Reproduce what viv's XR3DLayer vertex shader does with the matrices it is
+ * given: `model * scale`, where `scale` is derived internally by VolumeLayer from
+ * the same physicalSizes metadata. Returns the rendered extent of the volume.
+ */
+function renderedExtent(source, modelMatrix, shape) {
+  const vivScale = getPhysicalSizeScalingMatrix(source);
+  return new Matrix4(modelMatrix)
+    .multiplyRight(vivScale)
+    .transformPoint(shape);
+}
+
+describe('view-types/spatial-beta/utils', () => {
+  describe('getVolumeModelMatrix', () => {
+    // HuBMAP 3DIMC dataset HBM459.CGSD.533: 452x514x50 voxels at 1x1x2 um.
+    const anisotropicZ = fakeSource(1, 1, 2);
+    const shape = [452, 514, 50];
+    // ImageWrapper.getModelMatrix() scales into absolute micrometers.
+    const physicalModelMatrix = new Matrix4().scale([1, 1, 2]);
+
+    it('renders the true physical extent instead of squaring the anisotropy', () => {
+      const volumeModelMatrix = getVolumeModelMatrix(
+        anisotropicZ, physicalModelMatrix,
+      );
+      expect(
+        renderedExtent(anisotropicZ, volumeModelMatrix, shape),
+      ).toEqual([452, 514, 100]);
+    });
+
+    it('regression: passing the physical model matrix straight through doubles z', () => {
+      // This is what the beta spatial view did before the fix.
+      expect(
+        renderedExtent(anisotropicZ, physicalModelMatrix, shape),
+      ).toEqual([452, 514, 200]);
+    });
+
+    it('is not z-specific', () => {
+      // Same dataset, anisotropic in x instead.
+      const anisotropicX = fakeSource(2, 1, 1);
+      const modelMatrix = new Matrix4().scale([2, 1, 1]);
+      const volumeModelMatrix = getVolumeModelMatrix(anisotropicX, modelMatrix);
+      expect(
+        renderedExtent(anisotropicX, volumeModelMatrix, shape),
+      ).toEqual([904, 514, 50]);
+    });
+
+    it('is a no-op for isotropic voxels', () => {
+      const isotropic = fakeSource(0.5, 0.5, 0.5);
+      const modelMatrix = new Matrix4().scale([0.5, 0.5, 0.5]);
+      // viv normalizes by the minimum, so its matrix is already the identity.
+      expect(
+        getVolumeModelMatrix(isotropic, modelMatrix),
+      ).toEqual(modelMatrix);
+    });
+
+    it('accepts a PixelSource array and uses the full-resolution level', () => {
+      const volumeModelMatrix = getVolumeModelMatrix(
+        [anisotropicZ, anisotropicZ], physicalModelMatrix,
+      );
+      expect(
+        renderedExtent(anisotropicZ, volumeModelMatrix, shape),
+      ).toEqual([452, 514, 100]);
+    });
+
+    it('falls back to the identity when there is no model matrix', () => {
+      // Missing physicalSizes: viv's matrix is the identity, so is ours.
+      const noPhysicalSizes = { meta: {} };
+      expect(
+        getVolumeModelMatrix(noPhysicalSizes, undefined),
+      ).toEqual(new Matrix4().identity());
+    });
+  });
+});

--- a/packages/view-types/spatial-three/src/SpatialThree.tsx
+++ b/packages/view-types/spatial-three/src/SpatialThree.tsx
@@ -374,7 +374,6 @@ export function SpatialThree(props: SpatialThreeProps) {
     }
   }, [segmentationSettings, segmentationGroup]);
 
-
   // 1st Rendering Pass Load the Data in the given resolution OR Resolution Changed
   const dataToCheck = images[layerScope]?.image?.instance?.getData();
   if (

--- a/packages/view-types/spatial-three/src/three-utils.ts
+++ b/packages/view-types/spatial-three/src/three-utils.ts
@@ -37,7 +37,15 @@ function extractInformationFromProps(
   const {
     spatialRenderingMode,
   } = props;
-  const data = image?.image?.instance?.getData();
+
+
+  // TODO: The code here should not rely on vivData.meta.physicalSizes,
+  // but should instead use imageWrapper.getModelMatrix() which is more general.
+  // Then, stripPhysicalSizes can be set to true and possibly removed as a parameter,
+  // making stripPhysicalSizes the default behavior in ImageWrapper.getData().
+  const stripPhysicalSizes = false;
+
+  const data = image?.image?.instance?.getData(stripPhysicalSizes);
   if (!data) {
     return {
       channelsVisible: null,

--- a/packages/view-types/spatial-three/src/types.ts
+++ b/packages/view-types/spatial-three/src/types.ts
@@ -31,7 +31,7 @@ export interface VolumeSource {
 export interface ImageWrapper {
   image: {
     instance: {
-      getData(): VolumeSource[];
+      getData(stripPhysicalSizes?: boolean): VolumeSource[];
       isInterleaved(): boolean;
       getChannelIndex(target: number | string): number;
       getAutoTargetResolution(): number;

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -2678,10 +2678,16 @@ importers:
       plur:
         specifier: ^5.1.0
         version: 5.1.0
+      react-aria:
+        specifier: 'catalog:'
+        version: 3.47.0(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
       short-number:
         specifier: ^1.0.6
         version: 1.0.7
     devDependencies:
+      '@testing-library/react':
+        specifier: 'catalog:'
+        version: 16.3.0(@testing-library/dom@10.4.0)(@types/react-dom@18.0.6)(@types/react@19.1.6)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
       react:
         specifier: 'catalog:'
         version: 19.2.6


### PR DESCRIPTION
<!-- Replace with the number of the issue filed from UPSTREAM-ISSUE-3d-physical-size.md -->
Fixes #2550

#### Background

3D volume rendering in `spatialBeta` applies physical pixel size twice, so anisotropic volumes
render stretched along their coarsest axis by the anisotropy ratio. A volume with `1 x 1 x 2 µm`
voxels renders twice as deep as it should. The legacy `spatial` view renders the same file
correctly, so this shows up as a regression for anyone migrating a volumetric dataset to the beta
views.

`ImageWrapper.getModelMatrix()` scales an image into absolute micrometers, and
`Spatial.createImageLayer()` passes that to viv's `VolumeLayer` as `modelMatrix`. But `VolumeLayer`
independently derives its own physical size scaling matrix from the same metadata, and the
`XR3DLayer` vertex shader applies both:

```glsl
gl_Position = proj * view * model * scale * resolution * vec4(positions, 1.);
```

The legacy view avoided this because its `modelMatrix` comes from `loader.metadata.transform`, which
`getMetaWithTransformMatrices` leaves as the identity for a single image, so viv's internal matrix
was the only physical scaling applied. 2D is unaffected — `MultiscaleImageLayer` and `ImageLayer`
default `usePhysicalSizeScaling` to false, so there the model matrix is the only scaling.

Alongside that, the beta stack lost the 3D camera controls the legacy stack had, which compounds the
problem: once a volume is distorted or panned away there is no way back to a known orientation.

- `spatialBeta` reads `spatialAxisFixed` but nothing in the beta stack can set it. The legacy control
  lived in the spatial view's plot options menu (`SpatialOptions`), and `spatialBeta`'s `TitleInfo`
  is never given an `options` prop. `AbstractSpatialOrScatterplot` only pins the orbit target while
  that flag is set, so the target moves on every pan.
- The auto-computed initial view state is applied only when
  `notYetInitialized || stillDefaultInitialized`, and deliberately does not re-run on pan or zoom.
  Switching to 3D after panning in 2D therefore keeps the 2D target and zoom, even though
  `getInitialSpatialTargets` has already recomputed 3D values. The legacy layer controller reset the
  camera explicitly on every 2D/3D transition.

#### Change List

- Added `getVolumeModelMatrix()` in `@vitessce/spatial-beta`, which divides viv's physical size
  scaling matrix back out of the image's model matrix so that `model * scale` still equals the
  physical model matrix. Cancelling viv's matrix rather than passing the identity keeps 3D consistent
  with `ImageWrapper.getBoundingCube()`, which drives the clipping-plane slider ranges in absolute
  micrometers; passing the identity would shrink the render by the minimum physical size and
  desynchronise those sliders.
- Used it in `Spatial.createImageLayer()` when `spatialRenderingMode === '3D'`, and in
  `getInitialSpatialTargets()`, which passes a model matrix to `viv.getDefaultInitialViewState()` —
  that composes the two matrices the same way the render path does, so it needs the same corrected
  matrix or the initial camera does not frame the volume that is drawn. The 2D path is unchanged.
- Added a `SpatialOptions` plot options menu to `spatialBeta` carrying the "Fix Camera Axis" control,
  reusing the legacy control's label and aria-label. It lives in the spatial view rather than the
  layer controller because `spatialAxisFixed` is in `AUTO_INDEPENDENT_COORDINATION_TYPES`: under
  `initStrategy: 'auto'` each view gets its own scope for it, so a control in the layer controller
  writes to a scope the spatial view never reads. No coordination-type changes were needed.
- Re-initialize the camera in `SpatialSubscriber` when `spatialRenderingMode` changes, resetting
  target, zoom and rotation. Guarded on the initial targets being computable, so a dataset that is
  not ready yet does not reset the target to `null` — it re-runs once the data loads.
- Forward `orbitAxis` through the beta view's `setViewState`. DeckGL never emits it (`orbitAxis` is an
  `OrbitView` prop rather than part of its viewState), so nothing was being lost in practice, but it
  left `spatialOrbitAxis` unwritable through the view's only camera bridge despite being a declared
  coordination type for the view.
- Added an `anisotropic-volume` example config over a public HuBMAP 3DIMC dataset
  (`452 x 514 x 50` at `1 x 1 x 2 µm`) as a regression case. It deliberately does not set
  `three: true`, so it exercises the deck.gl/viv `VolumeLayer` path.
- Added unit tests for `getVolumeModelMatrix` (including a regression test pinning the old doubled
  extent) and for the `SpatialOptions` control.

#### Checklist

 - [x] Have tested PR with one or more demo configurations
 - [x] Documentation added, updated, or not applicable

Testing notes: verified with the new `anisotropic-volume` demo config, and against the real file
through the loader — `ImageWrapper.getModelMatrix()` and viv's internal matrix both report a scale of
`[1, 1, 2]`, and the composed `model * scale` extent goes from `452 x 514 x 200` to
`452 x 514 x 100`, now matching `getBoundingCube()`. Compared side by side against the same file
under `spatial` + `layerController`, and confirmed 2D is unchanged. For the camera: panning in 2D and
then switching to 3D previously left the volume clipped at the edge of the view and now re-centers;
and with "Fix Camera Axis" on, a ctrl-drag pan in 3D no longer moves the orbit target, where it does
with the control off.

Documentation: no manual docs change needed. The coordination type page is autogenerated from
`COMPONENT_COORDINATION_TYPES` (`sites/docs/src/pages/_AutogeneratedCoordinationTypes.js`), and this
PR does not add or re-associate any coordination type.
