### PR TITLE
Updates for ng segment list branch

### DIFF
--- a/.changeset/tidy-colors-arrive.md
+++ b/.changeset/tidy-colors-arrive.md
@@ -1,0 +1,10 @@
+---
+"@vitessce/constants-internal": patch
+"@vitessce/schemas": patch
+"@vitessce/csv": patch
+"@vitessce/vit-s": patch
+"@vitessce/neuroglancer": patch
+"@vitessce/all": patch
+---
+
+Add an obsColors data type (one RGB color per observation), an obsColors.csv file type, a useSegmentationMultiObsColors multi-level data hook, and support for the new obsColors option of obsColorEncoding in the Neuroglancer view.

--- a/dev-docs/design-guidelines.md
+++ b/dev-docs/design-guidelines.md
@@ -62,6 +62,6 @@ This section contains an evolving set of code style guidelines that are not curr
 - Use `.js` extensions for relative imports, [even in TypeScript contexts](https://github.com/microsoft/TypeScript/issues/42151#issuecomment-914472944).
 - Do not use `.js` extensions for third-party packages, unless either:
   - The function or variable that needs to be accessed is not exported from the main entrypoint of the package.
-  - The package is published as CommonJS or UMD rather than ESM (or the ESM build is broken as with [json2csv](https://github.com/zemirco/json2csv/issues/539) and [react-virtualized](https://github.com/bvaughn/react-virtualized/issues/1632)).
+  - The package is published as CommonJS or UMD rather than ESM (or the ESM build is broken).
 
 

--- a/examples/configs/package.json
+++ b/examples/configs/package.json
@@ -22,6 +22,7 @@
     "@vitessce/vit-s": "workspace:*",
     "@vitessce/styles": "workspace:*",
     "react-sticky-el": "^2.1.1",
-    "clsx": "catalog:"
+    "clsx": "catalog:",
+    "@json2csv/plainjs": "^7.0.8"
   }
 }

--- a/examples/configs/src/utils.js
+++ b/examples/configs/src/utils.js
@@ -15,6 +15,21 @@ export function makeIdsCsvDataUrl(ids) {
   return `data:text/csv,${encodeURIComponent(csv)}`;
 }
 
+/**
+ * Make a data URL for an obsColors.csv file,
+ * with an 'id' column and a 'color' column.
+ * @param {object} obsIdToColor Mapping from observation ID
+ * to a hex color string, like { cell_1: '#ff0000' }.
+ * @returns {string} The data URL.
+ */
+export function makeColorsCsvDataUrl(obsIdToColor) {
+  const parser = new Parser({ fields: ['id', 'color'] });
+  const csv = parser.parse(
+    Object.entries(obsIdToColor).map(([id, color]) => ({ id, color })),
+  );
+  return `data:text/csv,${encodeURIComponent(csv)}`;
+}
+
 // Exported because used by the cypress tests: They route API requests to the fixtures instead.
 export const urlPrefix = 'https://data-1.vitessce.io/0.0.31/master_release';
 

--- a/examples/configs/src/utils.js
+++ b/examples/configs/src/utils.js
@@ -7,6 +7,13 @@ import {
   FileType as ft,
   CoordinationType as ct,
 } from '@vitessce/constants';
+import { Parser } from '@json2csv/plainjs';
+
+export function makeIdsCsvDataUrl(ids) {
+  const parser = new Parser({ fields: ['id'] });
+  const csv = parser.parse(ids.map(id => ({ id })));
+  return `data:text/csv,${encodeURIComponent(csv)}`;
+}
 
 // Exported because used by the cypress tests: They route API requests to the fixtures instead.
 export const urlPrefix = 'https://data-1.vitessce.io/0.0.31/master_release';

--- a/examples/configs/src/view-configs/3d-maps/melanoma-neuroglancer-with-segments.js
+++ b/examples/configs/src/view-configs/3d-maps/melanoma-neuroglancer-with-segments.js
@@ -31,13 +31,15 @@ function generateNeuroglancerMinimalConfiguration() {
       fileUid: 'melanom-meshes',
     },
     options: {
+      /*
       segmentColors: {
         612: '#d74242',
         3351: '#b9d742',
         4328: '#42d77d',
         6531: '#427dd7',
         8446: '#b942d7',
-      },
+        },
+      */
     },
   });
 
@@ -46,7 +48,7 @@ function generateNeuroglancerMinimalConfiguration() {
     url: makeIdsCsvDataUrl([612, 3351, 4328, 6531, 8446]),
     coordinationValues: {
       obsType: 'cell',
-      featureType:'feature',
+      featureType: 'feature',
       featureValueType: 'value',
     },
   });
@@ -169,7 +171,7 @@ function generateNeuroglancerMinimalConfiguration() {
         segmentationChannel: CL([
           {
             obsType: 'cell',
-            featureType:'feature',
+            featureType: 'feature',
             featureValueType: 'value',
             spatialChannelVisible: true,
           },

--- a/examples/configs/src/view-configs/3d-maps/melanoma-neuroglancer-with-segments.js
+++ b/examples/configs/src/view-configs/3d-maps/melanoma-neuroglancer-with-segments.js
@@ -6,7 +6,7 @@ import {
   vconcat,
   getInitialCoordinationScopePrefix,
 } from '@vitessce/config';
-import { Parser } from '@json2csv/plainjs';
+import { makeIdsCsvDataUrl } from '../../utils.js';
 
 function generateNeuroglancerMinimalConfiguration() {
   const config = new VitessceConfig({
@@ -43,12 +43,7 @@ function generateNeuroglancerMinimalConfiguration() {
 
   dataset.addFile({
     fileType: 'obsFeatureMatrix.csv',
-    url: `data:text/csv,${encodeURIComponent(`id,tSNE1,tSNE2
-612,0.1,0.2
-3351,0.3,0.4
-4328,0.5,0.6
-6531,0.7,0.8
-8446,0.9,1.0`)}`,
+    url: makeIdsCsvDataUrl([612, 3351, 4328, 6531, 8446]),
     coordinationValues: {
       obsType: 'cell',
       featureType:'feature',

--- a/examples/configs/src/view-configs/3d-maps/melanoma-neuroglancer-with-segments.js
+++ b/examples/configs/src/view-configs/3d-maps/melanoma-neuroglancer-with-segments.js
@@ -6,6 +6,7 @@ import {
   vconcat,
   getInitialCoordinationScopePrefix,
 } from '@vitessce/config';
+import { Parser } from '@json2csv/plainjs';
 
 function generateNeuroglancerMinimalConfiguration() {
   const config = new VitessceConfig({
@@ -30,8 +31,6 @@ function generateNeuroglancerMinimalConfiguration() {
       fileUid: 'melanom-meshes',
     },
     options: {
-      segments: [612, 3351, 4328, 6531, 8446],
-      forceSegments: true,
       segmentColors: {
         612: '#d74242',
         3351: '#b9d742',
@@ -39,6 +38,21 @@ function generateNeuroglancerMinimalConfiguration() {
         6531: '#427dd7',
         8446: '#b942d7',
       },
+    },
+  });
+
+  dataset.addFile({
+    fileType: 'obsFeatureMatrix.csv',
+    url: `data:text/csv,${encodeURIComponent(`id,tSNE1,tSNE2
+612,0.1,0.2
+3351,0.3,0.4
+4328,0.5,0.6
+6531,0.7,0.8
+8446,0.9,1.0`)}`,
+    coordinationValues: {
+      obsType: 'cell',
+      featureType:'feature',
+      featureValueType: 'value',
     },
   });
 
@@ -160,6 +174,8 @@ function generateNeuroglancerMinimalConfiguration() {
         segmentationChannel: CL([
           {
             obsType: 'cell',
+            featureType:'feature',
+            featureValueType: 'value',
             spatialChannelVisible: true,
           },
         ]),

--- a/examples/configs/src/view-configs/3d-maps/melanoma-neuroglancer-with-segments.js
+++ b/examples/configs/src/view-configs/3d-maps/melanoma-neuroglancer-with-segments.js
@@ -6,7 +6,7 @@ import {
   vconcat,
   getInitialCoordinationScopePrefix,
 } from '@vitessce/config';
-import { makeIdsCsvDataUrl } from '../../utils.js';
+import { makeIdsCsvDataUrl, makeColorsCsvDataUrl } from '../../utils.js';
 
 function generateNeuroglancerMinimalConfiguration() {
   const config = new VitessceConfig({
@@ -30,17 +30,6 @@ function generateNeuroglancerMinimalConfiguration() {
     coordinationValues: {
       fileUid: 'melanom-meshes',
     },
-    options: {
-      /*
-      segmentColors: {
-        612: '#d74242',
-        3351: '#b9d742',
-        4328: '#42d77d',
-        6531: '#427dd7',
-        8446: '#b942d7',
-        },
-      */
-    },
   });
 
   dataset.addFile({
@@ -50,6 +39,24 @@ function generateNeuroglancerMinimalConfiguration() {
       obsType: 'cell',
       featureType: 'feature',
       featureValueType: 'value',
+    },
+  });
+
+  dataset.addFile({
+    fileType: 'obsColors.csv',
+    url: makeColorsCsvDataUrl({
+      612: '#d74242',
+      3351: '#b9d742',
+      4328: '#42d77d',
+      6531: '#427dd7',
+      8446: '#b942d7',
+    }),
+    options: {
+      obsIndex: 'id',
+      obsColors: 'color',
+    },
+    coordinationValues: {
+      obsType: 'cell',
     },
   });
 
@@ -174,6 +181,7 @@ function generateNeuroglancerMinimalConfiguration() {
             featureType: 'feature',
             featureValueType: 'value',
             spatialChannelVisible: true,
+            obsColorEncoding: 'obsColors',
           },
         ]),
       },

--- a/packages/constants-internal/src/constant-relationships.ts
+++ b/packages/constants-internal/src/constant-relationships.ts
@@ -12,6 +12,7 @@ export const FILE_TYPE_DATA_TYPE_MAPPING = {
   [FileType.OBS_POINTS_CSV]: DataType.OBS_POINTS,
   [FileType.OBS_LOCATIONS_CSV]: DataType.OBS_LOCATIONS,
   [FileType.OBS_LABELS_CSV]: DataType.OBS_LABELS,
+  [FileType.OBS_COLORS_CSV]: DataType.OBS_COLORS,
   [FileType.FEATURE_LABELS_CSV]: DataType.FEATURE_LABELS,
   [FileType.SAMPLE_SETS_CSV]: DataType.SAMPLE_SETS,
   [FileType.OBS_FEATURE_MATRIX_CSV]: DataType.OBS_FEATURE_MATRIX,
@@ -106,6 +107,9 @@ export const DATA_TYPE_COORDINATION_VALUE_USAGE = {
   [DataType.OBS_LABELS]: [
     CoordinationType.OBS_TYPE,
     CoordinationType.OBS_LABELS_TYPE,
+  ],
+  [DataType.OBS_COLORS]: [
+    CoordinationType.OBS_TYPE,
   ],
   [DataType.FEATURE_LABELS]: [
     CoordinationType.FEATURE_TYPE,

--- a/packages/constants-internal/src/constants.ts
+++ b/packages/constants-internal/src/constants.ts
@@ -38,6 +38,7 @@ export const ViewType = {
 
 export const DataType = {
   OBS_LABELS: 'obsLabels',
+  OBS_COLORS: 'obsColors',
   OBS_EMBEDDING: 'obsEmbedding',
   OBS_FEATURE_MATRIX: 'obsFeatureMatrix',
   OBS_SETS: 'obsSets',
@@ -86,6 +87,7 @@ export const FileType = {
   OBS_POINTS_CSV: 'obsPoints.csv',
   OBS_LOCATIONS_CSV: 'obsLocations.csv',
   OBS_LABELS_CSV: 'obsLabels.csv',
+  OBS_COLORS_CSV: 'obsColors.csv',
   FEATURE_LABELS_CSV: 'featureLabels.csv',
   OBS_FEATURE_MATRIX_CSV: 'obsFeatureMatrix.csv',
   OBS_SEGMENTATIONS_JSON: 'obsSegmentations.json',

--- a/packages/file-types/csv/src/csv-loaders/ObsColorsCsv.js
+++ b/packages/file-types/csv/src/csv-loaders/ObsColorsCsv.js
@@ -1,0 +1,52 @@
+import CsvLoader from './CsvLoader.js';
+
+const HEX_REGEX = /^#?([A-F\d]{2})([A-F\d]{2})([A-F\d]{2})$/i;
+
+function parseHexColor(hex) {
+  const result = HEX_REGEX.exec(String(hex).trim());
+  if (!result) {
+    return null;
+  }
+  return [
+    parseInt(result[1], 16),
+    parseInt(result[2], 16),
+    parseInt(result[3], 16),
+  ];
+}
+
+function parseChannel(value) {
+  const num = Number(value);
+  if (Number.isNaN(num)) {
+    return null;
+  }
+  return Math.max(0, Math.min(255, Math.round(num)));
+}
+
+export default class ObsColorsCsvLoader extends CsvLoader {
+  loadFromCache(data) {
+    if (this.cachedResult) {
+      return this.cachedResult;
+    }
+    const { obsIndex: indexCol, obsColors: colorCols } = this.options;
+    const obsIndex = data.map(d => String(d[indexCol]));
+    // The obsColors option is either a single column of hex color strings,
+    // or an array of three columns for the R, G, and B channel values.
+    const obsColors = Array.isArray(colorCols)
+      ? data.map((d) => {
+        const rgb = colorCols.map(col => parseChannel(d[col]));
+        return rgb.some(c => c === null) ? null : rgb;
+      })
+      : data.map(d => parseHexColor(d[colorCols]));
+
+    // For convenience, also provide a Map from observation ID to [r, g, b],
+    // so that consumers do not need to align obsIndex and obsColors themselves.
+    // Observations whose color could not be parsed are omitted.
+    const obsColorMap = new Map(
+      obsIndex
+        .map((obsId, i) => ([obsId, obsColors[i]]))
+        .filter(([, color]) => color !== null),
+    );
+    this.cachedResult = { obsIndex, obsColors, obsColorMap };
+    return this.cachedResult;
+  }
+}

--- a/packages/file-types/csv/src/csv-loaders/index.js
+++ b/packages/file-types/csv/src/csv-loaders/index.js
@@ -3,6 +3,7 @@ export { default as FeatureLabelsCsvLoader } from './FeatureLabelsCsv.js';
 export { default as ObsEmbeddingCsvLoader } from './ObsEmbeddingCsv.js';
 export { default as ObsFeatureMatrixCsvLoader } from './ObsFeatureMatrixCsv.js';
 export { default as ObsLabelsCsvLoader } from './ObsLabelsCsv.js';
+export { default as ObsColorsCsvLoader } from './ObsColorsCsv.js';
 export { default as ObsSpotsCsvLoader } from './ObsSpotsCsv.js';
 export { default as ObsPointsCsvLoader } from './ObsPointsCsv.js';
 export { default as ObsLocationsCsvLoader } from './ObsLocationsCsv.js';

--- a/packages/main/all/src/base-plugins.ts
+++ b/packages/main/all/src/base-plugins.ts
@@ -28,6 +28,7 @@ import {
   obsPointsCsvSchema,
   obsLocationsCsvSchema,
   obsLabelsCsvSchema,
+  obsColorsCsvSchema,
   featureLabelsCsvSchema,
   sampleSetsCsvSchema,
   obsSetsAnndataSchema,
@@ -118,6 +119,7 @@ import {
   ObsPointsCsvLoader,
   ObsLocationsCsvLoader,
   ObsLabelsCsvLoader,
+  ObsColorsCsvLoader,
   ObsFeatureMatrixCsvLoader,
   FeatureLabelsCsvLoader,
   SampleSetsCsvLoader,
@@ -297,6 +299,7 @@ export const baseFileTypes = [
   makeFileType(FileType.OBS_POINTS_CSV, DataType.OBS_POINTS, ObsPointsCsvLoader, CsvSource, obsPointsCsvSchema),
   makeFileType(FileType.OBS_LOCATIONS_CSV, DataType.OBS_LOCATIONS, ObsLocationsCsvLoader, CsvSource, obsLocationsCsvSchema),
   makeFileType(FileType.OBS_LABELS_CSV, DataType.OBS_LABELS, ObsLabelsCsvLoader, CsvSource, obsLabelsCsvSchema),
+  makeFileType(FileType.OBS_COLORS_CSV, DataType.OBS_COLORS, ObsColorsCsvLoader, CsvSource, obsColorsCsvSchema),
   makeFileType(FileType.OBS_FEATURE_MATRIX_CSV, DataType.OBS_FEATURE_MATRIX, ObsFeatureMatrixCsvLoader, CsvSource, z.null()),
   makeFileType(FileType.FEATURE_LABELS_CSV, DataType.FEATURE_LABELS, FeatureLabelsCsvLoader, CsvSource, featureLabelsCsvSchema),
   makeFileType(FileType.SAMPLE_SETS_CSV, DataType.SAMPLE_SETS, SampleSetsCsvLoader, CsvSource, sampleSetsCsvSchema),
@@ -500,6 +503,8 @@ export const baseCoordinationTypes = [
     'cellSetSelection',
     z.enum([
       'geneSelection', 'cellSetSelection', 'spatialChannelColor', 'spatialLayerColor', 'obsLabels',
+      // For per-observation colors loaded from an obsColors data type.
+      'obsColors',
       // For point coloring.
       'random', 'randomByFeature',
     ]),

--- a/packages/schemas/src/file-def-options.ts
+++ b/packages/schemas/src/file-def-options.ts
@@ -313,15 +313,6 @@ export const ngPrecomputedMeshSchema = z.object({
   enableDefaultSubsources: z.boolean()
     .describe('When true (default), automatically loads all subsources (defined in mesh metadata), when false loads what is explicitly enabled in `subsources`.')
     .optional(),
-  segments: z.array(z.union([z.number(), z.string()]))
-    .describe('An explicit list of segment IDs to display in this segmentation layer. Used as a fallback when no obsSets CSV is provided for this layer/channel. Ignored if obsSets are provided, unless `forceSegments` is true.')
-    .optional(),
-  segmentColors: z.record(z.string())
-    .describe('An explicit map of segment ID to hex color (e.g. `{"12": "#ff0000"}`). Keys are segment IDs as strings (object keys are always strings, even if the ID is numeric); values are hex color strings. Overrides any color computed from obsSets or `segments` for the given IDs, regardless of `forceSegments`.')
-    .optional(),
-  forceSegments: z.boolean()
-    .describe('When true, the `segments` list is always used to determine which segments to display, even if obsSets are also provided for this layer/channel. Defaults to false (obsSets take priority over `segments` when both are present).')
-    .optional(),
 }).partial().nullable();
 // Annotation Layer
 export const ngPointAnnotationSchema = z.object({

--- a/packages/schemas/src/file-def-options.ts
+++ b/packages/schemas/src/file-def-options.ts
@@ -380,6 +380,16 @@ export const obsLabelsCsvSchema = z.object({
   obsIndex: z.string(),
   obsLabels: z.string(),
 });
+export const obsColorsCsvSchema = z.object({
+  obsIndex: z.string(),
+  // Either a single column containing hex color strings (e.g., "#ff0000"),
+  // or three columns containing the R, G, and B channel values (each in [0, 255]).
+  obsColors: z.union([
+    z.string(),
+    z.array(z.string()).length(3),
+  ]),
+  // TODO: add an explicit format field?
+});
 export const featureLabelsCsvSchema = z.object({
   featureIndex: z.string(),
   featureLabels: z.string(),

--- a/packages/schemas/src/index.ts
+++ b/packages/schemas/src/index.ts
@@ -10,6 +10,7 @@ export {
   obsPointsCsvSchema,
   obsLocationsCsvSchema,
   obsLabelsCsvSchema,
+  obsColorsCsvSchema,
   featureLabelsCsvSchema,
   sampleSetsCsvSchema,
   obsSetsAnndataSchema,

--- a/packages/utils/sets-utils/package.json
+++ b/packages/utils/sets-utils/package.json
@@ -38,7 +38,7 @@
     "concaveman": "^1.2.1",
     "d3-dsv": "catalog:",
     "internmap": "catalog:",
-    "json2csv": "^5.0.0",
+    "@json2csv/plainjs": "^7.0.8",
     "lodash-es": "catalog:",
     "tinycolor2": "^1.4.1",
     "uuid": "catalog:"

--- a/packages/utils/sets-utils/src/io.js
+++ b/packages/utils/sets-utils/src/io.js
@@ -1,8 +1,6 @@
 import { isNil } from 'lodash-es';
 import { dsvFormat } from 'd3-dsv';
-// TODO(monorepo): try to find a different package for this.
-// Reference: https://github.com/zemirco/json2csv/issues/539
-import { Parser } from 'json2csv/dist/json2csv.umd.js';
+import { Parser } from '@json2csv/plainjs';
 import { getDefaultColor } from '@vitessce/utils';
 import { colorArrayToString, colorStringToArray } from './utils.js';
 import {

--- a/packages/view-types/layer-controller-beta/src/SegmentationChannelController.js
+++ b/packages/view-types/layer-controller-beta/src/SegmentationChannelController.js
@@ -141,6 +141,7 @@ function SegmentationChannelEllipsisMenu(props) {
           <option value="spatialChannelColor">Static Color</option>
           <option value="geneSelection">Feature Value</option>
           <option value="cellSetSelection">Set Selection</option>
+          <option value="obsColors">Per-observation Colors</option>
         </NativeSelect>
       </MenuItem>
       <MenuItem dense disableGutters>

--- a/packages/view-types/neuroglancer/src/NeuroglancerSubscriber.js
+++ b/packages/view-types/neuroglancer/src/NeuroglancerSubscriber.js
@@ -22,7 +22,8 @@ import {
   useSegmentationMultiObsFeatureMatrixIndices,
   useSegmentationMultiObsSets,
   useGridItemSize,
-  useMemoCustomComparison } from '@vitessce/vit-s';
+  useMemoCustomComparison,
+} from '@vitessce/vit-s';
 import {
   ViewHelpMapping,
   ViewType,
@@ -50,8 +51,8 @@ import {
   applyColormap,
   parseAnnotationChunkSegmentsWithPositions,
   GREY_HEX,
-  autoColorForId,
   remapCellColors,
+  autoColorForId,
 } from './utils.js';
 
 
@@ -360,9 +361,18 @@ export function NeuroglancerSubscriber(props) {
     segmentationLayerScopes?.forEach((layerScope) => {
       result[layerScope] = {};
       segmentationChannelScopesByLayer?.[layerScope]?.forEach((channelScope) => {
+        // Prefer obsFeatureMatrix.obsIndex from segmentationMultiIndicesData,
+        // but fall back to obsSets.obsIndex if not available.
         const { obsSets: layerSets, obsIndex: layerIndexFromSets } = obsSegmentationsSetsData
           ?.[layerScope]?.[channelScope] || {};
-        const layerIndex = layerIndexFromSets ?? null;
+        const { obsIndex: layerIndexFromMatrix } = segmentationMultiIndicesData
+          ?.[layerScope]?.[channelScope] || {};
+
+        const layerIndex = layerIndexFromMatrix ?? (layerIndexFromSets ?? null);
+        const idsToColor = layerIndex;
+        const knownIdSet = new Set((layerIndex ?? []).map(String));
+
+        console.log(layerIndex);
         const {
           obsSetColor,
           obsColorEncoding,
@@ -373,46 +383,14 @@ export function NeuroglancerSubscriber(props) {
           featureValueColormap,
           featureValueColormapRange,
         } = segmentationChannelCoordination[0][layerScope][channelScope];
-        // Segments provided directly via options
-        // `options.forceSegments: true` makes `segments` win as the *ID list*
-        // even when obsSets are also present — colors come from options.segmentColors if provided,
-        // otherwise colors for those IDs come from obsSets (cell set membership / expression)
-        const layerNgOptions = obsSegmentationsData?.[layerScope]?.neuroglancerOptions;
-        const configSegments = layerNgOptions?.segments ?? null;
-        const forceSegments = layerNgOptions?.forceSegments ?? false;
-        const configSegmentColors = layerNgOptions?.segmentColors ?? null;
-        // Priority for *which IDs* to show: obsSets (layerIndex) wins by
-        // default; configSegments is used only as a fallback when there is
-        // no layerIndex, unless forceSegments is set, in which case
-        // configSegments always wins as the ID list.
-        const useConfigSegmentIds = Boolean(configSegments?.length)
-          && (forceSegments || !layerIndex);
-        const segmentIds = useConfigSegmentIds ? configSegments : layerIndex;
-        // Applies the explicit segmentColors override (if any) on top of
-        // whatever colors were computed, then commits to `result`.
-        const finalizeChannelColors = (ngCellColors, opacity, defaultColor) => {
-          const merged = (configSegmentColors && useConfigSegmentIds)
-            ? { ...ngCellColors, ...configSegmentColors }
-            : ngCellColors;
-            // Store hex as default even if no layerIndex
-            // so applyColorsAndVisibility knows the intended color
-            // result[layerScope][channelScope] = ngCellColors;
-            // TODO: Remove remapping when Meshid/cellID mismatch is fixed
-          result[layerScope][channelScope] = remapCellColors(merged, cellIdToMeshIdRef);
-          result[layerScope].opacity = opacity ?? 1.0;
-          if (defaultColor !== undefined) {
-            result[layerScope].defaultColor = defaultColor;
-          }
-        };
         if (obsColorEncoding === 'spatialChannelColor') {
-          // All segments get the same static channel color — this encoding
-          // is inherently flat, so segments/forceSegments only affects which
-          // IDs are included, not the (single) color used.
-          if (spatialChannelColor || useConfigSegmentIds) {
-            const hex = spatialChannelColor ? rgbToHex(spatialChannelColor) : autoColorForId(layerScope + channelScope);
+          // All segments get the same static channel color
+          if (spatialChannelColor) {
+            const hex = rgbToHex(spatialChannelColor);
             const ngCellColors = {};
-            if (segmentIds?.length) {
-              if (obsSetSelection?.length > 0 && layerSets) {
+            if (layerIndex) {
+              // Has obs sets — use layerIndex for IDs
+              if (obsSetSelection?.length > 0) {
                 const mergedCellSets = mergeObsSets(layerSets, additionalObsSets);
                 const selectedIds = new Set();
                 obsSetSelection.forEach((setPath) => {
@@ -422,26 +400,26 @@ export function NeuroglancerSubscriber(props) {
                     : rootNode;
                   leafNode?.set?.forEach(([id]) => selectedIds.add(String(id)));
                 });
-                // Every ID keeps a color: selected or unknown-to-obsSets gets flat color;
-                // known but deselected gets grey
-                const knownIds = new Set((layerIndex ?? []).map(String));
-                segmentIds.forEach((id) => {
+                layerIndex.forEach((id) => {
                   if (selectedIds.has(String(id))) {
-                    ngCellColors[id] = hex;
-                  } else if (knownIds.has(String(id))) {
-                    ngCellColors[id] = GREY_HEX;
-                  } else {
                     ngCellColors[id] = hex;
                   }
                 });
               } else {
-                // null or empty selection - show ALL segments in segmentIds
-                segmentIds.forEach((id) => {
+                // null or empty selection - show ALL segments
+                layerIndex.forEach((id) => {
                   ngCellColors[id] = hex;
                 });
               }
             }
-            finalizeChannelColors(ngCellColors, spatialChannelOpacity, hex);
+
+            // Store hex as default even if no layerIndex
+            // so applyColorsAndVisibility knows the intended color
+            // result[layerScope][channelScope] = ngCellColors;
+            // TODO: Remove remapping when Meshid/cellID mismatch is fixed
+            result[layerScope][channelScope] = remapCellColors(ngCellColors, cellIdToMeshIdRef);
+            result[layerScope].opacity = spatialChannelOpacity ?? 1.0;
+            result[layerScope].defaultColor = hex; // store default color
           }
         } else if (obsColorEncoding === 'geneSelection') {
           // For NG mesh segmentations, obsIndex comes from obsSegmentationsSetsData
@@ -451,10 +429,7 @@ export function NeuroglancerSubscriber(props) {
             ?.[layerScope]?.[channelScope]?.obsIndex;
           const expressionData = segmentationMultiExpressionNormData
             ?.[layerScope]?.[channelScope];
-          // IDs to color: the restricted/forced list if given, otherwise
-          // every ID obsSets knows about (existing default behavior).
-          const idsToColor = segmentIds?.length ? segmentIds : instanceObsIndex;
-          if (instanceObsIndex && matrixObsIndex && expressionData?.[0] && idsToColor) {
+          if (instanceObsIndex && matrixObsIndex && expressionData?.[0]) {
             // matrixObsIndex uses 'MIS_X' format, instanceObsIndex uses 'X'
             // Strip prefix to align the two index spaces
             const matrixIndexMap = new Map(
@@ -464,23 +439,11 @@ export function NeuroglancerSubscriber(props) {
                 return [normalizedKey, i];
               }),
             );
-            // Map each obsSets-known ID directly to its row in the expression matrix.
-            const idToRowIndex = new Map(
-              instanceObsIndex.map(id => [String(id), matrixIndexMap.get(String(id))]),
-            );
+            const toMatrixIndex = instanceObsIndex.map(key => matrixIndexMap.get(String(key)));
             const [low, high] = featureValueColormapRange ?? [0, 1];
             const ngCellColors = {};
-            idsToColor.forEach((id) => {
-              const rowIndex = idToRowIndex.get(String(id));
-              if (rowIndex === undefined) {
-                // A forced/config segment that obsSets/expression data
-                // doesn't know about — leave uncolored (rather than a flat
-                // filler color) unless segmentColors covers it; NG will
-                // apply its own default per-segment coloring, and the key
-                // stays present so the segment remains visible.
-                ngCellColors[id] = autoColorForId(id);
-                return;
-              }
+            instanceObsIndex.forEach((id, i) => {
+              const rowIndex = toMatrixIndex[i];
               const rawVal = expressionData[0][rowIndex] ?? 0;
               // Uint8Array values are 0-255, already normalized — convert to 0-1
               const t = rawVal / 255;
@@ -490,24 +453,25 @@ export function NeuroglancerSubscriber(props) {
               const color = applyColormap(featureValueColormap ?? 'viridis', tClamped);
               ngCellColors[id] = rgbToHex(color);
             });
-            finalizeChannelColors(ngCellColors, spatialChannelOpacity);
-          } else if (idsToColor) {
-            // No expression data available at all — leave IDs uncolored
-            // (segmentColors, applied in finalizeChannelColors, is the only
-            // explicit override; otherwise NG's own default coloring applies).
+            // TODO: Remove
+            result[layerScope][channelScope] = remapCellColors(ngCellColors, cellIdToMeshIdRef);
+            // result[layerScope][channelScope] = ngCellColors;
+            result[layerScope].opacity = spatialChannelOpacity ?? 1.0;
+          } else if (instanceObsIndex) {
+            // No expression data available — use default color for all segments
+            const fallbackColor = spatialChannelColor ? rgbToHex(spatialChannelColor) : GREY_HEX;
             const ngCellColors = {};
-            idsToColor.forEach((id) => {
-              ngCellColors[id] = autoColorForId(id);
+            instanceObsIndex.forEach((id) => {
+              ngCellColors[id] = fallbackColor;
             });
-            finalizeChannelColors(ngCellColors, spatialChannelOpacity);
+            // TODO: remove
+            result[layerScope][channelScope] = remapCellColors(ngCellColors, cellIdToMeshIdRef);
+            // result[layerScope][channelScope] = ngCellColors;
+            result[layerScope].opacity = spatialChannelOpacity ?? 1.0;
+            result[layerScope].defaultColor = fallbackColor;
           }
         } else if (layerSets && layerIndex) {
-          // cellSetSelection encoding — color by obs set membership.
-          // Colors are always computed from the full obsSets-derived
-          // layerIndex (so cell-set membership colors are correct), but only
-          // IDs in segmentIds are emitted — this is what lets a forced,
-          // smaller `segments` list still inherit obsSet colors rather than
-          // falling back to a flat color.
+          // cellSetSelection encoding — color by obs set membership
           const mergedCellSets = mergeObsSets(layerSets, additionalObsSets);
           const cellColors = getCellColors({
             cellSets: mergedCellSets,
@@ -516,37 +480,23 @@ export function NeuroglancerSubscriber(props) {
             obsIndex: layerIndex,
             theme,
           });
-          const idsToColor = segmentIds?.length ? segmentIds : layerIndex;
-          // getCellColors only returns entries for the currently *selected*
-          // sets — a deselected obsSets member and an ID obsSets has never
-          // heard of both come back as `cellColors.get(id) === undefined`.
-          // Distinguish them: a deselected (but known) obsSets member
-          // recedes to grey (the lasso-selection), while an ID obsSets
-          // has no record of at all gets an auto-generated color.
-          const knownIds = new Set(layerIndex.map(String));
           const ngCellColors = {};
+          // cellColors is a Map keyed by segment ID
           idsToColor.forEach((id) => {
-            const color = cellColors.get(id);
-            if (color) {
-              ngCellColors[id] = rgbToHex(color);
-            } else if (knownIds.has(String(id))) {
-              // Known to obsSets, just not part of the current selection.
-              ngCellColors[id] = GREY_HEX;
-            } else {
-              // Not part of obsSets at all — auto-color deterministically.
-              ngCellColors[id] = autoColorForId(id);
+            if (knownIdSet.has(String(id))) {
+              const color = cellColors.get(id);
+              if (color) {
+                ngCellColors[id] = rgbToHex(color);
+              } else {
+                // Not part of obsSets at all — auto-color deterministically.
+                ngCellColors[id] = autoColorForId(id);
+              }
             }
           });
-          finalizeChannelColors(ngCellColors, spatialChannelOpacity);
-        } else if (useConfigSegmentIds) {
-          // No obsSets at all (or forceSegments is set) and this channel isn't using
-          // spatialChannelColor/geneSelection encoding. There's no obsSet color data
-          // data to fall back on here, so each Id gets an auto-generated color
-          const ngCellColors = {};
-          segmentIds.forEach((id) => {
-            ngCellColors[id] = autoColorForId(id);
-          });
-          finalizeChannelColors(ngCellColors, spatialChannelOpacity);
+          // TODO: remove
+          result[layerScope][channelScope] = remapCellColors(ngCellColors, cellIdToMeshIdRef);
+          // result[layerScope][channelScope] = ngCellColors;
+          result[layerScope].opacity = spatialChannelOpacity ?? 1.0;
         }
       });
     });
@@ -557,7 +507,6 @@ export function NeuroglancerSubscriber(props) {
     segmentationLayerScopes,
     segmentationChannelScopesByLayer,
     obsSegmentationsSetsData,
-    obsSegmentationsData,
     segmentationChannelCoordination,
     theme,
     segmentationMultiExpressionNormData,

--- a/packages/view-types/neuroglancer/src/NeuroglancerSubscriber.js
+++ b/packages/view-types/neuroglancer/src/NeuroglancerSubscriber.js
@@ -21,6 +21,7 @@ import {
   useSegmentationMultiFeatureSelection,
   useSegmentationMultiObsFeatureMatrixIndices,
   useSegmentationMultiObsSets,
+  useSegmentationMultiObsColors,
   useGridItemSize,
   useMemoCustomComparison,
 } from '@vitessce/vit-s';
@@ -296,6 +297,11 @@ export function NeuroglancerSubscriber(props) {
     coordinationScopes, coordinationScopesBy, loaders, dataset,
   );
 
+  // Optional: per-observation RGB colors, if an obsColors file is present.
+  const [obsSegmentationsColorsData, obsSegmentationsColorsDataStatus, obsSegmentationsColorsDataErrors] = useSegmentationMultiObsColors(
+    coordinationScopes, coordinationScopesBy, loaders, dataset,
+  );
+
   const [
     segmentationMultiExpressionData,
     segmentationMultiLoadedFeatureSelection,
@@ -315,6 +321,7 @@ export function NeuroglancerSubscriber(props) {
     ...obsPointsErrors,
     ...obsSegmentationsDataErrors,
     ...obsSegmentationsSetsDataErrors,
+    ...obsSegmentationsColorsDataErrors,
     ...pointMultiIndicesDataErrors,
     ...segmentationMultiFeatureSelectionErrors,
     ...segmentationMultiIndicesDataErrors,
@@ -327,6 +334,7 @@ export function NeuroglancerSubscriber(props) {
     // Segmentations
     obsSegmentationsDataStatus,
     obsSegmentationsSetsDataStatus,
+    obsSegmentationsColorsDataStatus,
     segmentationMultiFeatureSelectionStatus,
     segmentationMultiIndicesDataStatus,
   ]);
@@ -367,8 +375,16 @@ export function NeuroglancerSubscriber(props) {
           ?.[layerScope]?.[channelScope] || {};
         const { obsIndex: layerIndexFromMatrix } = segmentationMultiIndicesData
           ?.[layerScope]?.[channelScope] || {};
+        const { obsIndex: layerIndexFromColors, obsColorMap } = obsSegmentationsColorsData
+          ?.[layerScope]?.[channelScope] || {};
 
-        const layerIndex = layerIndexFromMatrix ?? (layerIndexFromSets ?? null);
+        // Prefer the observation index from obsFeatureMatrix,
+        // then from the per-observation colors,
+        // and finally, if neither of those are provided, from obsSets.
+        const layerIndex = layerIndexFromMatrix
+          ?? (layerIndexFromColors
+            ?? (layerIndexFromSets ?? null)
+          );
         const idsToColor = layerIndex;
         const knownIdSet = new Set((layerIndex ?? []).map(String));
 
@@ -382,7 +398,26 @@ export function NeuroglancerSubscriber(props) {
           featureValueColormap,
           featureValueColormapRange,
         } = segmentationChannelCoordination[0][layerScope][channelScope];
-        if (obsColorEncoding === 'spatialChannelColor') {
+        if (obsColorEncoding === 'obsColors') {
+          // Each segment gets its own color, from the obsColors data type.
+          if (obsColorMap) {
+            const ngCellColors = {};
+            idsToColor.forEach((id) => {
+              if (knownIdSet.has(String(id))) {
+                const color = obsColorMap.get(id);
+                if (color) {
+                  ngCellColors[id] = rgbToHex(color);
+                } else {
+                  // Not part of obsColors at all - use a default grey.
+                  ngCellColors[id] = GREY_HEX;
+                }
+              }
+            });
+            // TODO: Remove remapping when Meshid/cellID mismatch is fixed
+            result[layerScope][channelScope] = remapCellColors(ngCellColors, cellIdToMeshIdRef);
+            result[layerScope].opacity = spatialChannelOpacity ?? 1.0;
+          }
+        } else if (obsColorEncoding === 'spatialChannelColor') {
           // All segments get the same static channel color
           if (spatialChannelColor) {
             const hex = rgbToHex(spatialChannelColor);
@@ -506,6 +541,7 @@ export function NeuroglancerSubscriber(props) {
     segmentationLayerScopes,
     segmentationChannelScopesByLayer,
     obsSegmentationsSetsData,
+    obsSegmentationsColorsData,
     segmentationChannelCoordination,
     theme,
     segmentationMultiExpressionNormData,

--- a/packages/view-types/neuroglancer/src/NeuroglancerSubscriber.js
+++ b/packages/view-types/neuroglancer/src/NeuroglancerSubscriber.js
@@ -372,7 +372,6 @@ export function NeuroglancerSubscriber(props) {
         const idsToColor = layerIndex;
         const knownIdSet = new Set((layerIndex ?? []).map(String));
 
-        console.log(layerIndex);
         const {
           obsSetColor,
           obsColorEncoding,

--- a/packages/view-types/neuroglancer/src/NeuroglancerSubscriber.js
+++ b/packages/view-types/neuroglancer/src/NeuroglancerSubscriber.js
@@ -398,6 +398,22 @@ export function NeuroglancerSubscriber(props) {
           featureValueColormap,
           featureValueColormapRange,
         } = segmentationChannelCoordination[0][layerScope][channelScope];
+
+        // Applies the explicit segmentColors override (if any) on top of
+        // whatever colors were computed, then commits to `result`.
+        const finalizeChannelColors = (ngCellColors, opacity, defaultColor) => {
+          const merged = ngCellColors;
+          // Store hex as default even if no layerIndex
+          // so applyColorsAndVisibility knows the intended color
+          // result[layerScope][channelScope] = ngCellColors;
+          // TODO: Remove remapping when Meshid/cellID mismatch is fixed
+          result[layerScope][channelScope] = remapCellColors(merged, cellIdToMeshIdRef);
+          result[layerScope].opacity = opacity ?? 1.0;
+          if (defaultColor !== undefined) {
+            result[layerScope].defaultColor = defaultColor;
+          }
+        };
+
         if (obsColorEncoding === 'obsColors') {
           // Each segment gets its own color, from the obsColors data type.
           if (obsColorMap) {
@@ -419,8 +435,8 @@ export function NeuroglancerSubscriber(props) {
           }
         } else if (obsColorEncoding === 'spatialChannelColor') {
           // All segments get the same static channel color
+          const hex = spatialChannelColor ? rgbToHex(spatialChannelColor) : autoColorForId(layerScope + channelScope);
           if (spatialChannelColor) {
-            const hex = rgbToHex(spatialChannelColor);
             const ngCellColors = {};
             if (layerIndex) {
               // Has obs sets — use layerIndex for IDs
@@ -446,14 +462,7 @@ export function NeuroglancerSubscriber(props) {
                 });
               }
             }
-
-            // Store hex as default even if no layerIndex
-            // so applyColorsAndVisibility knows the intended color
-            // result[layerScope][channelScope] = ngCellColors;
-            // TODO: Remove remapping when Meshid/cellID mismatch is fixed
-            result[layerScope][channelScope] = remapCellColors(ngCellColors, cellIdToMeshIdRef);
-            result[layerScope].opacity = spatialChannelOpacity ?? 1.0;
-            result[layerScope].defaultColor = hex; // store default color
+            finalizeChannelColors(ngCellColors, spatialChannelOpacity, hex);
           }
         } else if (obsColorEncoding === 'geneSelection') {
           // For NG mesh segmentations, obsIndex comes from obsSegmentationsSetsData
@@ -487,10 +496,7 @@ export function NeuroglancerSubscriber(props) {
               const color = applyColormap(featureValueColormap ?? 'viridis', tClamped);
               ngCellColors[id] = rgbToHex(color);
             });
-            // TODO: Remove
-            result[layerScope][channelScope] = remapCellColors(ngCellColors, cellIdToMeshIdRef);
-            // result[layerScope][channelScope] = ngCellColors;
-            result[layerScope].opacity = spatialChannelOpacity ?? 1.0;
+            finalizeChannelColors(ngCellColors, spatialChannelOpacity);
           } else if (instanceObsIndex) {
             // No expression data available — use default color for all segments
             const fallbackColor = spatialChannelColor ? rgbToHex(spatialChannelColor) : GREY_HEX;
@@ -498,11 +504,7 @@ export function NeuroglancerSubscriber(props) {
             instanceObsIndex.forEach((id) => {
               ngCellColors[id] = fallbackColor;
             });
-            // TODO: remove
-            result[layerScope][channelScope] = remapCellColors(ngCellColors, cellIdToMeshIdRef);
-            // result[layerScope][channelScope] = ngCellColors;
-            result[layerScope].opacity = spatialChannelOpacity ?? 1.0;
-            result[layerScope].defaultColor = fallbackColor;
+            finalizeChannelColors(ngCellColors, spatialChannelOpacity);
           }
         } else if (layerSets && layerIndex) {
           // cellSetSelection encoding — color by obs set membership
@@ -518,19 +520,16 @@ export function NeuroglancerSubscriber(props) {
           // cellColors is a Map keyed by segment ID
           idsToColor.forEach((id) => {
             if (knownIdSet.has(String(id))) {
-              const color = cellColors.get(id);
+              const color = cellColors.get(String(id));
               if (color) {
                 ngCellColors[id] = rgbToHex(color);
               } else {
                 // Not part of obsSets at all — auto-color deterministically.
-                ngCellColors[id] = autoColorForId(id);
+                ngCellColors[id] = GREY_HEX;
               }
             }
           });
-          // TODO: remove
-          result[layerScope][channelScope] = remapCellColors(ngCellColors, cellIdToMeshIdRef);
-          // result[layerScope][channelScope] = ngCellColors;
-          result[layerScope].opacity = spatialChannelOpacity ?? 1.0;
+          finalizeChannelColors(ngCellColors, spatialChannelOpacity);
         }
       });
     });

--- a/packages/view-types/neuroglancer/src/NeuroglancerSubscriber.js
+++ b/packages/view-types/neuroglancer/src/NeuroglancerSubscriber.js
@@ -429,9 +429,7 @@ export function NeuroglancerSubscriber(props) {
                 }
               }
             });
-            // TODO: Remove remapping when Meshid/cellID mismatch is fixed
-            result[layerScope][channelScope] = remapCellColors(ngCellColors, cellIdToMeshIdRef);
-            result[layerScope].opacity = spatialChannelOpacity ?? 1.0;
+            finalizeChannelColors(ngCellColors, spatialChannelOpacity);
           }
         } else if (obsColorEncoding === 'spatialChannelColor') {
           // All segments get the same static channel color

--- a/packages/view-types/neuroglancer/src/use-memo-custom-equals.js
+++ b/packages/view-types/neuroglancer/src/use-memo-custom-equals.js
@@ -50,6 +50,9 @@ export function customIsEqualForCellColors(prevDeps, nextDeps) {
           curriedShallowDiffByChannelWithKeys('obsSegmentationsSetsData', layerScope, channelScope, [
             'obsSets', 'obsIndex',
           ])
+            || curriedShallowDiffByChannelWithKeys('obsSegmentationsColorsData', layerScope, channelScope, [
+              'obsColorMap',
+            ])
             || curriedShallowDiffByLayer('obsSegmentationsData', layerScope)
             || curriedShallowDiffByChannelCoordinationWithKeys('segmentationChannelCoordination', layerScope, channelScope, [
               'obsSetColor',

--- a/packages/vit-s/src/data-hooks-multilevel-utils.js
+++ b/packages/vit-s/src/data-hooks-multilevel-utils.js
@@ -589,3 +589,22 @@ export function useObsLabelsMultiLevel(
     depth, DataType.OBS_LABELS,
   );
 }
+
+/**
+ * Wrapper around useDataTypeMultiLevel.
+ * @param {object} loaders
+ * @param {string} dataset
+ * @param {boolean} isRequired
+ * @param {object} matchOnObj
+ * @param {number} depth
+ * @returns {array} [data, status, errors]
+ */
+export function useObsColorsMultiLevel(
+  loaders, dataset, isRequired, matchOnObj,
+  depth,
+) {
+  return useDataTypeMultiLevel(
+    loaders, dataset, isRequired, matchOnObj,
+    depth, DataType.OBS_COLORS,
+  );
+}

--- a/packages/vit-s/src/data-hooks-multilevel.js
+++ b/packages/vit-s/src/data-hooks-multilevel.js
@@ -10,6 +10,7 @@ import {
   useObsLocationsMultiLevel,
   useObsSetsMultiLevel,
   useObsLabelsMultiLevel,
+  useObsColorsMultiLevel,
 } from './data-hooks-multilevel-utils.js';
 
 
@@ -318,4 +319,35 @@ export function useSegmentationMultiObsSets(
     loaders, dataset, false, matchOnObj, 2,
   );
   return [indicesData, indicesDataStatus, indicesDataErrors];
+}
+
+/**
+ * Wrapper around useObsColorsMultiLevel.
+ * @param {object} coordinationScopes
+ * @param {object} coordinationScopesBy
+ * @param {object} loaders
+ * @param {string} dataset
+ * @returns {array} [data, status, errors]
+ */
+export function useSegmentationMultiObsColors(
+  coordinationScopes, coordinationScopesBy, loaders, dataset,
+) {
+  const obsTypeCoordination = useComplexCoordinationSecondary(
+    [
+      CoordinationType.OBS_TYPE,
+    ],
+    coordinationScopes,
+    coordinationScopesBy,
+    CoordinationType.SEGMENTATION_LAYER,
+    CoordinationType.SEGMENTATION_CHANNEL,
+  );
+  const matchOnObj = useMemo(() => obsTypeCoordination[0],
+    // imageCoordination reference changes each render,
+    // use coordinationScopes and coordinationScopesBy which are
+    // indirect dependencies here.
+    [coordinationScopes, coordinationScopesBy]);
+  const [colorsData, colorsDataStatus, colorsDataErrors] = useObsColorsMultiLevel(
+    loaders, dataset, false, matchOnObj, 2,
+  );
+  return [colorsData, colorsDataStatus, colorsDataErrors];
 }

--- a/packages/vit-s/src/index.js
+++ b/packages/vit-s/src/index.js
@@ -93,6 +93,7 @@ export {
   useSegmentationMultiObsFeatureMatrixIndices,
   useSegmentationMultiObsLocations,
   useSegmentationMultiObsSets,
+  useSegmentationMultiObsColors,
 } from './data-hooks-multilevel.js';
 export {
   useHasLoader,

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -462,6 +462,9 @@ importers:
 
   examples/configs:
     dependencies:
+      '@json2csv/plainjs':
+        specifier: ^7.0.8
+        version: 7.0.8
       '@vitessce/config':
         specifier: workspace:*
         version: link:../../packages/config
@@ -1707,6 +1710,9 @@ importers:
 
   packages/utils/sets-utils:
     dependencies:
+      '@json2csv/plainjs':
+        specifier: ^7.0.8
+        version: 7.0.8
       '@turf/centroid':
         specifier: catalog:turf
         version: 7.2.0
@@ -1731,9 +1737,6 @@ importers:
       internmap:
         specifier: 'catalog:'
         version: 2.0.3
-      json2csv:
-        specifier: ^5.0.0
-        version: 5.0.7
       lodash-es:
         specifier: 'catalog:'
         version: 4.17.21
@@ -5378,6 +5381,12 @@ packages:
   '@jsdevtools/ono@7.1.3':
     resolution: {integrity: sha512-4JQNk+3mVzK3xh2rqd6RB4J46qUR19azEHBneZyTZM+c456qOrbbM/5xcR8huNCCcbVt7+UmizG6GuUvPvKUYg==}
 
+  '@json2csv/formatters@7.0.8':
+    resolution: {integrity: sha512-YYpeZF7qKSX55FMYEl0m7Hn188l050k171/KwDHSMPHLHvWxDbzjmH1qVfXyV7XO7MMpDx1P7xksd/jXqlLxDw==}
+
+  '@json2csv/plainjs@7.0.8':
+    resolution: {integrity: sha512-bxsdb7tcHFyq6SGvDdHrxgSLxc8ScNyX+6B1aT+Anp8PEieZIenf6lPIJ2CnB4MQkrNANfFj6mXJlK9f8Bh5wg==}
+
   '@leichtgewicht/ip-codec@2.0.4':
     resolution: {integrity: sha512-Hcv+nVC0kZnQ3tD9GVu5xSMR4VVYOteQIr/hwFPVEvPdlXqgGEuRjiheChHgdM+JyqdgNcmzZOX/tnl0JOiI7A==}
 
@@ -7007,6 +7016,9 @@ packages:
 
   '@standard-schema/spec@1.0.0':
     resolution: {integrity: sha512-m2bOd0f2RT9k8QJx1JN85cZYyH1RqFBdlwtkSlf4tBDYLCiiZnv1fIIwacK6cqwXavOydf0NPToMQgpKq+dVlA==}
+
+  '@streamparser/json@0.0.23':
+    resolution: {integrity: sha512-givIVGxVGwP2oh5wiGdjQBKLZAS6LMkvnOxKybKTZDWP9LCO20eAzAL8OkUg8iR7u28cB2Ti7lFfLHnAAZGN6A==}
 
   '@svgr/babel-plugin-add-jsx-attribute@6.5.1':
     resolution: {integrity: sha512-9PYGcXrAxitycIjRmZB+Q0JaN07GZIWaTBIGQzfaZv+qr1n8X1XUEJ5rZ/vx6OVD9RRYlrNnXWExQXcmZeD/BQ==}
@@ -11575,12 +11587,6 @@ packages:
   json-stringify-safe@5.0.1:
     resolution: {integrity: sha512-ZClg6AaYvamvYEE82d3Iyd3vSSIjQ+odgjaTzRuO3s7toCdFKczob2i0zCh7JE8kWn17yvAWhUVxvqGwUalsRA==}
 
-  json2csv@5.0.7:
-    resolution: {integrity: sha512-YRZbUnyaJZLZUJSRi2G/MqahCyRv9n/ds+4oIetjDF3jWQA7AG7iSeKTiZiCNqtMZM7HDyt0e/W6lEnoGEmMGA==}
-    engines: {node: '>= 10', npm: '>= 6.13.0'}
-    deprecated: Package no longer supported. Contact Support at https://www.npmjs.com/support for more info.
-    hasBin: true
-
   json5@1.0.2:
     resolution: {integrity: sha512-g1MWMLBiz8FKi1e4w0UyVL3w+iJceWAFBAaBnnGKOpNa5f8TLktkbre1+s6oICydWAm+HRUGTmI+//xv2hvXYA==}
     hasBin: true
@@ -11595,10 +11601,6 @@ packages:
 
   jsonfile@6.1.0:
     resolution: {integrity: sha512-5dgndWOriYSm5cnYaJNhalLNDKOqFwyDB/rr1E9ZsGciGvKPs8R2xYGCacuf3z6K1YKDz182fd+fY3cn3pMqXQ==}
-
-  jsonparse@1.3.1:
-    resolution: {integrity: sha512-POQXvpdL69+CluYsillJ7SUhKvytYjW9vG/GKpnf+xP8UWgYEM/RaMzHHofbALDiKbbP1W8UEYmgGl39WkPZsg==}
-    engines: {'0': node >= 0.2.0}
 
   jsprim@1.4.2:
     resolution: {integrity: sha512-P2bSOMAc/ciLz6DzgjVlGJP9+BrJWu5UDGK70C2iweC5QBIeFf0ZXRvGjEj2uYgrY2MkAAhsSWHDWlFtEroZWw==}
@@ -19229,6 +19231,13 @@ snapshots:
 
   '@jsdevtools/ono@7.1.3': {}
 
+  '@json2csv/formatters@7.0.8': {}
+
+  '@json2csv/plainjs@7.0.8':
+    dependencies:
+      '@json2csv/formatters': 7.0.8
+      '@streamparser/json': 0.0.23
+
   '@leichtgewicht/ip-codec@2.0.4': {}
 
   '@loaders.gl/3d-tiles@3.2.10(@loaders.gl/core@3.2.10)':
@@ -21677,6 +21686,8 @@ snapshots:
       micromark-util-symbol: 1.1.0
 
   '@standard-schema/spec@1.0.0': {}
+
+  '@streamparser/json@0.0.23': {}
 
   '@svgr/babel-plugin-add-jsx-attribute@6.5.1(@babel/core@7.28.0)':
     dependencies:
@@ -27555,12 +27566,6 @@ snapshots:
 
   json-stringify-safe@5.0.1: {}
 
-  json2csv@5.0.7:
-    dependencies:
-      commander: 6.2.1
-      jsonparse: 1.3.1
-      lodash.get: 4.4.2
-
   json5@1.0.2:
     dependencies:
       minimist: 1.2.8
@@ -27576,8 +27581,6 @@ snapshots:
       universalify: 2.0.0
     optionalDependencies:
       graceful-fs: 4.2.11
-
-  jsonparse@1.3.1: {}
 
   jsprim@1.4.2:
     dependencies:

--- a/sites/docs/docs/data-file-types.mdx
+++ b/sites/docs/docs/data-file-types.mdx
@@ -239,6 +239,38 @@ coordinationValues={`{
 }`}
 />
 
+### `obsColors.csv`
+
+A two-column (minimum; the file may contain extra columns) CSV file.
+One column stores the observation index (unique ID for each observation) and the other stores a color per observation.
+Colors can either be stored in a single column of hex strings, or in three columns of R, G, and B channel values (each in the range `[0, 255]`).
+The column names are configurable.
+For example, the file contents might look like:
+
+| cell_id | color |
+| ----- | ----- |
+| cell_1 | #ff0000 |
+| cell_2 | #00ff00 |
+| ... | ... |
+
+<FileDefTabs
+fileName="my_cell_colors.csv"
+fileType="obsColors.csv"
+fileConst="OBS_COLORS_CSV"
+options={`{
+    // The column containing the observation index.
+    "obsIndex": "cell_id",
+    // The column containing the hex color strings.
+    // Alternatively, an array of three columns
+    // containing the R, G, and B channel values,
+    // e.g., ["r", "g", "b"].
+    "obsColors": "color"
+}`}
+coordinationValues={`{
+    "obsType": "cell"
+}`}
+/>
+
 ### `featureLabels.csv`
 
 A two-column (minimum; the file may contain extra columns) CSV file.


### PR DESCRIPTION
<!-- Credit (as a starting template): https://github.com/visgl/deck.gl/blob/master/.github/pull_request_template.md -->
<!-- For feature, feature enhancement or bug fix, create an issue first and finish To Do List there -->
<!-- Anything doesn't work as expected is a bug, including code, doc and test -->
PR into the branch for #2547 
<!-- For other PRs without open issue -->



<!-- For all the PRs -->
#### Change List

Given that this feature is primarily used for development purposes, I tried to minimize the complexity added to NeuroglancerSubscriber by moving it to the example config JS files. I added helper functions to the example configs which construct inline CSV strings to pass the segment list.

Given that the per-observation coloring logic may be useful beyond the Neuroglancer view, I added a new `obsColors` data type to allow specifying one color per observation, and for now added a CSV data loading class for this.

I know there were also changes related to whether to color segments by a grey color versus a set color - I plan to make a follow up PR related to the filtering/selection logic (also to make it generalizable beyond the Neuroglancer view and consistent, at least hopefully eventually, with other views).

#### Checklist
 - [ ] Have tested PR with one or more demo configurations
 - [ ] Documentation added, updated, or not applicable
