### PR TITLE
NickAkhmetov/Add `globalDisable3d` prop and prevent hidden layers from being loaded/affecting performance

### DIFF
--- a/.changeset/quiet-switches-rest.md
+++ b/.changeset/quiet-switches-rest.md
@@ -1,0 +1,6 @@
+---
+"@vitessce/layer-controller-beta": patch
+"@vitessce/spatial-beta": patch
+---
+
+The beta layer controller now honors a `globalDisable3d` prop, so a view config can hide the 3D rendering-mode switch as it could with the legacy layer controller. This matters for configs whose data cannot usefully be volume-rendered, which previously had no way to prevent a user from switching the spatial view into 3D. The beta spatial view also no longer builds a viv `VolumeLayer` for image layers that are hidden: `VolumeLayer` downloads a whole volume per channel from `updateState`, and DeckGL does not gate layer updates on `visible`, so a hidden layer previously paid the full cost of a volume load whenever 3D was switched on.

--- a/packages/view-types/layer-controller-beta/package.json
+++ b/packages/view-types/layer-controller-beta/package.json
@@ -49,6 +49,7 @@
     "react-color-with-lodash": "^2.19.5"
   },
   "devDependencies": {
+    "@testing-library/react": "catalog:",
     "react": "catalog:",
     "react-dom": "catalog:",
     "vite": "catalog:",

--- a/packages/view-types/layer-controller-beta/src/GlobalDimensionSlider.js
+++ b/packages/view-types/layer-controller-beta/src/GlobalDimensionSlider.js
@@ -37,6 +37,15 @@ const useStyles = makeStyles()(theme => ({
   },
 }));
 
+/**
+ * The Z variant of this slider also carries the view's 3D rendering-mode switch.
+ * `enable3d` allows a view config to withhold that switch, for data which cannot usefully be
+ * volume-rendered. It is a single boolean rather than the legacy `layerController`'s per-layer
+ * `disable3d` name list because the beta stack has one switch per view driving the shared
+ * `spatialRenderingMode`, and because beta layer names come from the image's own OME metadata
+ * (`ImageWrapper.getName()`) rather than from the view config, so a config author has no names to
+ * match against.
+ */
 export default function GlobalDimensionSlider(props) {
   const {
     label,
@@ -46,6 +55,7 @@ export default function GlobalDimensionSlider(props) {
     max = 0,
     spatialRenderingMode = null,
     setSpatialRenderingMode = null,
+    enable3d = true,
   } = props;
 
   const { classes: lcClasses } = useControllerSectionStyles();
@@ -91,7 +101,7 @@ export default function GlobalDimensionSlider(props) {
             ) : null}
           </Grid>
           <Grid size={2}>
-            {isForZ ? (
+            {isForZ && enable3d ? (
               <FormGroup row className={classes.switchFormGroup}>
                 <FormControlLabel
                   control={<Switch color="primary" checked={spatialRenderingMode === '3D'} onChange={handleRenderingModeChange} name="is3dMode" />}

--- a/packages/view-types/layer-controller-beta/src/GlobalDimensionSlider.test.jsx
+++ b/packages/view-types/layer-controller-beta/src/GlobalDimensionSlider.test.jsx
@@ -1,0 +1,49 @@
+import React from 'react';
+import { describe, it, expect } from 'vitest';
+import { render, screen } from '@testing-library/react';
+
+import GlobalDimensionSlider from './GlobalDimensionSlider.js';
+
+
+function renderZSlider(props) {
+  return render(
+    <GlobalDimensionSlider
+      label="Z"
+      targetValue={0}
+      setTargetValue={() => {}}
+      max={10}
+      spatialRenderingMode="2D"
+      setSpatialRenderingMode={() => {}}
+      {...props}
+    />,
+  );
+}
+
+describe('GlobalDimensionSlider.js', () => {
+  describe('<GlobalDimensionSlider />', () => {
+    it('offers the 3D switch by default', async () => {
+      renderZSlider();
+      expect(await screen.findByRole('checkbox', { name: '3D' })).toBeDefined();
+    });
+
+    it('withholds the 3D switch when a config disables 3D', () => {
+      renderZSlider({ enable3d: false });
+      expect(screen.queryByRole('checkbox', { name: '3D' })).toBeNull();
+      // The Z-slice slider itself must survive.
+      expect(screen.queryByLabelText('Z-slice slider')).not.toBeNull();
+    });
+
+    it('has no 3D switch on a non-Z dimension', () => {
+      // T sliders are rendered without a rendering mode, which is what marks them as not-Z.
+      render(
+        <GlobalDimensionSlider
+          label="T"
+          targetValue={0}
+          setTargetValue={() => {}}
+          max={3}
+        />,
+      );
+      expect(screen.queryByRole('checkbox', { name: '3D' })).toBeNull();
+    });
+  });
+});

--- a/packages/view-types/layer-controller-beta/src/LayerController.js
+++ b/packages/view-types/layer-controller-beta/src/LayerController.js
@@ -40,6 +40,7 @@ export default function LayerController(props) {
     volumeLoadingStatus,
     tiledPointsLoadingProgress,
     layerPerFeatureForPoints,
+    globalDisable3d,
     centroidSegmentationPairs = [],
     pairedSegScopes = new Set(),
     pairedPointScopes = new Set(),
@@ -89,6 +90,7 @@ export default function LayerController(props) {
           max={maxZ}
           spatialRenderingMode={spatialRenderingMode}
           setSpatialRenderingMode={setSpatialRenderingMode}
+          enable3d={!globalDisable3d}
         />
       ) : null}
       {anyLayerHasT ? (

--- a/packages/view-types/layer-controller-beta/src/LayerControllerSubscriber.js
+++ b/packages/view-types/layer-controller-beta/src/LayerControllerSubscriber.js
@@ -41,6 +41,8 @@ import LayerController from './LayerController.js';
  * @param {function} props.removeGridComponent The callback function to pass to TitleInfo,
  * to call when the component has been removed from the grid.
  * @param {string} props.title The component title.
+ * @param {boolean} props.globalDisable3d Hide the 3D rendering-mode switch, so this view cannot
+ * enter volume rendering. Named to match the equivalent prop on the legacy `layerController`.
  * @param {object[]} props.cameraPresets An array of camera preset objects,
  * which can be applied by the user by pressing CTRL+[0-9].
  * Each preset object can have the following coordination properties:
@@ -58,6 +60,7 @@ export function LayerControllerSubscriber(props) {
     title = 'Spatial Layers',
     uuid,
     layerPerFeatureForPoints = false,
+    globalDisable3d = false,
     cameraPresets,
     helpText = ViewHelpMapping.LAYER_CONTROLLER_BETA,
   } = props;
@@ -440,6 +443,7 @@ export function LayerControllerSubscriber(props) {
         pointLayerCoordination={pointLayerCoordination}
         pointMultiIndicesData={pointMultiIndicesData}
         layerPerFeatureForPoints={layerPerFeatureForPoints}
+        globalDisable3d={globalDisable3d}
         volumeLoadingStatus={volumeLoadingStatus}
         tiledPointsLoadingProgress={tiledPointsLoadingProgress}
 

--- a/packages/view-types/spatial-beta/src/Spatial.js
+++ b/packages/view-types/spatial-beta/src/Spatial.js
@@ -16,7 +16,7 @@ import {
 import { AbstractSpatialOrScatterplot, createQuadTree } from '@vitessce/scatterplot';
 import { CoordinationType } from '@vitessce/constants-internal';
 import { log } from '@vitessce/globals';
-import { getLayerLoaderTuple, renderSubBitmaskLayers } from './utils.js';
+import { getLayerLoaderTuple, isLayerVisible, renderSubBitmaskLayers } from './utils.js';
 
 const POINT_LAYER_PREFIX = 'point-layer-';
 const SPOT_LAYER_PREFIX = 'spot-layer-';
@@ -1186,6 +1186,16 @@ class Spatial extends AbstractSpatialOrScatterplot {
     const transparentColor = layerCoordination[CoordinationType.SPATIAL_LAYER_TRANSPARENT_COLOR];
     const useTransparentColor = Array.isArray(transparentColor) && transparentColor.length === 3;
 
+    // Skip hidden layers entirely in 3D. viv's VolumeLayer downloads a whole volume per channel
+    // from updateState, and DeckGL does not gate layer updates on `visible` -- so a hidden layer
+    // still pays full price. With one layer per image, a config holding several co-located
+    // acquisitions would fetch hundreds of megabytes the moment 3D is switched on, even though
+    // only one of them is on screen. The legacy `spatial` view never hit this because it filtered
+    // imageLayerDefs down to the single layer flagged `use3d`. Compared against `false` rather
+    // than falsy so that an unset value still counts as visible, matching ImageLayerController.
+    if (is3dMode && !isLayerVisible(visible)) {
+      return null;
+    }
 
     const extensions = getVivLayerExtensions(
       is3dMode, colormap, renderingMode,

--- a/packages/view-types/spatial-beta/src/utils.js
+++ b/packages/view-types/spatial-beta/src/utils.js
@@ -192,6 +192,16 @@ export function getInitialSpatialTargets({
 }
 
 /**
+ * Whether a layer should be rendered, given its `spatialLayerVisible` coordination value.
+ * An unset value counts as visible, matching the layer controller's own default.
+ * @param {boolean|undefined|null} spatialLayerVisible The coordination value.
+ * @returns {boolean} True if the layer should be rendered.
+ */
+export function isLayerVisible(spatialLayerVisible) {
+  return spatialLayerVisible !== false;
+}
+
+/**
  * Make a subtitle for the spatial component.
  * @param {object} data PixelSource | PixelSource[]
  * @returns {Array} [Layer, PixelSource | PixelSource[]] tuple.

--- a/packages/view-types/spatial-beta/src/utils.test.js
+++ b/packages/view-types/spatial-beta/src/utils.test.js
@@ -1,0 +1,21 @@
+import { describe, it, expect } from 'vitest';
+import { isLayerVisible } from './utils.js';
+
+describe('spatial-beta/utils.js', () => {
+  describe('isLayerVisible', () => {
+    it('is visible when explicitly true', () => {
+      expect(isLayerVisible(true)).toBe(true);
+    });
+
+    it('is hidden when explicitly false', () => {
+      expect(isLayerVisible(false)).toBe(false);
+    });
+
+    it('is visible when unset, matching the layer controller default', () => {
+      // ImageLayerController treats a non-boolean spatialLayerVisible as visible, so a layer
+      // whose config omits it must not be skipped in 3D.
+      expect(isLayerVisible(undefined)).toBe(true);
+      expect(isLayerVisible(null)).toBe(true);
+    });
+  });
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -2169,6 +2169,9 @@ importers:
         specifier: ^2.19.5
         version: 2.19.5(react@19.2.6)
     devDependencies:
+      '@testing-library/react':
+        specifier: 'catalog:'
+        version: 16.3.0(@testing-library/dom@10.4.0)(@types/react-dom@18.0.6)(@types/react@19.1.6)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
       react:
         specifier: 'catalog:'
         version: 19.2.6
@@ -7762,6 +7765,7 @@ packages:
 
   '@ungap/structured-clone@1.2.0':
     resolution: {integrity: sha512-zuVdFrMJiuCDQUMCzQaD6KL28MjnqqN8XnAqiEq9PNm/hCPTSGfrXCOfwj1ow4LFb/tNymJPwsNbVePc1xFqrQ==}
+    deprecated: Potential CWE-502 - Update to 1.3.1 or higher
 
   '@use-gesture/core@10.3.1':
     resolution: {integrity: sha512-WcINiDt8WjqBdUXye25anHiNxPc0VOrlT8F6LLkU6cycrOGUDyY/yyFmsg3k8i5OLvv25llc0QC45GhR/C8llw==}


### PR DESCRIPTION
Fixes #2557

#### Background

A view config that suppressed 3D on the legacy `layerController` gains an unsuppressable 3D switch when it moves to `layerControllerBeta`: the beta controller renders the switch for any image with more than one z-slice and never reads `disable3d` or `globalDisable3d`. Flipping that switch is expensive in a way the legacy stack was not, because `spatialBeta`'s `createImageLayers()` builds a viv `VolumeLayer` for _every_ image layer, and `VolumeLayer` downloads a whole volume per channel from `updateState`. DeckGL does not gate layer updates on `visible`, so hidden layers load too.

The legacy `spatial` view filtered `imageLayerDefs` by `layer.use3d === use3d`, so exactly one volume was ever loaded no matter how many images a config held.

We hit this in the HuBMAP portal on a seqFISH dataset: 18 co-located hybridization-cycle images in one spatial view, each 2048x2048x11 with 4 channels. Switching to 3D tried to pull ≈755 MB across ≈360 concurrent range requests, and the view sat on viv's `Loading Volume xx%...` indefinitely.

#### Change List

- `layerControllerBeta` accepts `globalDisable3d`, threaded from `LayerControllerSubscriber` through  `LayerController` to `GlobalDimensionSlider`, which withholds the 3D switch when set. The Z-slice slider is unaffected.
- `spatialBeta` skips building a layer for hidden image layers when in 3D, via a new  `isLayerVisible` helper. It compares against `false` rather than falsiness so that an unset  `spatialLayerVisible` still counts as visible, matching `ImageLayerController`'s own default.

#### Notes for reviewers

- **Why a boolean and not the legacy `disable3d` name list.** The beta stack has one switch per view  driving the shared `spatialRenderingMode`, so there is no per-layer 3D state to disable. Beta layer  names also come from `ImageWrapper.getName()` — the image's own OME metadata — rather than from the  view config, and the `image.ome-tiff` file def has no `name` field, so a config author has nothing  to match against. On the dataset above, all 18 files report the same OME `Name`  (`MMStack_Pos10`, the acquisition position) even though the config distinguishes them, so a name-keyed list would have matched all layers or none.
- **`globalDisable3d` is a negated name**, which we are trying to avoid. Kept to match the existing prop of the same meaning on the legacy `layerController`, so configs can move between stacks unchanged. Happy to rename to `enable3d` (default `true`) if preferred — the internal prop passed down to `GlobalDimensionSlider` is already named that way.
- **Hidden-layer skipping does not fix the all-layers-visible case.** A config where every layer is visible still loads one volume per layer. Capping how many volumes load at once reads as a product decision rather than a bug fix, so this PR leaves it alone; it only makes the cost controllable by a config that hides layers, which today it is not.
- `packages/view-types/spatial-beta/src/utils.test.js` is a new file here and is also added by the `spatialBeta` 3D physical-size PR (#2551). If both land, the merge is additive (two `describe` blocks).
- The `pnpm-lock.yaml` diff adds `@testing-library/react` as a devDependency of
  `@vitessce/layer-controller-beta` for the new component test; the one unrelated `deprecated:` annotation in that diff came from pnpm refreshing registry metadata.

#### Testing

- `GlobalDimensionSlider.test.jsx` — asserts the 3D switch is present by default, absent when 3D is disabled (and that the Z-slice slider survives), and absent on a non-Z dimension.
- `spatial-beta/src/utils.test.js` — pins `isLayerVisible`, in particular that an unset value counts as visible.
- Full workspace suite: 56 files / 333 tests passing. `eslint` clean on both changed packages (5 pre-existing warnings in untouched files). `tsc --build` clean for both packages.
