### PR TITLE
Strip meta.physicalSizes rather than invert

### DIFF
--- a/packages/utils/image-utils/src/ImageWrapper.ts
+++ b/packages/utils/image-utils/src/ImageWrapper.ts
@@ -72,7 +72,35 @@ export default class ImageWrapper implements AbstractImageWrapper {
     return true;
   }
 
-  getData(): VivLoaderDataType {
+  // TODO: make stripPhysicalSizes the default behavior,
+  // and remove it as a parameter, once it is no longer
+  // used by spatial-accelerated and spatial-three.
+  getData(stripPhysicalSizes = true): VivLoaderDataType {
+    // Here, we strip the physical size information from the Viv loaders,
+    // since we instead pass it via the model matrix.
+    // If we keep it here AND the caller also uses getModelMatrix(),
+    // then the physical size information will be applied twice.
+    // Reference: https://github.com/hms-dbmi/viv/blob/ec590278f8f5591c64200be9ce189aa5c12215fc/packages/layers/src/utils.js#L162
+    if (stripPhysicalSizes) {
+      const data = this.vivLoader.data;
+      // Clone each pixel source rather than spreading it into a plain object,
+      // so that its prototype methods (e.g. getRaster, getTile) are preserved.
+      const newData = data.map(d => {
+        if ('meta' in d) {
+          const { meta } = d;
+          if (meta && 'physicalSizes' in meta) {
+            // Undefined results in using the identity matrix.
+            const newMeta = { ...meta, physicalSizes: undefined };
+            const clone = Object.create(Object.getPrototypeOf(d));
+            Object.assign(clone, d, { meta: newMeta });
+            return clone;
+          }
+        }
+        return d;
+      });
+      return newData as VivLoaderDataType;
+    }
+
     return this.vivLoader.data;
   }
 

--- a/packages/utils/image-utils/src/ImageWrapper.ts
+++ b/packages/utils/image-utils/src/ImageWrapper.ts
@@ -82,10 +82,10 @@ export default class ImageWrapper implements AbstractImageWrapper {
     // then the physical size information will be applied twice.
     // Reference: https://github.com/hms-dbmi/viv/blob/ec590278f8f5591c64200be9ce189aa5c12215fc/packages/layers/src/utils.js#L162
     if (stripPhysicalSizes) {
-      const data = this.vivLoader.data;
+      const { data } = this.vivLoader;
       // Clone each pixel source rather than spreading it into a plain object,
       // so that its prototype methods (e.g. getRaster, getTile) are preserved.
-      const newData = data.map(d => {
+      const newData = data.map((d) => {
         if ('meta' in d) {
           const { meta } = d;
           if (meta && 'physicalSizes' in meta) {

--- a/packages/view-types/spatial-accelerated/src/VolumeDataManager.js
+++ b/packages/view-types/spatial-accelerated/src/VolumeDataManager.js
@@ -755,8 +755,14 @@ export class VolumeDataManager {
 
       this.zarrStore.resolutions = resolutions;
 
+      // TODO: The code here should not rely on vivData.meta.physicalSizes,
+      // but should instead use imageWrapper.getModelMatrix() which is more general.
+      // Then, stripPhysicalSizes can be set to true and possibly removed as a parameter,
+      // making stripPhysicalSizes the default behavior in ImageWrapper.getData().
+      const stripPhysicalSizes = false;
+
       // TODO: filter to only those resolutions below the 16k x 16x x 4k limit?
-      const vivData = imageWrapper.getData();
+      const vivData = imageWrapper.getData(stripPhysicalSizes);
 
       if (!Array.isArray(vivData) || vivData.length < 1) {
         throw new Error('Not a multiresolution loader');

--- a/packages/view-types/spatial-beta/src/Spatial.js
+++ b/packages/view-types/spatial-beta/src/Spatial.js
@@ -16,7 +16,7 @@ import {
 import { AbstractSpatialOrScatterplot, createQuadTree } from '@vitessce/scatterplot';
 import { CoordinationType } from '@vitessce/constants-internal';
 import { log } from '@vitessce/globals';
-import { getLayerLoaderTuple, getVolumeModelMatrix, renderSubBitmaskLayers } from './utils.js';
+import { getLayerLoaderTuple, renderSubBitmaskLayers } from './utils.js';
 
 const POINT_LAYER_PREFIX = 'point-layer-';
 const SPOT_LAYER_PREFIX = 'spot-layer-';
@@ -1198,13 +1198,7 @@ class Spatial extends AbstractSpatialOrScatterplot {
     }
 
     // TODO: support model matrix from coordination space also.
-    const imageModelMatrix = image?.image?.instance?.getModelMatrix();
-    // In 3D, viv's VolumeLayer applies its own physical size scaling matrix on
-    // top of whatever modelMatrix it is given, so the physical scaling has to be
-    // divided back out here to avoid applying it twice. See getVolumeModelMatrix.
-    const layerDefModelMatrix = is3dMode
-      ? getVolumeModelMatrix(data, imageModelMatrix)
-      : (imageModelMatrix || {});
+    const layerDefModelMatrix = image?.image?.instance?.getModelMatrix() || {};
 
     // We need to keep the same selections array reference,
     // otherwise the Viv layer will not be re-used as we want it to,

--- a/packages/view-types/spatial-three/src/SpatialThree.tsx
+++ b/packages/view-types/spatial-three/src/SpatialThree.tsx
@@ -374,7 +374,6 @@ export function SpatialThree(props: SpatialThreeProps) {
     }
   }, [segmentationSettings, segmentationGroup]);
 
-
   // 1st Rendering Pass Load the Data in the given resolution OR Resolution Changed
   const dataToCheck = images[layerScope]?.image?.instance?.getData();
   if (

--- a/packages/view-types/spatial-three/src/three-utils.ts
+++ b/packages/view-types/spatial-three/src/three-utils.ts
@@ -37,7 +37,15 @@ function extractInformationFromProps(
   const {
     spatialRenderingMode,
   } = props;
-  const data = image?.image?.instance?.getData();
+
+
+  // TODO: The code here should not rely on vivData.meta.physicalSizes,
+  // but should instead use imageWrapper.getModelMatrix() which is more general.
+  // Then, stripPhysicalSizes can be set to true and possibly removed as a parameter,
+  // making stripPhysicalSizes the default behavior in ImageWrapper.getData().
+  const stripPhysicalSizes = false;
+
+  const data = image?.image?.instance?.getData(stripPhysicalSizes);
   if (!data) {
     return {
       channelsVisible: null,

--- a/packages/view-types/spatial-three/src/types.ts
+++ b/packages/view-types/spatial-three/src/types.ts
@@ -31,7 +31,7 @@ export interface VolumeSource {
 export interface ImageWrapper {
   image: {
     instance: {
-      getData(): VolumeSource[];
+      getData(stripPhysicalSizes?: boolean): VolumeSource[];
       isInterleaved(): boolean;
       getChannelIndex(target: number | string): number;
       getAutoTargetResolution(): number;


### PR DESCRIPTION
<!-- Credit (as a starting template): https://github.com/visgl/deck.gl/blob/master/.github/pull_request_template.md -->
<!-- For feature, feature enhancement or bug fix, create an issue first and finish To Do List there -->
<!-- Anything doesn't work as expected is a bug, including code, doc and test -->

This is a PR into the branch for #2551 . The effect should be the same, kind of a matter of style/preference. Here, the code strips the `meta.physicalSizes` metadata when we can assume the modelMatrix already accounts for the physical sizing, rather than un-applying the matrix operations before viv re-applys them


<!-- For other PRs without open issue -->
#### Background
<!-- For all the PRs -->
#### Change List
-
#### Checklist
 - [ ] Have tested PR with one or more demo configurations
 - [ ] Documentation added, updated, or not applicable
