### PR TITLE
Update treemap, obsSets view and add skills

### DIFF
--- a/.changeset/spotty-donkeys-listen.md
+++ b/.changeset/spotty-donkeys-listen.md
@@ -1,0 +1,6 @@
+---
+"@vitessce/statistical-plots": patch
+"@vitessce/constants-internal": patch
+---
+
+Update the treemap view to follow the Vitessce filtering, selection, and highlighting principles: filtering (obsFilter/obsSetFilter/sampleFilter/sampleSetFilter, with the corresponding filter modes) determines which observations and sets are included at all, selection (obsSelection/obsSetSelection/sampleSelection/sampleSetSelection, with the corresponding selection modes) de-emphasizes filter-included but un-selected rectangles rather than omitting them, and highlighting (obsHighlight/obsSetHighlight/sampleHighlight) outlines the corresponding rectangles. In particular, when there is no obsSetFilter or sampleSetFilter, the un-selected sets are now displayed as de-emphasized treemap nodes broken down by the sets of the other hierarchy level, rather than being omitted. The un-selected sets to include are the siblings of the selected sets, each expanded at its own corresponding hierarchy level.

--- a/.changeset/spotty-donkeys-listen.md
+++ b/.changeset/spotty-donkeys-listen.md
@@ -3,4 +3,4 @@
 "@vitessce/constants-internal": patch
 ---
 
-Update the treemap view to follow the Vitessce filtering, selection, and highlighting principles: filtering (obsFilter/obsSetFilter/sampleFilter/sampleSetFilter, with the corresponding filter modes) determines which observations and sets are included at all, selection (obsSelection/obsSetSelection/sampleSelection/sampleSetSelection, with the corresponding selection modes) de-emphasizes filter-included but un-selected rectangles rather than omitting them, and highlighting (obsHighlight/obsSetHighlight/sampleHighlight) outlines the corresponding rectangles. In particular, when there is no obsSetFilter or sampleSetFilter, the un-selected sets are now displayed as de-emphasized treemap nodes broken down by the sets of the other hierarchy level, rather than being omitted. The un-selected sets to include are the siblings of the selected sets, each expanded at its own corresponding hierarchy level.
+Update the treemap view to follow the Vitessce filtering, selection, and highlighting principles.

--- a/.changeset/tidy-hoops-wander.md
+++ b/.changeset/tidy-hoops-wander.md
@@ -1,0 +1,7 @@
+---
+"@vitessce/obs-sets-manager": patch
+"@vitessce/sets-utils": patch
+"@vitessce/constants-internal": patch
+---
+
+Add a per-node filter checkbox to the obsSets view, which controls obsSetFilter alongside the existing obsSetSelection checkbox. Sets which do not meet the filtering criteria are struck through and cannot be selected.

--- a/.claude/skills/vitessce-filter-select-highlight/SKILL.md
+++ b/.claude/skills/vitessce-filter-select-highlight/SKILL.md
@@ -19,9 +19,20 @@ Filtering, selection, and highlighting are controlled by several coordination ty
 - obsSelectionMode: behavior-modifier, whether to use obsSelection versus obsSetSelection for the current selection criteria.
 - obsHighlight: a single observation ID to highlight
 - obsSetHighlight: a single observation set path to highlight
-- featureFilter: a list of filter-included feature IDs
-- featureSelection: a list of selected feature IDs
-- featureHighlight: a single feature ID to highlight
+- featureFilter
+- featureSetFilter
+- featureFilterMode
+- featureSelection
+- featureSetSelection
+- featureSelectionMode
+- featureHighlight
+- sampleFilter
+- sampleSetFilter
+- sampleFilterMode
+- sampleSelection
+- sampleSetSelection
+- sampleSelectionMode
+- sampleHighlight
 
 ## Control views such as the observation set manager view
 

--- a/.claude/skills/vitessce-filter-select-highlight/SKILL.md
+++ b/.claude/skills/vitessce-filter-select-highlight/SKILL.md
@@ -35,7 +35,7 @@ Filtering, selection, and highlighting are controlled by several coordination ty
 - sampleHighlight
 
 
-When filtering or selection is `null`, this means that all data items (or sets of data items) should be included/selected. The empty array means that nothing should be included/selected. When highlight is `null`, this means that nothing is currently highlighted.
+When filtering is `null`, this means that all data items (or sets of data items, among the first group of sets) are included. When selection is `null`, this means that all data items (or sets of data items) that meet the filtering criteria are selected. An explicit empty array means that nothing should be included/selected. When highlight is `null`, this means that nothing is currently highlighted.
 
 ## Control views such as the observation set manager view
 

--- a/.claude/skills/vitessce-filter-select-highlight/SKILL.md
+++ b/.claude/skills/vitessce-filter-select-highlight/SKILL.md
@@ -1,0 +1,34 @@
+---
+name: vitessce-filter-select-highlight
+description: Use when modifying the filtering, selection, or highlighting logic in Vitessce. Also use when writing example configurations if it involves filtering, selection, or highlighting.
+---
+
+The core principle is consistency. Despite different Vitessce views displaying data using different visualization designs or visual encodings, we want to ensure the following is the case across view implementations:
+
+- Filtering refers to whether particular data items (or sets of data items) are considered at all during either rendering or computation. For example, if the filtering logic specifies that only immune cell types are included, then we do not render non-immune cell types (as data points, along categorical axes, in legends, etc.) In other words, when immune cell types are the only cell types that meet the current filtering criteria, we do not include non-immune cell types in any visual encoding (or upstream computation of a visual encoding, such as when computing distributions or averages).
+- Selection refers to a visual emphasis on one or more data items or sets of data items (e.g., immune cell types). Items (or sets of items) which meet the filtering criteria, yet are un-selected, should still be rendered (as data points, along categorical axes, in legends), but should be de-emphasized visually (e.g., greyed-out or with reduced opacity or reduced size).
+- Highlighting refers to ephemeral emphasis on one or a few data items (observation or feature) (e.g., a particular cell or gene). This emphasis should correspond to a visual encoding such as an outline.
+
+
+Filtering, selection, and highlighting are controlled by several coordination types:
+- obsFilter: a list of filter-included observation IDs
+- obsSetFilter: a list of filter-included observation set paths (each path is an array of strings)
+- obsFilterMode: behavior-modifier, whether to use obsFilter versus obsSetFilter for the current filtering criteria.
+- obsSelection: a list of selected observation IDs
+- obsSetSelection: a list of selected observation set paths (each path is an array of strings)
+- obsSelectionMode: behavior-modifier, whether to use obsSelection versus obsSetSelection for the current selection criteria.
+- obsHighlight: a single observation ID to highlight
+- obsSetHighlight: a single observation set path to highlight
+- featureFilter: a list of filter-included feature IDs
+- featureSelection: a list of selected feature IDs
+- featureHighlight: a single feature ID to highlight
+
+## Control views such as the observation set manager view
+
+Control views are the only exception where items that are currently filtered-out may need to be included in the user interface, to facilitate users modifying the filtering criteria. For example, if immune cell types are currently the only cell types included according to the filtering criteria, users who become interested in non-immune cell types over the course of their analysis will need a mechanism to update the filtering criteria to specify that non-immune cell types should be included again. If there is no UI to facilitate this, then users will never be able to re-include data items that had been previously added to the exclusion list.
+
+## Work in progress
+
+Ensuring that these principles are applied across all view implementations is a work in progress.
+We are working to address this in existing code.
+New code should adhere to these principles from the start.

--- a/.claude/skills/vitessce-filter-select-highlight/SKILL.md
+++ b/.claude/skills/vitessce-filter-select-highlight/SKILL.md
@@ -34,6 +34,9 @@ Filtering, selection, and highlighting are controlled by several coordination ty
 - sampleSelectionMode
 - sampleHighlight
 
+
+When filtering or selection is `null`, this means that all data items (or sets of data items) should be included/selected. The empty array means that nothing should be included/selected. When highlight is `null`, this means that nothing is currently highlighted.
+
 ## Control views such as the observation set manager view
 
 Control views are the only exception where items that are currently filtered-out may need to be included in the user interface, to facilitate users modifying the filtering criteria. For example, if immune cell types are currently the only cell types included according to the filtering criteria, users who become interested in non-immune cell types over the course of their analysis will need a mechanism to update the filtering criteria to specify that non-immune cell types should be included again. If there is no UI to facilitate this, then users will never be able to re-include data items that had been previously added to the exclusion list.

--- a/.claude/skills/vitessce-sets/SKILL.md
+++ b/.claude/skills/vitessce-sets/SKILL.md
@@ -1,0 +1,222 @@
+---
+name: vitessce-sets
+description: Use when modifying logic involving sets of observations (e.g., cells) or features (e.g., genes), either flat or hierarchical. Observation sets are used to store and manage cell type annotations and cell clustering results.
+---
+
+# Observation Sets and Feature Sets
+
+Almost all set logic lives in **`packages/utils/sets-utils/`** (`@vitessce/sets-utils`) and is consumed by
+loaders (`packages/file-types/*`), the manager view (`packages/view-types/obs-sets-manager/`), and every
+view that colors or stratifies by set.
+
+| File | Contents |
+|---|---|
+| `src/cell-set-utils.js` | Tree/node traversal, transforms, set operations, tree → render/color/size derivations |
+| `src/set-path-utils.js` | Path comparison and hierarchy inference (`findLongestCommonPath`, `filterPathsByExpansionAndSelection`, `findChangedHierarchy`) |
+| `src/utils.js` | Path key encoding (`PATH_SEP`, `pathToKey`), rename helpers, `mergeObsSets`, `setObsSelection` |
+| `src/io.js` | JSON/CSV import, export, schema upgrade |
+| `src/CellSetsZarrLoader.js` | `dataToCellSetsTree` — columnar data → tree (used by all loaders, despite the filename) |
+| `src/expr-utils.js` | `stratifyArrays` / `stratifyExpressionData` — group values by (obs set, sample set, feature) |
+| `src/interpolate-colors.js` | `getCellColors` and continuous color scales |
+| `src/constants.js` | `HIERARCHICAL_SCHEMAS.latestVersion`, `SETS_DATATYPE_OBS`, file extension / MIME constants |
+
+## Data model
+
+A sets object is a forest, typed as `SetsTree` in `packages/types/src/sets.ts`:
+
+```js
+{
+  version: '0.1.3',
+  datatype: 'obs',            // SETS_DATATYPE_OBS; informational, stripped by Zod parse
+  tree: [                     // level-zero nodes = "groups of sets" (e.g. one group to represent cell types, another group to store a clustering result, and so on)
+    {
+      name: 'Cell Type Annotations',
+      children: [
+        {
+          name: 'Vasculature',
+          children: [
+            { name: 'Pericytes',   set: [['cell_1', null], ['cell_2', 0.87]] },
+            { name: 'Endothelial', set: [['cell_4', null]] },
+          ],
+        },
+      ],
+    },
+  ],
+}
+```
+
+
+Invariants, all of which existing code assumes:
+
+- **A node has either `children` or `set`, never both.** Leaf detection is `!node.children`
+  throughout `cell-set-utils.js`. Putting a `set` on an internal node breaks `nodeToSet`,
+  `getNodeLength`, and `treeToMembershipMap`. `onDropNode` in `ObsSetsManagerSubscriber.js`
+  exists mostly to enforce this during drag-and-drop.
+- **A `set` is an array of `[obsId, predictionScore]` tuples**, not an array of IDs. The score is
+  `null` when unknown. Forgetting the tuple shape is the single most common bug here — always
+  destructure: `nodeSet.map(([obsId]) => ...)`.
+- **Names are unique among siblings**, which is what makes a path an identity.
+- Level-zero nodes always have `children` (never a `set`), so the minimum useful depth is 2.
+- `color` is optional per node and only used as a *seed* for `initializeCellSetColor`; the live
+  color state is the `obsSetColor` coordination value, not the tree.
+
+### Paths are the identity
+
+A set is referenced everywhere by its **path**: an array of node names from the level-zero node down,
+e.g. `['Cell Type Annotations', 'Vasculature', 'Pericytes']` (Zod: `obsSetPath` in
+`packages/schemas/src/shared.ts`). Consequences:
+
+- Compare paths with `lodash-es`'s `isEqual`, never `===`. Prefix tests use `isEqualOrPrefix`.
+- `treeFindNodeByNamePath(tree, path)` returns `null` if zero **or more than one** node matches, so
+  it silently returns `null` on a malformed tree with duplicate sibling names.
+- React keys and the `rc-tree` API need strings, so paths are joined with `PATH_SEP` (`'___'`) via
+  `pathToKey`. This is a lossy encoding — a set name containing `___` will corrupt the round trip.
+  Prefer passing real path arrays and only convert at the `rc-tree` boundary.
+- **Renaming or moving a node must update every place the path is stored**: the tree itself plus
+  `obsSetColor`, `obsSetSelection`, and `obsSetExpansion`. Use `tryRenamePath` to rewrite a path and
+  all of its descendant paths. See `onNodeSetName` and `onNodeRemove` in
+  `ObsSetsManagerSubscriber.js` for the complete pattern.
+
+### The membership map
+
+Loaders also return `obsSetsMembership`: a `Map<obsId, string[][]>` from observation ID to the paths
+of every leaf set containing it (`treeToMembershipMap`). This is the reverse index used for tooltips
+(`useGetObsInfo` / `useGetObsMembership` in `packages/vit-s/src/hooks.js`) — use it instead of
+scanning the tree when you have an ID and want its sets.
+
+## Coordination state
+
+The tree from the loader is read-only data. Everything mutable is coordination state:
+
+| Coordination type | Shape | Meaning |
+|---|---|---|
+| `obsSetSelection` | `string[][] \| null` | Selected set paths. `null` means "all"; `[]` means "none" |
+| `obsSetExpansion` | `string[][] \| null` | Set paths expanded in the tree UI |
+| `obsSetColor` | `{ path: string[], color: [r,g,b] }[]` | Per-path color assignments |
+| `additionalObsSets` | `SetsTree \| null` | User-defined sets, stored in the view config |
+| `obsColorEncoding` | `'cellSetSelection' \| 'geneSelection' \| ...` | Which encoding wins when coloring |
+
+Filtering/selection/highlighting semantics (including the `null` vs `[]` distinction and the
+`obsSetFilter` / `obsSetHighlight` types) are covered by the **vitessce-filter-select-highlight**
+skill; follow it for any change to what gets rendered or de-emphasized.
+
+### Dataset-defined vs. user-defined sets
+
+Two separate trees coexist and must not be conflated:
+
+- `obsSets` — loaded from the dataset, immutable.
+- `additionalObsSets` — created by the user (lasso selections, set operations, imports), persisted in
+  the view config.
+
+`mergeObsSets(obsSets, additionalObsSets)` concatenates their `tree` arrays into one forest.
+**Merged sets are for reading only.** When writing, update `additionalObsSets` — never the loaded
+`obsSets`. Every consumer follows this shape:
+
+```js
+const mergedObsSets = useMemo(
+  () => mergeObsSets(obsSets, additionalObsSets),
+  [obsSets, additionalObsSets],
+);
+```
+
+Because `mergeObsSets` stamps `version` and `datatype` itself, name collisions between the two trees
+would create ambiguous paths. `treesConflict` guards against this on import, and the manager view
+refuses conflicting imports rather than deduplicating.
+
+New user-defined sets should be created with `setObsSelection` (in `src/utils.js`), which appends a
+numbered node under the `'My Selections'` level-zero node, assigns a palette color, selects the new
+path, and switches `obsColorEncoding` to `'cellSetSelection'` — all in one call. Pass a `prefix` to
+label the provenance (`'Union '`, `'Intersection '`, `'Complement '`, default `'Selection '`).
+
+## Loading
+
+Loaders convert columnar data to a tree with `dataToCellSetsTree(data, options)`, where `data` is
+`[obsIndices, setIds, setScores]` (one entry per configured hierarchy) and `options` is the file
+definition's `obsSets` array. Passing an array of columns for one hierarchy produces a multi-level
+tree, coarse → fine; a single column produces a flat two-level tree. Redundant trailing levels
+(`['Parent', 'Child', 'Child']`) collapse into a leaf.
+
+Every sets loader then does the same three things — see
+`packages/file-types/csv/src/csv-loaders/ObsSetsCsv.js` and
+`packages/file-types/zarr/src/anndata-loaders/ObsSetsAnndataLoader.js`, which are near-identical:
+
+```js
+const obsSetsMembership = treeToMembershipMap(obsSets);
+const coordinationValues = {
+  // Auto-select every child of the first hierarchy.
+  obsSetSelection: obsSets.tree[0].children.map(node => [obsSets.tree[0].name, node.name]),
+  // Assign palette colors, per hierarchy and per level, seeding from node.color when present.
+  obsSetColor: initializeCellSetColor(obsSets, []),
+};
+return new LoaderResult({ obsIndex, obsSets, obsSetsMembership }, url, coordinationValues);
+```
+
+Returning `coordinationValues` is how a loader seeds initial selection and colors; `useDataType`
+applies them only where the view config left the value unset (see
+`packages/vit-s/src/data-hook-utils.js`). If you add a sets loader, keep this block consistent with
+the existing ones — views assume a non-empty initial selection and a populated `obsSetColor`.
+
+Options schemas live in `packages/schemas/src/file-def-options.ts` (`annDataObsSetsArr`,
+`obsSetsCsvSchema`). Note the CSV loaders read `option.scorePath` while `obsSetsCsvSchema` declares
+`scoreColumn` — if you touch confidence-score loading for CSV, reconcile the two rather than copying
+either name.
+
+## Utilities worth reaching for
+
+Prefer these over hand-rolled recursion; they encode the invariants above.
+
+**Traversal / query**
+`nodeToSet` (flatten descendants to tuples) · `getNodeLength` · `nodeToHeight` ·
+`treeFindNodeByNamePath` · `nodeToLevelDescendantNamePaths(node, level, prevPath, stopEarly)` ·
+`treeToExpectedCheckedLevel` (infer which "color by cluster level" radio button matches the current
+selection).
+
+**Immutable transforms** — all return new nodes; none mutate.
+`nodeTransform` (first match wins, stops recursing) vs `nodeTransformAll` (transforms match *and*
+continues into children) · `nodeAppendChild` / `nodePrependChild` / `nodeInsertChild` ·
+`filterNode(node, prevPath, filterPath)` returns `null` for the removed node, so always follow with
+`.filter(Boolean)`.
+
+**Set operations** — `treeToUnion`, `treeToIntersection`, `treeToComplement(tree, paths, items)`.
+These return plain ID arrays (scores dropped). The complement needs the full `obsIndex` as `items`.
+All three are `Array.prototype.includes`-based and therefore O(n²); if you call them on large
+datasets, convert to `Set` first rather than adding another `includes` loop.
+
+**Derivations for views** — `getCellColors` / `treeToCellColorsBySetNames` (mixes color with gray by
+`predictionScore` when non-null, so low-confidence cells look desaturated) ·
+`treeToCellSetColorIndicesBySetNames` · `treeToSelectedSetMap` (obsId → path) ·
+`treeToObsIdsBySetNames` / `treeToObsIndicesBySetNames` · `treeToSetSizesBySetNames` (returns
+`isGrayedOut` for unselected sets) · `getCellSetPolygons` · `nodeToRenderProps`.
+
+**Hierarchy inference for plots** — `findLongestCommonPath`, `filterPathsByExpansionAndSelection`,
+and `findChangedHierarchy` let a view show one hierarchy at a time based on what the user last
+selected. `CellSetSizesPlotSubscriber.js` and `HeatmapSubscriber.js` are the reference consumers.
+
+## Sample sets
+
+`sampleSets` (`packages/file-types/*/…/SampleSets*.js`) use the **same tree structure, utilities, and
+path semantics**, but hold sample IDs rather than observation IDs. Crossing between them requires
+`sampleEdges` (a `Map<obsId, sampleId>`); `stratifyArrays` in `expr-utils.js` shows the join. When
+adding set logic that should work for both, put it in `sets-utils` and keep it ID-agnostic instead of
+naming parameters `cell*`.
+
+## Feature sets
+
+Feature-side sets are **not implemented as trees yet**. `FEATURE_SET_SELECTION`,
+`FEATURE_SET_COLOR`, `FEATURE_SET_HIGHLIGHT`, and `ADDITIONAL_FEATURE_SETS` appear only as
+commented-out `TODO`s in `packages/constants-internal/src/coordination.ts`. The existing
+`featureSetEnrichment` data (used by `FeatureSetEnrichmentBarPlot`) is a separate, flat mechanism —
+do not treat it as the feature analogue of `obsSets`. If asked to add hierarchical feature sets,
+mirror the obs implementation and reuse `sets-utils` rather than forking it.
+
+## Naming debt
+
+Older code says `cellSets` / `cellSetSelection` / `cellSetColor`; the current vocabulary is
+`obsSets` / `obsSetSelection` / `obsSetColor`. Within one file, match the surrounding names; for new
+files and new exports, use the `obs*` names. `obsColorEncoding` still takes the legacy string value
+`'cellSetSelection'` — that string is load-bearing, do not "fix" it.
+
+## Lack of assumptions
+
+Current code does not assume that each observation ID appears at least nor at most once within a given set group, for maximum flexibility.
+E.g., within a group of sets, a cell with ID `cell_1` can appear as a member of multiple sibling leaf set nodes.

--- a/.claude/skills/vitessce-spatial-layers/SKILL.md
+++ b/.claude/skills/vitessce-spatial-layers/SKILL.md
@@ -1,0 +1,259 @@
+---
+name: vitessce-spatial-layers
+description: Use when modifying logic involving spatial layers or channels. Spatial layers include images, segmentations, and points.
+---
+
+# Spatial layers and channels
+
+Multiple views consume, render, or control spatially-resolved information:
+
+- `spatialBeta` — renders 2D spatial data (with limited support for 3D).
+- `layerControllerBeta` — the UI for the spatial coordination state
+- For 3D data: `neuroglancer`, `spatial-three`, and `spatial-accelerated`.
+
+
+`packages/view-types/spatial/` and `packages/view-types/layer-controller/` are **legacy** views
+(with `spatialImageLayer` and `spatialSegmentationLayer` as their legacy coordination properties). Do not port changes into them, and do not read them for reference — the data models are
+different.
+
+## The layer/channel hierarchy
+
+Multi-level coordination gives each layer (and, for images and segmentations, each channel within a
+layer) its own set of coordination scopes. A list of which coordination type belongs
+at which level is located in the **Multi-level coordination** section of `sites/docs/docs/coordination-types.mdx`
+— update this list when needed.
+
+| Layer type | Levels | Matched to a file by | Notes |
+|---|---|---|---|
+| `imageLayer` | layer → `imageChannel` | `fileUid` | Channel = one `c` index of a (multiscale) image |
+| `segmentationLayer` | layer → `segmentationChannel` | layer: `fileUid`; channel: `obsType` | Bitmask or polygon (`obsSegmentationsType`) or mesh |
+| `spotLayer` | layer only | `obsType` | Circles with a radius; Used for Visium assays |
+| `pointLayer` | layer only | `obsType` | No radius; supports tiled loading; Used for FISH-like transcript points |
+
+Per-observation state (`obsSetSelection`, `obsColorEncoding`, `featureSelection`, `obsHighlight`, …)
+lives **at the channel level for segmentations** but **at the layer level for spots and points**,
+because a spot/point layer has exactly one `obsType` while a segmentation layer can carry several
+(one per bitmask/polygon channel). This asymmetry is the single biggest source of bugs here: check whether
+you are inside a `layerScope` loop or a `(layerScope, channelScope)` loop before reading anything
+obs-related.
+
+### The scope name is the identity
+
+`imageLayer`, `imageChannel`, `segmentationLayer`, `segmentationChannel`, `spotLayer`, and
+`pointLayer` are all registered as `z.string().nullable()` in `packages/main/all/src/base-plugins.ts`. Nothing reads their coordination values; the **coordination
+scope name** (e.g. `'imageLayerA'`) is what identifies the layer or channel, and it is the key of every
+per-layer object in this codebase.
+
+The one meaningful value is `null`: `useMultiCoordinationScopesNonNull` and
+`useMultiCoordinationScopesSecondaryNonNull` drop any scope whose value is `null`, so setting a
+layer or channel scope to `null` removes it from the view entirely. That is different from
+`spatialLayerVisible: false`, which keeps the layer (and its controller row) but hides it.
+
+## Reading the coordination state
+
+Both subscribers open with the identical block; keep them in sync. Order of arguments matters.
+
+```js
+// Meta-coordination must be resolved first — every hook below takes the *computed* scopes.
+const coordinationScopes = useCoordinationScopes(coordinationScopesRaw);
+const coordinationScopesBy = useCoordinationScopesBy(coordinationScopes, coordinationScopesByRaw);
+
+// Two-level: (secondaryType, primaryType, ...) — the channel type comes FIRST.
+const [imageLayerScopes, imageChannelScopesByLayer] = useMultiCoordinationScopesSecondaryNonNull(
+  CoordinationType.IMAGE_CHANNEL, CoordinationType.IMAGE_LAYER,
+  coordinationScopes, coordinationScopesBy,
+);
+// One-level:
+const spotLayerScopes = useMultiCoordinationScopesNonNull(
+  CoordinationType.SPOT_LAYER, coordinationScopes,
+);
+
+// Values + setters, keyed by scope name.
+const imageLayerCoordination = useComplexCoordination(
+  [/* per-layer coordination types */], coordinationScopes, coordinationScopesBy,
+  CoordinationType.IMAGE_LAYER,
+);
+const imageChannelCoordination = useComplexCoordinationSecondary(
+  [/* per-channel coordination types */], coordinationScopes, coordinationScopesBy,
+  CoordinationType.IMAGE_LAYER, CoordinationType.IMAGE_CHANNEL,
+);
+```
+
+Access patterns, which appear verbatim hundreds of times:
+
+```js
+layerCoordination[0][layerScope].spatialLayerOpacity                 // value
+layerCoordination[1][layerScope].setSpatialLayerOpacity(0.5)         // setter
+channelCoordination[0][layerScope][channelScope].spatialChannelColor
+channelCoordination[1][layerScope][channelScope].setSpatialChannelColor([255, 0, 0])
+```
+
+Both hooks fall back from fine-grained to coarse-grained: `useComplexCoordination` falls back to the
+view-level scope for a parameter that has no per-layer mapping in `coordinationScopesBy`, and
+`useComplexCoordinationSecondary` falls back to a flat `coordinationScopes[channelType]` array shared
+by every layer. Relying on the fallback is fine for reading; do not depend on it when writing, since
+a "per-channel" setter that fell back to a view-level scope will write to every layer at once.
+
+The `[values, setters]` object identities change on **every render** (only the inner per-scope
+objects are memoized). Never put `xLayerCoordination` in a `useMemo`/`useEffect` dependency array;
+use `coordinationScopes` and `coordinationScopesBy` as indirect dependencies, as the existing hooks
+do (with the `eslint-disable react-hooks/exhaustive-deps` comment explaining why).
+
+## Loading the data
+
+Each layer type has a `useMulti*` hook in `packages/vit-s/src/data-hooks.js` (layer-level) or
+`data-hooks-multilevel.js` (channel-level). They build a `matchOn` object from the coordination
+values and hand it to `useDataTypeMulti` / `use*MultiLevel`, so the returned object is keyed the same
+way as the coordination objects:
+
+| Hook | Keyed by | Match on |
+|---|---|---|
+| `useMultiImages` | `[layerScope]` | `fileUid` |
+| `useMultiObsSegmentations` | `[layerScope]` | `fileUid` |
+| `useMultiObsSpots` / `useMultiObsPoints` | `[layerScope]` | `obsType` |
+| `useSegmentationMultiObsSets` / `…ObsLocations` / `…ObsFeatureMatrixIndices` / `…FeatureSelection` | `[layerScope][channelScope]` | `obsType` (+ `featureType`, `featureValueType`) |
+| `useSpotMultiObsSets` / `useSpotMulti*`, `usePointMulti*` | `[layerScope]` | `obsType` |
+
+
+Payload shapes worth knowing:
+
+- Images: `imageData[layerScope].image.instance` is an `ImageWrapper`
+  (`packages/utils/image-utils/src/ImageWrapper.ts`). Ask it for metadata rather than digging into
+  viv loaders: `getModelMatrix()`, `getChannelNames()`, `getChannelIndex()`,
+  `getNumChannels()`, `hasDimC/Z/T()`, `getNumZ/T()`, `isMultiResolution()`,
+  `getMultiResolutionStats()`, `getAutoTargetResolution()`, `getBoundingCube()`, `isInterleaved()`,
+  `getPhotometricInterpretation()`.
+- Bitmask segmentations: `obsSegmentations[layerScope].obsSegmentations.instance` — also an
+  `ImageWrapper`, with `obsSegmentationsType === 'bitmask'`.
+- Polygon segmentations: `obsSegmentations[layerScope].obsSegmentations.data` is an array of polygons,
+  with `obsSegmentationsType === 'polygon'`.
+
+## Initial values from loaders
+
+Loaders seed the whole hierarchy by returning `CoordinationLevel` objects in `coordinationValues`
+(`CL` from `@vitessce/config`). Canonical example, `OmeZarrLoader.js`:
+
+```js
+const coordinationValues = {
+  spatialTargetZ: imageWrapper.getDefaultTargetZ(),   // view-level, not per-layer
+  spatialTargetT: imageWrapper.getDefaultTargetT(),
+  imageLayer: CL([{
+    fileUid: this.coordinationValues?.fileUid || null,
+    spatialLayerVisible: true,
+    spatialLayerOpacity: 1.0,
+    photometricInterpretation: imageWrapper.getPhotometricInterpretation(),
+    imageChannel: CL(channelCoordination),  // one object per channel, ≤ 5 by default
+  }]),
+};
+```
+
+`useDataTypeMulti` passes these to `mergeCoordination` with the prefix
+`init_{datasetUid}_{dataType}_` (`getInitialCoordinationScopePrefix`), which expands `CL` into
+`metaCoordinationScopes` + `metaCoordinationScopesBy` entries. Generated scope names are
+deterministic so a config author can override any of them; existing (user-defined) scopes are never
+overwritten, and generated meta-scopes are *prepended* so user meta-coordination wins. Loaders that
+already do this: `OmeZarrLoader`, `OmeTiffLoader`, `*AsObsSegmentationsLoader`, `SpatialData*Loader`,
+`ObsSpots*`/`ObsPoints*`/`ObsSegmentations*` loaders. Match one of them rather than inventing a shape.
+
+## Authoring configs
+
+Use `linkViewsByObject` with nested `CL` (see the doc comment on
+`VitessceConfig.addCoordinationByObject`, which contains a full worked example):
+
+```js
+config.linkViewsByObject([spatialView, lcView], {
+  imageLayer: CL([{
+    fileUid: 'my-image',
+    spatialLayerOpacity: 1,
+    imageChannel: CL([
+      { spatialTargetC: 0, spatialChannelColor: [255, 0, 0] },
+      { spatialTargetC: 1, spatialChannelColor: [0, 255, 0] },
+    ]),
+  }]),
+}, { meta: true });
+```
+
+`spatialTargetC` accepts a channel **name or index** (`z.number().or(z.string())`); always resolve it
+through `ImageWrapper.getChannelIndex()` before passing it to viv. See
+**vitessce-create-view-config** / **vitessce-modify-view-config** for the surrounding config rules.
+
+### `scopePrefix`: overriding what the loader auto-initializes
+
+Without it, `linkViewsByObject` names its new scopes with the usual `getNextScope` sequence (`A`,
+`B`, …). Those names cannot collide with the loader's auto-generated names, so the config-defined
+layer and the loader-initialized layer both survive the merge — you get **two** image layers where
+you wanted one, with only one of them carrying your values.
+
+`scopePrefix` swaps in `createPrefixedGetNextScopeNumeric(prefix)` for the duration of the call, so
+every scope created by it is named `{prefix}0`, `{prefix}1`, …. Passing the loader's own prefix makes
+the collision happen **on purpose**:
+
+```js
+import { CL, getInitialCoordinationScopePrefix } from '@vitessce/vit-s';
+
+config.linkViewsByObject([spatialView, lcView], {
+  imageLayer: CL({ photometricInterpretation: 'RGB' }),
+}, { scopePrefix: getInitialCoordinationScopePrefix('A', 'image') }); // 'A' = the dataset UID
+```
+
+The prefix must match the loader exactly: `getInitialCoordinationScopePrefix(datasetUid, dataType)`,
+where `dataType` is the loader's `DataType` (`'image'`, `'obsSegmentations'`, `'obsSpots'`,
+`'obsPoints'`) — **not** the coordination type. Getting the dataset UID or the data type wrong fails
+silently in exactly the duplicated-layer way described above.
+
+Use one `linkViewsByObject` call per prefix. Two calls sharing a prefix restart the numbering from
+`{prefix}0` and would overwrite each other's scopes.
+
+## Adding a per-layer or per-channel coordination type
+
+1. `packages/constants-internal/src/constants.ts` — the `CoordinationType` constant.
+2. `packages/main/all/src/base-plugins.ts` — `new PluginCoordinationType(type, default, zodSchema)`.
+3. `packages/constants-internal/src/coordination.ts` — add to `COMPONENT_COORDINATION_TYPES` for
+   **both** `ViewType.SPATIAL_BETA` and `ViewType.LAYER_CONTROLLER_BETA`.
+4. Add it to the matching `useComplexCoordination` / `useComplexCoordinationSecondary` parameter
+   array in **both** `SpatialSubscriber.js` and `LayerControllerSubscriber.js` (they are separate
+   lists and already differ slightly — e.g. `pixelHighlight` is spatial-only).
+5. Seed a default in the relevant loader's `CL` block.
+6. Document it under the right level in `sites/docs/docs/coordination-types.mdx`.
+7. For a per-**image-channel** type, also add it to
+   `addImageChannelInMetaCoordinationScopesHelper` in `packages/vit-s/src/state/spatial-reducers.js`,
+   otherwise the "Add Channel" button creates a channel with no scope for it. (Note the existing bug
+   there: `spatialMaxResolution` is keyed by `nextOpacityScope` instead of its own scope — do not
+   copy that line.)
+
+See **vitessce-add-coordination-type** for the non-multi-level parts of this checklist.
+
+## Rendering conventions in `Spatial.js`
+
+`Spatial` is a class component extending `AbstractSpatialOrScatterplot`, deliberately bypassing React
+state for performance. The structure is rigid; follow it exactly:
+
+- Derived data lives in **instance variables keyed by scope** (`this.spotColors[layerScope]`,
+  `this.segmentationColors[layerScope][channelScope]`, `this.obsSpotsQuadTree`, …), each declared and
+  commented in the constructor.
+- Every instance variable has an `onUpdateX(layerScope[, channelScope])` method plus an
+  `onUpdateAllX()` that loops over the scopes, and both are invoked from the constructor.
+- `componentDidUpdate(prevProps)` diffs props with `shallowDiff` / `shallowDiffByLayer` /
+  `shallowDiffByChannel` / `shallowDiffBy{Layer,Channel}Coordination`, calls the narrowest
+  `onUpdate*`, and sets `forceUpdate = true`. Any new derived value needs a branch here or it will
+  silently go stale; when the `*LayerScopes` array itself changes, the `onUpdateAll*` path runs.
+- `createXLayer(s)` build DeckGL layers with ids `image-layer-`/`volume-layer-`/
+  `segmentation-layer-`/`spot-layer-`/`point-layer-` + `layerScope`. Bitmask and polygon segmentation
+  layers deliberately share the same id.
+- Layer and channel state **compose multiplicatively**: `visible && spatialChannelVisible`,
+  `spatialLayerOpacity * spatialChannelOpacity`. Legends and tooltips gate on the same conjunction
+  plus `legendVisible` / `tooltipsVisible`.
+- RGB images (`photometricInterpretation === 'RGB'`) ignore `channelScopes` entirely and hard-code
+  three channels; the layer controller hides the channel rows in that case.
+
+## Layer controller conventions
+
+- `LayerController.js` renders layer scopes **reversed**, so controller rows read top-to-bottom in
+  the same order the layers stack on screen.
+- Adding/removing image channels rewrites the meta-coordination scopes via
+  `useAddImageChannelInMetaCoordinationScopes` / `useRemoveImageChannelInMetaCoordinationScopes`,
+  which is why `ImageLayerController` needs the **raw** `coordinationScopesRaw` prop rather than the
+  computed scopes. The add button is capped at `viv.MAX_CHANNELS` and at the image's channel count.
+  There is no equivalent add/remove for segmentation channels, spots, or points.
+- `spatialTargetZ` / `spatialTargetT` / `spatialRenderingMode` are **view-level**, shared by all
+  layers (the global Z/T sliders); everything else in the controller is per-layer or per-channel.

--- a/packages/constants-internal/src/coordination.ts
+++ b/packages/constants-internal/src/coordination.ts
@@ -358,6 +358,7 @@ export const COMPONENT_COORDINATION_TYPES = {
     CoordinationType.OBS_TYPE,
     CoordinationType.OBS_SET_SELECTION,
     CoordinationType.OBS_SET_FILTER,
+    CoordinationType.OBS_FILTER_MODE,
     CoordinationType.OBS_SET_EXPANSION,
     CoordinationType.OBS_SET_HIGHLIGHT,
     CoordinationType.OBS_SET_COLOR,

--- a/packages/constants-internal/src/coordination.ts
+++ b/packages/constants-internal/src/coordination.ts
@@ -708,6 +708,7 @@ export const COMPONENT_COORDINATION_TYPES = {
     CoordinationType.FEATURE_TYPE,
     CoordinationType.FEATURE_VALUE_TYPE,
     CoordinationType.OBS_FILTER,
+    CoordinationType.OBS_FILTER_MODE,
     CoordinationType.OBS_HIGHLIGHT,
     CoordinationType.OBS_SET_SELECTION,
     CoordinationType.OBS_SET_FILTER,

--- a/packages/main/all/src/base-plugins.ts
+++ b/packages/main/all/src/base-plugins.ts
@@ -473,6 +473,8 @@ export const baseCoordinationTypes = [
     z.array(obsSetPath).nullable(),
   ),
   new PluginCoordinationType(CoordinationType.OBS_FILTER_MODE, null, z.enum(['obsFilter', 'obsSetFilter']).nullable()),
+  // TODO: define a new coordination type that specifies whether the selection is inclusion or exclusion
+  // TODO: define a new coordination type that specifies whether the filtering is inclusion or exclusion
   new PluginCoordinationType(
     CoordinationType.OBS_SET_EXPANSION,
     null,
@@ -511,6 +513,7 @@ export const baseCoordinationTypes = [
     null,
     z.array(z.string()).nullable(),
   ),
+  // TODO: define set-wise filter/selection/highlight coordination types and associated _Mode behavior modifier types.
   new PluginCoordinationType(CoordinationType.FEATURE_AGGREGATION_STRATEGY, null, z.union([
     z.enum([
       'first', 'last', 'mean', 'sum', 'difference',

--- a/packages/main/all/src/base-plugins.ts
+++ b/packages/main/all/src/base-plugins.ts
@@ -473,8 +473,8 @@ export const baseCoordinationTypes = [
     z.array(obsSetPath).nullable(),
   ),
   new PluginCoordinationType(CoordinationType.OBS_FILTER_MODE, null, z.enum(['obsFilter', 'obsSetFilter']).nullable()),
-  // TODO: define a new coordination type that specifies whether the selection is inclusion or exclusion
-  // TODO: define a new coordination type that specifies whether the filtering is inclusion or exclusion
+  // TODO: define a new coordination type that specifies whether the selection is inclusion or exclusion?
+  // TODO: define a new coordination type that specifies whether the filtering is inclusion or exclusion?
   new PluginCoordinationType(
     CoordinationType.OBS_SET_EXPANSION,
     null,
@@ -513,7 +513,6 @@ export const baseCoordinationTypes = [
     null,
     z.array(z.string()).nullable(),
   ),
-  // TODO: define set-wise filter/selection/highlight coordination types and associated _Mode behavior modifier types.
   new PluginCoordinationType(CoordinationType.FEATURE_AGGREGATION_STRATEGY, null, z.union([
     z.enum([
       'first', 'last', 'mean', 'sum', 'difference',

--- a/packages/utils/sets-utils/src/index.js
+++ b/packages/utils/sets-utils/src/index.js
@@ -33,6 +33,14 @@ export {
   findChangedHierarchy,
 } from './set-path-utils.js';
 export {
+  isPathFilterIncluded,
+  isPathFilterPartiallyIncluded,
+  normalizeFilterPaths,
+  addPathToFilter,
+  removePathFromFilter,
+  restrictSelectionToFilter,
+} from './set-filter-utils.js';
+export {
   isEqualOrPrefix,
   tryRenamePath,
   PATH_SEP,

--- a/packages/utils/sets-utils/src/index.js
+++ b/packages/utils/sets-utils/src/index.js
@@ -36,6 +36,7 @@ export {
   isPathFilterIncluded,
   isPathFilterPartiallyIncluded,
   normalizeFilterPaths,
+  getSiblingPaths,
   addPathToFilter,
   removePathFromFilter,
   restrictSelectionToFilter,

--- a/packages/utils/sets-utils/src/set-filter-utils.js
+++ b/packages/utils/sets-utils/src/set-filter-utils.js
@@ -119,6 +119,30 @@ function siblingPathsAlongDescent(mergedSets, ancestorPath, targetPath) {
 }
 
 /**
+ * Determine the paths of the sets which share a parent with the target set,
+ * i.e. the sets which sit at the same level of the same part of the hierarchy.
+ * The target set's own path is included in the result. Level-zero nodes
+ * (hierarchies) are treated as siblings of each other.
+ * @param {object} mergedSets A merged sets tree object.
+ * @param {string[]} targetPath The path of the set in question.
+ * @returns {string[][]} Array of set paths, empty if they cannot be determined.
+ */
+export function getSiblingPaths(mergedSets, targetPath) {
+  if (!mergedSets?.tree || !Array.isArray(targetPath) || targetPath.length === 0) {
+    return [];
+  }
+  if (targetPath.length === 1) {
+    return mergedSets.tree.map(lzn => [lzn.name]);
+  }
+  const parentPath = targetPath.slice(0, -1);
+  const parentNode = treeFindNodeByNamePath(mergedSets, parentPath);
+  if (!parentNode?.children) {
+    return [];
+  }
+  return parentNode.children.map(child => [...parentPath, child.name]);
+}
+
+/**
  * Add a set (and its descendants) to the set-level filtering criteria.
  * @param {object} mergedSets A merged sets tree object.
  * @param {string[][]|null} filterPaths Value of obsSetFilter or sampleSetFilter.

--- a/packages/utils/sets-utils/src/set-filter-utils.js
+++ b/packages/utils/sets-utils/src/set-filter-utils.js
@@ -1,0 +1,198 @@
+import { isEqualOrPrefix } from './utils.js';
+import { treeFindNodeByNamePath } from './cell-set-utils.js';
+
+/**
+ * Determine whether a set meets the current set-level filtering criteria.
+ * A path in the filter includes both the set it points to and all of the
+ * descendants of that set.
+ * @param {string[][]|null} filterPaths Value of obsSetFilter or sampleSetFilter.
+ * A null value means that every set is included.
+ * @param {string[]} nodePath The path of the set in question.
+ * @returns {boolean} True if the set, and therefore its whole subtree,
+ * meets the filtering criteria.
+ */
+export function isPathFilterIncluded(filterPaths, nodePath) {
+  if (!Array.isArray(filterPaths)) {
+    return true;
+  }
+  return filterPaths.some(filterPath => isEqualOrPrefix(filterPath, nodePath));
+}
+
+/**
+ * Determine whether only part of a set's subtree meets the current set-level
+ * filtering criteria, i.e., the set itself is not included but at least one
+ * of its descendants is.
+ * @param {string[][]|null} filterPaths Value of obsSetFilter or sampleSetFilter.
+ * @param {string[]} nodePath The path of the set in question.
+ * @returns {boolean} True if the set is partially included.
+ */
+export function isPathFilterPartiallyIncluded(filterPaths, nodePath) {
+  if (!Array.isArray(filterPaths)) {
+    return false;
+  }
+  return !isPathFilterIncluded(filterPaths, nodePath)
+    && filterPaths.some(filterPath => isEqualOrPrefix(nodePath, filterPath));
+}
+
+/**
+ * Determine, for one node, the shortest list of set paths which covers exactly
+ * the included sets within that node's subtree. Recursive.
+ * @param {object} node A node object.
+ * @param {string[]} nodePath The path of the node.
+ * @param {string[][]} filterPaths Array of included set paths.
+ * @returns {object} `{ isAll, paths }` where `isAll` is true if the node's
+ * entire subtree is included, and `paths` is the covering list of paths.
+ */
+function collectIncludedPaths(node, nodePath, filterPaths) {
+  if (isPathFilterIncluded(filterPaths, nodePath)) {
+    return { isAll: true, paths: [nodePath] };
+  }
+  if (!node.children || node.children.length === 0) {
+    return { isAll: false, paths: [] };
+  }
+  const childResults = node.children.map(
+    child => collectIncludedPaths(child, [...nodePath, child.name], filterPaths),
+  );
+  if (childResults.every(childResult => childResult.isAll)) {
+    return { isAll: true, paths: [nodePath] };
+  }
+  return { isAll: false, paths: childResults.flatMap(childResult => childResult.paths) };
+}
+
+/**
+ * Simplify a list of included set paths, by replacing any complete group of
+ * siblings with its parent (recursively) and by dropping any path which is
+ * already covered by one of its ancestors.
+ * @param {object} mergedSets A merged sets tree object.
+ * @param {string[][]|null} filterPaths Value of obsSetFilter or sampleSetFilter.
+ * @returns {string[][]|null} The simplified array of set paths, or null if
+ * every set in the tree is included, since null is the canonical
+ * representation of "no set-level filtering criteria".
+ */
+export function normalizeFilterPaths(mergedSets, filterPaths) {
+  if (!Array.isArray(filterPaths)) {
+    return null;
+  }
+  if (!mergedSets?.tree) {
+    // Without the tree, sibling groups cannot be identified,
+    // so the paths are returned as-is.
+    return filterPaths;
+  }
+  const results = mergedSets.tree.map(
+    lzn => collectIncludedPaths(lzn, [lzn.name], filterPaths),
+  );
+  if (results.every(result => result.isAll)) {
+    return null;
+  }
+  return results.flatMap(result => result.paths);
+}
+
+/**
+ * Break an ancestor set path up into the set paths which cover the same sets
+ * except for those within the subtree of targetPath. For each level between
+ * ancestorPath and targetPath, this is every sibling other than the one on the
+ * way down to targetPath.
+ * @param {object} mergedSets A merged sets tree object.
+ * @param {string[]} ancestorPath The path of an ancestor of targetPath.
+ * @param {string[]} targetPath The path of the set to exclude.
+ * @returns {string[][]|null} Array of set paths, or null if the tree does not
+ * contain the nodes along the way down to targetPath.
+ */
+function siblingPathsAlongDescent(mergedSets, ancestorPath, targetPath) {
+  const result = [];
+  // ancestorPath is a prefix of targetPath, so each level on the way down to
+  // targetPath is one of its own prefixes.
+  for (let i = ancestorPath.length; i < targetPath.length; i += 1) {
+    const currPath = targetPath.slice(0, i);
+    const currNode = treeFindNodeByNamePath(mergedSets, currPath);
+    const nextName = targetPath[i];
+    if (!currNode?.children?.some(child => child.name === nextName)) {
+      return null;
+    }
+    currNode.children.forEach((child) => {
+      if (child.name !== nextName) {
+        result.push([...currPath, child.name]);
+      }
+    });
+  }
+  return result;
+}
+
+/**
+ * Add a set (and its descendants) to the set-level filtering criteria.
+ * @param {object} mergedSets A merged sets tree object.
+ * @param {string[][]|null} filterPaths Value of obsSetFilter or sampleSetFilter.
+ * @param {string[]} targetPath The path of the set to include.
+ * @returns {string[][]|null} The next array of included set paths,
+ * or null if every set is now included.
+ */
+export function addPathToFilter(mergedSets, filterPaths, targetPath) {
+  if (!Array.isArray(filterPaths)) {
+    // Every set is already included.
+    return null;
+  }
+  const nextPaths = [
+    // Drop the descendants of targetPath, which it now covers.
+    ...filterPaths.filter(filterPath => !isEqualOrPrefix(targetPath, filterPath)),
+    targetPath,
+  ];
+  return normalizeFilterPaths(mergedSets, nextPaths);
+}
+
+/**
+ * Remove a set (and its descendants) from the set-level filtering criteria.
+ * @param {object} mergedSets A merged sets tree object.
+ * @param {string[][]|null} filterPaths Value of obsSetFilter or sampleSetFilter.
+ * @param {string[]} targetPath The path of the set to exclude.
+ * @returns {string[][]} The next array of included set paths.
+ */
+export function removePathFromFilter(mergedSets, filterPaths, targetPath) {
+  const prevPaths = Array.isArray(filterPaths)
+    ? filterPaths
+    // A null value means that every set is included, so materialize that
+    // implicit "everything" as one path per hierarchy before removing.
+    : (mergedSets?.tree || []).map(lzn => [lzn.name]);
+  const nextPaths = [];
+  prevPaths.forEach((prevPath) => {
+    if (isEqualOrPrefix(targetPath, prevPath)) {
+      // prevPath is targetPath or one of its descendants, so it is excluded.
+      return;
+    }
+    if (isEqualOrPrefix(prevPath, targetPath)) {
+      // prevPath is an ancestor of targetPath, so it needs to be replaced by
+      // the sibling paths along the way down to targetPath.
+      const siblingPaths = siblingPathsAlongDescent(mergedSets, prevPath, targetPath);
+      // If the descent could not be resolved, prevPath is kept as-is rather
+      // than excluding more sets than the user asked for.
+      nextPaths.push(...(siblingPaths === null ? [prevPath] : siblingPaths));
+      return;
+    }
+    nextPaths.push(prevPath);
+  });
+  // Normalization can only return null when nothing was actually excluded,
+  // in which case the un-normalized paths are already correct.
+  return normalizeFilterPaths(mergedSets, nextPaths) || nextPaths;
+}
+
+/**
+ * Restrict a set-level selection to the sets which meet the current set-level
+ * filtering criteria. Used to uphold the invariant that the selection must not
+ * be a superset of the filter: sets which do not meet the filtering criteria
+ * cannot be selected.
+ * @param {string[][]|null} filterPaths Value of obsSetFilter or sampleSetFilter.
+ * @param {string[][]|null} selectionPaths Value of obsSetSelection
+ * or sampleSetSelection.
+ * @returns {string[][]|null} The next array of selected set paths,
+ * or null if there was no selection to begin with.
+ */
+export function restrictSelectionToFilter(filterPaths, selectionPaths) {
+  if (!Array.isArray(selectionPaths) || !Array.isArray(filterPaths)) {
+    return selectionPaths ?? null;
+  }
+  const nextSelection = selectionPaths.filter(
+    selectionPath => isPathFilterIncluded(filterPaths, selectionPath),
+  );
+  // Return the previous array when nothing changed, to avoid
+  // needless coordination value updates.
+  return nextSelection.length === selectionPaths.length ? selectionPaths : nextSelection;
+}

--- a/packages/utils/sets-utils/src/set-filter-utils.test.js
+++ b/packages/utils/sets-utils/src/set-filter-utils.test.js
@@ -3,6 +3,7 @@ import {
   isPathFilterIncluded,
   isPathFilterPartiallyIncluded,
   normalizeFilterPaths,
+  getSiblingPaths,
   addPathToFilter,
   removePathFromFilter,
   restrictSelectionToFilter,
@@ -112,6 +113,27 @@ describe('Tests for normalizeFilterPaths', () => {
   it('returns the paths as-is when the tree is unavailable', () => {
     const filterPaths = [['Cell Type Annotations', 'Immune']];
     expect(normalizeFilterPaths(null, filterPaths)).toEqual(filterPaths);
+  });
+});
+
+describe('Tests for getSiblingPaths', () => {
+  it('returns the level-zero paths for a level-zero node', () => {
+    expect(getSiblingPaths(TREE, ['Cell Type Annotations'])).toEqual([
+      ['Cell Type Annotations'],
+      ['Louvain Clustering'],
+    ]);
+  });
+
+  it('returns the parent\'s children, including the target', () => {
+    expect(getSiblingPaths(TREE, ['Cell Type Annotations', 'Vasculature', 'Pericytes'])).toEqual([
+      ['Cell Type Annotations', 'Vasculature', 'Pericytes'],
+      ['Cell Type Annotations', 'Vasculature', 'Endothelial'],
+    ]);
+  });
+
+  it('returns an empty array when the parent cannot be resolved', () => {
+    expect(getSiblingPaths(TREE, ['Nonexistent', 'Child'])).toEqual([]);
+    expect(getSiblingPaths(null, ['Cell Type Annotations'])).toEqual([]);
   });
 });
 

--- a/packages/utils/sets-utils/src/set-filter-utils.test.js
+++ b/packages/utils/sets-utils/src/set-filter-utils.test.js
@@ -1,0 +1,230 @@
+import { describe, it, expect } from 'vitest';
+import {
+  isPathFilterIncluded,
+  isPathFilterPartiallyIncluded,
+  normalizeFilterPaths,
+  addPathToFilter,
+  removePathFromFilter,
+  restrictSelectionToFilter,
+} from './set-filter-utils.js';
+
+const TREE = {
+  version: '0.1.3',
+  tree: [
+    {
+      name: 'Cell Type Annotations',
+      children: [
+        {
+          name: 'Vasculature',
+          children: [
+            { name: 'Pericytes', set: [['cell_1', null]] },
+            { name: 'Endothelial', set: [['cell_2', null]] },
+          ],
+        },
+        { name: 'Immune', set: [['cell_3', null]] },
+      ],
+    },
+    {
+      name: 'Louvain Clustering',
+      children: [
+        { name: 'Cluster 1', set: [['cell_1', null]] },
+        { name: 'Cluster 2', set: [['cell_2', null]] },
+      ],
+    },
+  ],
+};
+
+describe('Tests for isPathFilterIncluded', () => {
+  it('treats a null filter as including everything', () => {
+    expect(isPathFilterIncluded(null, ['Cell Type Annotations', 'Immune'])).toBe(true);
+  });
+
+  it('treats an empty filter as including nothing', () => {
+    expect(isPathFilterIncluded([], ['Cell Type Annotations', 'Immune'])).toBe(false);
+  });
+
+  it('includes the descendants of an included path', () => {
+    const filterPaths = [['Cell Type Annotations']];
+    expect(isPathFilterIncluded(filterPaths, ['Cell Type Annotations'])).toBe(true);
+    expect(isPathFilterIncluded(filterPaths, ['Cell Type Annotations', 'Vasculature'])).toBe(true);
+    expect(isPathFilterIncluded(
+      filterPaths, ['Cell Type Annotations', 'Vasculature', 'Pericytes'],
+    )).toBe(true);
+  });
+
+  it('does not include the ancestors of an included path', () => {
+    const filterPaths = [['Cell Type Annotations', 'Vasculature']];
+    expect(isPathFilterIncluded(filterPaths, ['Cell Type Annotations'])).toBe(false);
+    expect(isPathFilterIncluded(filterPaths, ['Louvain Clustering', 'Cluster 1'])).toBe(false);
+  });
+});
+
+describe('Tests for isPathFilterPartiallyIncluded', () => {
+  it('is false for a null filter', () => {
+    expect(isPathFilterPartiallyIncluded(null, ['Cell Type Annotations'])).toBe(false);
+  });
+
+  it('is true for the ancestor of an included path', () => {
+    const filterPaths = [['Cell Type Annotations', 'Vasculature']];
+    expect(isPathFilterPartiallyIncluded(filterPaths, ['Cell Type Annotations'])).toBe(true);
+  });
+
+  it('is false for an included path and for a fully excluded path', () => {
+    const filterPaths = [['Cell Type Annotations', 'Vasculature']];
+    expect(isPathFilterPartiallyIncluded(
+      filterPaths, ['Cell Type Annotations', 'Vasculature'],
+    )).toBe(false);
+    expect(isPathFilterPartiallyIncluded(
+      filterPaths, ['Louvain Clustering'],
+    )).toBe(false);
+  });
+});
+
+describe('Tests for normalizeFilterPaths', () => {
+  it('returns null when every set is included', () => {
+    expect(normalizeFilterPaths(TREE, [
+      ['Cell Type Annotations', 'Vasculature'],
+      ['Cell Type Annotations', 'Immune'],
+      ['Louvain Clustering'],
+    ])).toBeNull();
+  });
+
+  it('collapses a complete group of siblings into its parent', () => {
+    expect(normalizeFilterPaths(TREE, [
+      ['Cell Type Annotations', 'Vasculature', 'Pericytes'],
+      ['Cell Type Annotations', 'Vasculature', 'Endothelial'],
+      ['Louvain Clustering', 'Cluster 1'],
+    ])).toEqual([
+      ['Cell Type Annotations', 'Vasculature'],
+      ['Louvain Clustering', 'Cluster 1'],
+    ]);
+  });
+
+  it('drops a path which is already covered by an ancestor', () => {
+    expect(normalizeFilterPaths(TREE, [
+      ['Cell Type Annotations'],
+      ['Cell Type Annotations', 'Immune'],
+    ])).toEqual([
+      ['Cell Type Annotations'],
+    ]);
+  });
+
+  it('returns the paths as-is when the tree is unavailable', () => {
+    const filterPaths = [['Cell Type Annotations', 'Immune']];
+    expect(normalizeFilterPaths(null, filterPaths)).toEqual(filterPaths);
+  });
+});
+
+describe('Tests for removePathFromFilter', () => {
+  it('materializes a null filter before excluding a set', () => {
+    expect(removePathFromFilter(TREE, null, ['Cell Type Annotations', 'Immune'])).toEqual([
+      ['Cell Type Annotations', 'Vasculature'],
+      ['Louvain Clustering'],
+    ]);
+  });
+
+  it('breaks up ancestor paths at every level down to the excluded set', () => {
+    expect(removePathFromFilter(
+      TREE, null, ['Cell Type Annotations', 'Vasculature', 'Pericytes'],
+    )).toEqual([
+      ['Cell Type Annotations', 'Vasculature', 'Endothelial'],
+      ['Cell Type Annotations', 'Immune'],
+      ['Louvain Clustering'],
+    ]);
+  });
+
+  it('excludes the descendants of the excluded set', () => {
+    const filterPaths = [
+      ['Cell Type Annotations', 'Vasculature', 'Pericytes'],
+      ['Louvain Clustering', 'Cluster 1'],
+    ];
+    expect(removePathFromFilter(
+      TREE, filterPaths, ['Cell Type Annotations', 'Vasculature'],
+    )).toEqual([
+      ['Louvain Clustering', 'Cluster 1'],
+    ]);
+  });
+
+  it('leaves an excluded set excluded', () => {
+    const filterPaths = [['Louvain Clustering']];
+    expect(removePathFromFilter(
+      TREE, filterPaths, ['Cell Type Annotations', 'Immune'],
+    )).toEqual(filterPaths);
+  });
+
+  it('can exclude every set', () => {
+    const filterPaths = [['Louvain Clustering', 'Cluster 1']];
+    expect(removePathFromFilter(
+      TREE, filterPaths, ['Louvain Clustering', 'Cluster 1'],
+    )).toEqual([]);
+  });
+});
+
+describe('Tests for addPathToFilter', () => {
+  it('returns null for an already-unfiltered value', () => {
+    expect(addPathToFilter(TREE, null, ['Cell Type Annotations', 'Immune'])).toBeNull();
+  });
+
+  it('returns null once every set has been included again', () => {
+    const filterPaths = removePathFromFilter(
+      TREE, null, ['Cell Type Annotations', 'Immune'],
+    );
+    expect(addPathToFilter(
+      TREE, filterPaths, ['Cell Type Annotations', 'Immune'],
+    )).toBeNull();
+  });
+
+  it('includes the descendants of the added set', () => {
+    const filterPaths = [['Louvain Clustering', 'Cluster 1']];
+    expect(addPathToFilter(
+      TREE, filterPaths, ['Cell Type Annotations', 'Vasculature'],
+    )).toEqual([
+      ['Cell Type Annotations', 'Vasculature'],
+      ['Louvain Clustering', 'Cluster 1'],
+    ]);
+  });
+
+  it('drops paths which the added set now covers', () => {
+    const filterPaths = [
+      ['Cell Type Annotations', 'Vasculature', 'Pericytes'],
+      ['Louvain Clustering', 'Cluster 1'],
+    ];
+    expect(addPathToFilter(
+      TREE, filterPaths, ['Cell Type Annotations', 'Vasculature'],
+    )).toEqual([
+      ['Cell Type Annotations', 'Vasculature'],
+      ['Louvain Clustering', 'Cluster 1'],
+    ]);
+  });
+});
+
+describe('Tests for restrictSelectionToFilter', () => {
+  it('leaves the selection alone when there is no filter', () => {
+    const selectionPaths = [['Cell Type Annotations', 'Immune']];
+    expect(restrictSelectionToFilter(null, selectionPaths)).toBe(selectionPaths);
+  });
+
+  it('returns the same array reference when nothing changed', () => {
+    const selectionPaths = [['Louvain Clustering', 'Cluster 1']];
+    expect(restrictSelectionToFilter(
+      [['Louvain Clustering']], selectionPaths,
+    )).toBe(selectionPaths);
+  });
+
+  it('drops the selected sets which do not meet the filtering criteria', () => {
+    const selectionPaths = [
+      ['Cell Type Annotations', 'Immune'],
+      ['Louvain Clustering', 'Cluster 1'],
+    ];
+    expect(restrictSelectionToFilter([['Louvain Clustering']], selectionPaths)).toEqual([
+      ['Louvain Clustering', 'Cluster 1'],
+    ]);
+  });
+
+  it('drops a selected set which is only partially included', () => {
+    const selectionPaths = [['Cell Type Annotations', 'Vasculature']];
+    expect(restrictSelectionToFilter(
+      [['Cell Type Annotations', 'Vasculature', 'Pericytes']], selectionPaths,
+    )).toEqual([]);
+  });
+});

--- a/packages/utils/sets-utils/src/utils.js
+++ b/packages/utils/sets-utils/src/utils.js
@@ -92,6 +92,7 @@ export function getNextNumberedNodeName(nodes, prefix, suffix) {
  * @param {object[]} additionalCellSets The previous array of user-defined cell sets.
  * @param {function} setCellSetSelection The setter function for cell set selections.
  * @param {function} setAdditionalCellSets The setter function for user-defined cell sets.
+ * @returns {string[]} The path of the newly-created set.
  */
 export function setObsSelection(cellSelection, additionalCellSets, cellSetColor, setCellSetSelection, setAdditionalCellSets, setCellSetColor, setCellColorEncoding, prefix = 'Selection ', suffix = '') {
   const CELL_SELECTIONS_LEVEL_ZERO_NAME = 'My Selections';
@@ -136,6 +137,9 @@ export function setObsSelection(cellSelection, additionalCellSets, cellSetColor,
   ]);
   setCellSetSelection([nextPath]);
   setCellColorEncoding('cellSetSelection');
+  // Returned so that the caller can reference the new set,
+  // for example to add it to the filtering criteria.
+  return nextPath;
 }
 
 export function mergeObsSets(cellSets, additionalCellSets) {

--- a/packages/view-types/obs-sets-manager/src/ObsSetsManagerSubscriber.js
+++ b/packages/view-types/obs-sets-manager/src/ObsSetsManagerSubscriber.js
@@ -37,6 +37,7 @@ import {
   PATH_SEP,
 
   isPathFilterIncluded,
+  normalizeFilterPaths,
   addPathToFilter,
   removePathFromFilter,
   restrictSelectionToFilter,
@@ -154,6 +155,16 @@ export function ObsSetsManagerSubscriber(props) {
     setObsColorEncoding('cellSetSelection');
   }, [setObsColorEncoding]);
 
+  // A helper function for adding newly-created or newly-imported sets to the
+  // filtering criteria. Such a set cannot be covered by an existing filter,
+  // so it would otherwise appear as excluded (and therefore be un-selectable)
+  // as soon as it is created. A null filter already includes every set.
+  const includePathsInFilter = useCallback((newPaths) => {
+    if (Array.isArray(obsSetFilter) && newPaths.length > 0) {
+      setObsSetFilter([...obsSetFilter, ...newPaths]);
+    }
+  }, [obsSetFilter, setObsSetFilter]);
+
   // Merged cell sets are only to be used for convenience when reading
   // (if writing: update either `cellSets` _or_ `additionalObsSets`).
   const mergedObsSets = useMemo(
@@ -183,10 +194,24 @@ export function ObsSetsManagerSubscriber(props) {
       const newObsSetSelection = levelPaths.filter(
         levelPath => isPathFilterIncluded(obsSetFilter, levelPath),
       );
+      // Re-express the filtering criteria at this level, so that the sets
+      // which become selected are exactly the sets which are included.
+      // The criteria of the other hierarchies are left untouched, since a
+      // hierarchy which is left out of the filter entirely would be excluded.
+      const otherHierarchyPaths = (Array.isArray(obsSetFilter)
+        ? obsSetFilter.filter(d => d[0] !== levelZeroName)
+        // A null filter includes every set, so materialize that implicit
+        // "everything" as one path per remaining hierarchy.
+        : mergedObsSets.tree.filter(n => n.name !== levelZeroName).map(n => [n.name]));
+      setObsSetFilter(normalizeFilterPaths(
+        mergedObsSets, [...otherHierarchyPaths, ...newObsSetSelection],
+      ));
       setObsSetSelection(newObsSetSelection);
       setObsSetColorEncoding();
     }
-  }, [mergedObsSets, obsSetFilter, setObsSetColorEncoding, setObsSetSelection]);
+  }, [mergedObsSets, obsSetFilter, setObsSetColorEncoding, setObsSetSelection,
+    setObsSetFilter,
+  ]);
 
   // The user wants to check or uncheck a cell set node.
   const onCheckNode = useCallback((targetKey, checked) => {
@@ -394,12 +419,19 @@ export function ObsSetsManagerSubscriber(props) {
     newObsSetColor.push(...newColors);
     setObsSetColor(newObsSetColor);
     // The filter may also reference the dragged node or one of its descendants.
-    const nextObsSetFilter = obsSetFilter?.map(
-      path => (isEqualOrPrefix(dragPath, path)
-        ? [...newDragPath, ...path.slice(dragPath.length)]
-        : path),
-    );
-    if (nextObsSetFilter) {
+    if (Array.isArray(obsSetFilter)) {
+      const nextObsSetFilter = obsSetFilter.map(
+        path => (isEqualOrPrefix(dragPath, path)
+          ? [...newDragPath, ...path.slice(dragPath.length)]
+          : path),
+      );
+      // Moving a node should not change whether it meets the filtering
+      // criteria, but it may have been included only by way of its previous
+      // parent, in which case the moved node needs its own filter path.
+      if (isPathFilterIncluded(obsSetFilter, dragPath)
+        && !isPathFilterIncluded(nextObsSetFilter, newDragPath)) {
+        nextObsSetFilter.push(newDragPath);
+      }
       setObsSetFilter(nextObsSetFilter);
       // The dragged node was selected above, so drop it from the selection
       // again if it does not meet the filtering criteria.
@@ -577,49 +609,58 @@ export function ObsSetsManagerSubscriber(props) {
         },
       ],
     });
-  }, [additionalObsSets, setAdditionalObsSets]);
+    includePathsInFilter([[nextName]]);
+  }, [additionalObsSets, setAdditionalObsSets, includePathsInFilter]);
 
   // The user wants to create a new node corresponding to
   // the union of the selected sets.
   const onUnion = useCallback(() => {
     const newSet = treeToUnion(mergedObsSets, obsSetSelection);
-    setObsSelection(
+    const newPath = setObsSelection(
       newSet, additionalObsSets, obsSetColor,
       setObsSetSelection, setAdditionalObsSets, setObsSetColor,
       setObsColorEncoding,
       'Union ',
     );
+    // setObsSelection also selects the new set, so it must be included.
+    includePathsInFilter([newPath]);
   }, [additionalObsSets, obsSetColor, obsSetSelection, mergedObsSets,
     setAdditionalObsSets, setObsColorEncoding, setObsSetColor, setObsSetSelection,
+    includePathsInFilter,
   ]);
 
   // The user wants to create a new node corresponding to
   // the intersection of the selected sets.
   const onIntersection = useCallback(() => {
     const newSet = treeToIntersection(mergedObsSets, obsSetSelection);
-    setObsSelection(
+    const newPath = setObsSelection(
       newSet, additionalObsSets, obsSetColor,
       setObsSetSelection, setAdditionalObsSets, setObsSetColor,
       setObsColorEncoding,
       'Intersection ',
     );
+    // setObsSelection also selects the new set, so it must be included.
+    includePathsInFilter([newPath]);
   }, [additionalObsSets, obsSetColor, obsSetSelection, mergedObsSets,
     setAdditionalObsSets, setObsColorEncoding, setObsSetColor, setObsSetSelection,
+    includePathsInFilter,
   ]);
 
   // The user wants to create a new node corresponding to
   // the complement of the selected sets.
   const onComplement = useCallback(() => {
     const newSet = treeToComplement(mergedObsSets, obsSetSelection, allCellIds);
-    setObsSelection(
+    const newPath = setObsSelection(
       newSet, additionalObsSets, obsSetColor,
       setObsSetSelection, setAdditionalObsSets, setObsSetColor,
       setObsColorEncoding,
       'Complement ',
     );
+    // setObsSelection also selects the new set, so it must be included.
+    includePathsInFilter([newPath]);
   }, [additionalObsSets, allCellIds, obsSetColor, obsSetSelection,
     mergedObsSets, setAdditionalObsSets, setObsColorEncoding, setObsSetColor,
-    setObsSetSelection,
+    setObsSetSelection, includePathsInFilter,
   ]);
 
   // The user wants to import a cell set hierarchy,
@@ -642,9 +683,12 @@ export function ObsSetsManagerSubscriber(props) {
         ...obsSetColor,
         ...importAutoSetColors,
       ]);
+      // Imported hierarchies are included in the filtering criteria,
+      // rather than arriving in an excluded state.
+      includePathsInFilter(treeToImport.tree.map(lzn => [lzn.name]));
     }
   }, [additionalObsSets, obsSetColor, mergedObsSets, setAdditionalObsSets,
-    setObsSetColor,
+    setObsSetColor, includePathsInFilter,
   ]);
 
   // The user wants to download a particular hierarchy to a JSON file.

--- a/packages/view-types/obs-sets-manager/src/ObsSetsManagerSubscriber.js
+++ b/packages/view-types/obs-sets-manager/src/ObsSetsManagerSubscriber.js
@@ -36,6 +36,11 @@ import {
   tryRenamePath,
   PATH_SEP,
 
+  isPathFilterIncluded,
+  addPathToFilter,
+  removePathFromFilter,
+  restrictSelectionToFilter,
+
   downloadForUser,
   handleExportJSON,
   handleExportTabular,
@@ -87,12 +92,16 @@ export function ObsSetsManagerSubscriber(props) {
     dataset,
     obsType,
     obsSetSelection,
+    obsSetFilter,
+    obsFilterMode,
     obsSetExpansion,
     obsSetColor,
     additionalObsSets,
     obsColorEncoding,
   }, {
     setObsSetSelection,
+    setObsSetFilter,
+    setObsFilterMode,
     setObsColorEncoding,
     setObsSetColor,
     setObsSetExpansion,
@@ -167,11 +176,17 @@ export function ObsSetsManagerSubscriber(props) {
   const onCheckLevel = useCallback((levelZeroName, levelIndex) => {
     const lzn = mergedObsSets.tree.find(n => n.name === levelZeroName);
     if (lzn) {
-      const newObsSetSelection = nodeToLevelDescendantNamePaths(lzn, levelIndex, [], true);
+      const levelPaths = nodeToLevelDescendantNamePaths(lzn, levelIndex, [], true);
+      // A set which does not meet the filtering criteria cannot be selected,
+      // so the sets at this level which are (even partially) filtered out
+      // are left out of the new selection.
+      const newObsSetSelection = levelPaths.filter(
+        levelPath => isPathFilterIncluded(obsSetFilter, levelPath),
+      );
       setObsSetSelection(newObsSetSelection);
       setObsSetColorEncoding();
     }
-  }, [mergedObsSets, setObsSetColorEncoding, setObsSetSelection]);
+  }, [mergedObsSets, obsSetFilter, setObsSetColorEncoding, setObsSetSelection]);
 
   // The user wants to check or uncheck a cell set node.
   const onCheckNode = useCallback((targetKey, checked) => {
@@ -180,12 +195,41 @@ export function ObsSetsManagerSubscriber(props) {
       return;
     }
     if (checked) {
+      // Sets which do not meet the filtering criteria cannot be selected,
+      // since the selection must not be a superset of the filter.
+      if (!isPathFilterIncluded(obsSetFilter, targetPath)) {
+        return;
+      }
       setObsSetSelection([...obsSetSelection, targetPath]);
     } else {
       setObsSetSelection(obsSetSelection.filter(d => !isEqual(d, targetPath)));
     }
     setObsSetColorEncoding();
-  }, [obsSetSelection, setObsSetColorEncoding, setObsSetSelection]);
+  }, [obsSetFilter, obsSetSelection, setObsSetColorEncoding, setObsSetSelection]);
+
+  // The user wants to include or exclude a cell set node
+  // in/from the current filtering criteria.
+  const onFilterNode = useCallback((targetPath, filtered) => {
+    const nextObsSetFilter = (filtered
+      ? addPathToFilter(mergedObsSets, obsSetFilter, targetPath)
+      : removePathFromFilter(mergedObsSets, obsSetFilter, targetPath)
+    );
+    setObsSetFilter(nextObsSetFilter);
+    // Any set which no longer meets the filtering criteria must also be
+    // un-selected, to uphold the invariant that the selection is not
+    // a superset of the filter.
+    const nextObsSetSelection = restrictSelectionToFilter(nextObsSetFilter, obsSetSelection);
+    if (nextObsSetSelection !== obsSetSelection) {
+      setObsSetSelection(nextObsSetSelection);
+    }
+    // The set-level filter is ignored while the observation-level filter is
+    // the active criteria, so switch modes to make this change take effect.
+    if (obsFilterMode === 'obsFilter') {
+      setObsFilterMode('obsSetFilter');
+    }
+  }, [mergedObsSets, obsFilterMode, obsSetFilter, obsSetSelection,
+    setObsFilterMode, setObsSetFilter, setObsSetSelection,
+  ]);
 
   // The user wants to expand or collapse a node in the tree.
   const onExpandNode = useCallback((expandedKeys, targetKey, expanded) => {
@@ -349,8 +393,20 @@ export function ObsSetsManagerSubscriber(props) {
     );
     newObsSetColor.push(...newColors);
     setObsSetColor(newObsSetColor);
-  }, [additionalObsSets, obsSetColor, setAdditionalObsSets, setObsSetColor,
-    setObsSetSelection,
+    // The filter may also reference the dragged node or one of its descendants.
+    const nextObsSetFilter = obsSetFilter?.map(
+      path => (isEqualOrPrefix(dragPath, path)
+        ? [...newDragPath, ...path.slice(dragPath.length)]
+        : path),
+    );
+    if (nextObsSetFilter) {
+      setObsSetFilter(nextObsSetFilter);
+      // The dragged node was selected above, so drop it from the selection
+      // again if it does not meet the filtering criteria.
+      setObsSetSelection(restrictSelectionToFilter(nextObsSetFilter, [newDragPath]));
+    }
+  }, [additionalObsSets, obsSetColor, obsSetFilter, setAdditionalObsSets, setObsSetColor,
+    setObsSetFilter, setObsSetSelection,
   ]);
 
   // The user wants to change the color of a cell set node.
@@ -414,6 +470,9 @@ export function ObsSetsManagerSubscriber(props) {
     const nextObsSetSelection = obsSetSelection.map(d => (
       tryRenamePath(targetPath, d, nextNamePath)
     ));
+    const nextObsSetFilter = obsSetFilter?.map(d => (
+      tryRenamePath(targetPath, d, nextNamePath)
+    ));
     const nextObsSetExpansion = prevObsSetExpansion.map(d => (
       tryRenamePath(targetPath, d, nextNamePath)
     ));
@@ -421,9 +480,12 @@ export function ObsSetsManagerSubscriber(props) {
     setAdditionalObsSets(nextAdditionalObsSets);
     setObsSetColor(nextObsSetColor);
     setObsSetSelection(nextObsSetSelection);
+    if (nextObsSetFilter) {
+      setObsSetFilter(nextObsSetFilter);
+    }
     setObsSetExpansion(nextObsSetExpansion);
-  }, [additionalObsSets, obsSetColor, obsSetExpansion, obsSetSelection,
-    setAdditionalObsSets, setObsSetColor, setObsSetSelection,
+  }, [additionalObsSets, obsSetColor, obsSetExpansion, obsSetSelection, obsSetFilter,
+    setAdditionalObsSets, setObsSetColor, setObsSetSelection, setObsSetFilter,
     setObsSetExpansion,
   ]);
 
@@ -457,13 +519,17 @@ export function ObsSetsManagerSubscriber(props) {
     // path as a prefix (i.e. delete all descendents).
     const nextObsSetColor = obsSetColor.filter(d => !isEqualOrPrefix(targetPath, d.path));
     const nextObsSetSelection = obsSetSelection.filter(d => !isEqualOrPrefix(targetPath, d));
+    const nextObsSetFilter = obsSetFilter?.filter(d => !isEqualOrPrefix(targetPath, d));
     const nextObsSetExpansion = prevObsSetExpansion.filter(d => !isEqualOrPrefix(targetPath, d));
     setAdditionalObsSets(nextAdditionalObsSets);
     setObsSetColor(nextObsSetColor);
     setObsSetSelection(nextObsSetSelection);
+    if (nextObsSetFilter) {
+      setObsSetFilter(nextObsSetFilter);
+    }
     setObsSetExpansion(nextObsSetExpansion);
-  }, [additionalObsSets, obsSetColor, obsSetExpansion, obsSetSelection,
-    setAdditionalObsSets, setObsSetColor, setObsSetSelection,
+  }, [additionalObsSets, obsSetColor, obsSetExpansion, obsSetSelection, obsSetFilter,
+    setAdditionalObsSets, setObsSetColor, setObsSetSelection, setObsSetFilter,
     setObsSetExpansion,
   ]);
 
@@ -475,15 +541,18 @@ export function ObsSetsManagerSubscriber(props) {
     const setsToView = [];
     // Recursively determine which descendent nodes are currently expanded.
     function viewNode(node, nodePath) {
-      if (obsSetExpansion?.find(expandedPath => isEqual(nodePath, expandedPath))) {
-        if (node.children) {
-          node.children.forEach((c) => {
-            viewNode(c, [...nodePath, c.name]);
-          });
-        } else {
-          setsToView.push(nodePath);
-        }
-      } else {
+      const isExpanded = Boolean(
+        obsSetExpansion?.find(expandedPath => isEqual(nodePath, expandedPath)),
+      );
+      const isIncluded = isPathFilterIncluded(obsSetFilter, nodePath);
+      // Descend either because the node is expanded, or because only part of
+      // its subtree meets the filtering criteria, in which case the node
+      // itself cannot be selected but some of its descendants can.
+      if (node.children && (isExpanded || !isIncluded)) {
+        node.children.forEach((c) => {
+          viewNode(c, [...nodePath, c.name]);
+        });
+      } else if (isIncluded) {
         setsToView.push(nodePath);
       }
     }
@@ -491,7 +560,9 @@ export function ObsSetsManagerSubscriber(props) {
     viewNode(targetNode, targetPath);
     setObsSetSelection(setsToView);
     setObsSetColorEncoding();
-  }, [obsSetExpansion, mergedObsSets, setObsSetColorEncoding, setObsSetSelection]);
+  }, [obsSetExpansion, obsSetFilter, mergedObsSets,
+    setObsSetColorEncoding, setObsSetSelection,
+  ]);
 
   // The user wants to create a new level zero node.
   const onCreateLevelZeroNode = useCallback(() => {
@@ -615,12 +686,15 @@ export function ObsSetsManagerSubscriber(props) {
       additionalSets={additionalObsSets}
       levelSelection={checkedLevel}
       setSelection={obsSetSelection}
+      setFilter={obsSetFilter}
+      isSetFilterActive={obsFilterMode !== 'obsFilter'}
       setExpansion={obsSetExpansion}
       hasColorEncoding={obsColorEncoding === 'cellSetSelection'}
       draggable
       datatype={SETS_DATATYPE_OBS}
       onError={setWarning}
       onCheckNode={onCheckNode}
+      onFilterNode={onFilterNode}
       onExpandNode={onExpandNode}
       onDropNode={onDropNode}
       onCheckLevel={onCheckLevel}
@@ -643,10 +717,11 @@ export function ObsSetsManagerSubscriber(props) {
       theme={theme}
     />
   ), [additionalObsSets, obsColorEncoding, obsSetColor, obsSetExpansion, obsSetSelection,
+    obsSetFilter, obsFilterMode,
     cellSets, checkedLevel, onCheckLevel, onCheckNode, onComplement, onCreateLevelZeroNode,
     onDropNode, onExpandNode, onExportLevelZeroNodeJSON, onExportLevelZeroNodeTabular,
-    onExportSetJSON, onImportTree, onIntersection, onNodeCheckNewName, onNodeRemove, onNodeSetColor,
-    onNodeSetName, onNodeView, onUnion, setWarning, theme,
+    onExportSetJSON, onFilterNode, onImportTree, onIntersection, onNodeCheckNewName, onNodeRemove,
+    onNodeSetColor, onNodeSetName, onNodeView, onUnion, setWarning, theme,
   ]);
 
 

--- a/packages/view-types/obs-sets-manager/src/ObsSetsManagerSubscriber.js
+++ b/packages/view-types/obs-sets-manager/src/ObsSetsManagerSubscriber.js
@@ -37,7 +37,7 @@ import {
   PATH_SEP,
 
   isPathFilterIncluded,
-  normalizeFilterPaths,
+  getSiblingPaths,
   addPathToFilter,
   removePathFromFilter,
   restrictSelectionToFilter,
@@ -183,29 +183,15 @@ export function ObsSetsManagerSubscriber(props) {
 
   // Callback functions
 
-  // The user wants to select all nodes at a particular hierarchy level.
+  // The user wants to filter-include and select all nodes at a particular hierarchy level.
   const onCheckLevel = useCallback((levelZeroName, levelIndex) => {
     const lzn = mergedObsSets.tree.find(n => n.name === levelZeroName);
     if (lzn) {
       const levelPaths = nodeToLevelDescendantNamePaths(lzn, levelIndex, [], true);
-      // A set which does not meet the filtering criteria cannot be selected,
-      // so the sets at this level which are (even partially) filtered out
-      // are left out of the new selection.
       const newObsSetSelection = levelPaths.filter(
         levelPath => isPathFilterIncluded(obsSetFilter, levelPath),
       );
-      // Re-express the filtering criteria at this level, so that the sets
-      // which become selected are exactly the sets which are included.
-      // The criteria of the other hierarchies are left untouched, since a
-      // hierarchy which is left out of the filter entirely would be excluded.
-      const otherHierarchyPaths = (Array.isArray(obsSetFilter)
-        ? obsSetFilter.filter(d => d[0] !== levelZeroName)
-        // A null filter includes every set, so materialize that implicit
-        // "everything" as one path per remaining hierarchy.
-        : mergedObsSets.tree.filter(n => n.name !== levelZeroName).map(n => [n.name]));
-      setObsSetFilter(normalizeFilterPaths(
-        mergedObsSets, [...otherHierarchyPaths, ...newObsSetSelection],
-      ));
+      setObsSetFilter(newObsSetSelection);
       setObsSetSelection(newObsSetSelection);
       setObsSetColorEncoding();
     }
@@ -225,25 +211,38 @@ export function ObsSetsManagerSubscriber(props) {
       if (!isPathFilterIncluded(obsSetFilter, targetPath)) {
         return;
       }
+      // A null selection already includes every set which meets
+      // the filtering criteria.
+      if (!Array.isArray(obsSetSelection)) {
+        return;
+      }
       setObsSetSelection([...obsSetSelection, targetPath]);
     } else {
-      setObsSetSelection(obsSetSelection.filter(d => !isEqual(d, targetPath)));
+      const prevObsSetSelection = (Array.isArray(obsSetSelection)
+        ? obsSetSelection
+        // A null selection means that every set which meets the filtering
+        // criteria is selected. Materialize that as the target's sibling sets,
+        // so that un-checking one of them leaves the others selected.
+        : getSiblingPaths(mergedObsSets, targetPath).filter(
+          d => isPathFilterIncluded(obsSetFilter, d),
+        ));
+      setObsSetSelection(prevObsSetSelection.filter(d => !isEqual(d, targetPath)));
     }
     setObsSetColorEncoding();
-  }, [obsSetFilter, obsSetSelection, setObsSetColorEncoding, setObsSetSelection]);
+  }, [mergedObsSets, obsSetFilter, obsSetSelection,
+    setObsSetColorEncoding, setObsSetSelection,
+  ]);
 
-  // The user wants to include or exclude a cell set node
-  // in/from the current filtering criteria.
-  const onFilterNode = useCallback((targetPath, filtered) => {
-    const nextObsSetFilter = (filtered
-      ? addPathToFilter(mergedObsSets, obsSetFilter, targetPath)
-      : removePathFromFilter(mergedObsSets, obsSetFilter, targetPath)
-    );
+  // A helper function for applying new set-level filtering criteria.
+  // Pass nextObsSetSelectionOverride to replace the selection outright,
+  // rather than only dropping the sets which are no longer included.
+  const applyObsSetFilter = useCallback((nextObsSetFilter, nextObsSetSelectionOverride) => {
     setObsSetFilter(nextObsSetFilter);
     // Any set which no longer meets the filtering criteria must also be
     // un-selected, to uphold the invariant that the selection is not
     // a superset of the filter.
-    const nextObsSetSelection = restrictSelectionToFilter(nextObsSetFilter, obsSetSelection);
+    const nextObsSetSelection = nextObsSetSelectionOverride
+      ?? restrictSelectionToFilter(nextObsSetFilter, obsSetSelection);
     if (nextObsSetSelection !== obsSetSelection) {
       setObsSetSelection(nextObsSetSelection);
     }
@@ -252,9 +251,59 @@ export function ObsSetsManagerSubscriber(props) {
     if (obsFilterMode === 'obsFilter') {
       setObsFilterMode('obsSetFilter');
     }
-  }, [mergedObsSets, obsFilterMode, obsSetFilter, obsSetSelection,
-    setObsFilterMode, setObsSetFilter, setObsSetSelection,
+  }, [obsFilterMode, obsSetSelection, setObsFilterMode, setObsSetFilter,
+    setObsSetSelection,
   ]);
+
+  // The user wants to include or exclude a cell set node
+  // in/from the current filtering criteria.
+  const onFilterNode = useCallback((targetPath, filtered) => {
+    applyObsSetFilter(filtered
+      ? addPathToFilter(mergedObsSets, obsSetFilter, targetPath)
+      : removePathFromFilter(mergedObsSets, obsSetFilter, targetPath));
+  }, [mergedObsSets, obsSetFilter, applyObsSetFilter]);
+
+  // The user wants to narrow the filtering criteria down to a single cell set,
+  // excluding every other set (in every hierarchy).
+  const onFilterToOnlyNode = useCallback((targetPath) => {
+    // This set becomes the only one which is included, so it is also the only
+    // one which can be selected. A null selection already means exactly that,
+    // so it is left as-is rather than being materialized.
+    applyObsSetFilter(
+      [targetPath],
+      Array.isArray(obsSetSelection) ? [targetPath] : undefined,
+    );
+  }, [obsSetSelection, applyObsSetFilter]);
+
+  // The user wants to exclude a cell set node from the filtering criteria,
+  // narrowing those criteria down to the set's immediate siblings.
+  const onFilterToOthersInSiblings = useCallback((targetPath) => {
+    const siblingPaths = getSiblingPaths(mergedObsSets, targetPath);
+    applyObsSetFilter(siblingPaths.filter(d => !isEqual(d, targetPath)));
+  }, [mergedObsSets, applyObsSetFilter]);
+
+  // The user wants to exclude a cell set node from the filtering criteria,
+  // narrowing those criteria down to the rest of the set's hierarchy.
+  const onFilterToOthersInGroup = useCallback((targetPath) => {
+    // Removing the set from a filter of "the whole hierarchy" yields the
+    // sibling sets at every level on the way down to the set.
+    applyObsSetFilter(removePathFromFilter(
+      mergedObsSets, [[targetPath[0]]], targetPath,
+    ));
+  }, [mergedObsSets, applyObsSetFilter]);
+
+  // The user wants to select every set which meets the filtering criteria
+  // except for one. The filtering criteria themselves are left alone.
+  const onSelectComplement = useCallback((targetPath) => {
+    // Sets of other hierarchies are left out, since hierarchies overlap with
+    // each other: an observation belongs to one set per hierarchy, so a
+    // selection which spanned hierarchies would be ambiguous.
+    const includedPaths = (Array.isArray(obsSetFilter)
+      ? obsSetFilter.filter(d => d[0] === targetPath[0])
+      : [[targetPath[0]]]);
+    setObsSetSelection(removePathFromFilter(mergedObsSets, includedPaths, targetPath));
+    setObsSetColorEncoding();
+  }, [mergedObsSets, obsSetFilter, setObsSetSelection, setObsSetColorEncoding]);
 
   // The user wants to expand or collapse a node in the tree.
   const onExpandNode = useCallback((expandedKeys, targetKey, expanded) => {
@@ -499,7 +548,9 @@ export function ObsSetsManagerSubscriber(props) {
       path: tryRenamePath(targetPath, d.path, nextNamePath),
       color: d.color,
     }));
-    const nextObsSetSelection = obsSetSelection.map(d => (
+    // A null selection or filter is not expressed in terms of paths,
+    // so there is nothing to rename.
+    const nextObsSetSelection = obsSetSelection?.map(d => (
       tryRenamePath(targetPath, d, nextNamePath)
     ));
     const nextObsSetFilter = obsSetFilter?.map(d => (
@@ -511,7 +562,9 @@ export function ObsSetsManagerSubscriber(props) {
     // Need to update the node path everywhere it may be present.
     setAdditionalObsSets(nextAdditionalObsSets);
     setObsSetColor(nextObsSetColor);
-    setObsSetSelection(nextObsSetSelection);
+    if (nextObsSetSelection) {
+      setObsSetSelection(nextObsSetSelection);
+    }
     if (nextObsSetFilter) {
       setObsSetFilter(nextObsSetFilter);
     }
@@ -550,12 +603,16 @@ export function ObsSetsManagerSubscriber(props) {
     // Delete state for all paths that have this node
     // path as a prefix (i.e. delete all descendents).
     const nextObsSetColor = obsSetColor.filter(d => !isEqualOrPrefix(targetPath, d.path));
-    const nextObsSetSelection = obsSetSelection.filter(d => !isEqualOrPrefix(targetPath, d));
+    // A null selection or filter is not expressed in terms of paths,
+    // so there is nothing to delete.
+    const nextObsSetSelection = obsSetSelection?.filter(d => !isEqualOrPrefix(targetPath, d));
     const nextObsSetFilter = obsSetFilter?.filter(d => !isEqualOrPrefix(targetPath, d));
     const nextObsSetExpansion = prevObsSetExpansion.filter(d => !isEqualOrPrefix(targetPath, d));
     setAdditionalObsSets(nextAdditionalObsSets);
     setObsSetColor(nextObsSetColor);
-    setObsSetSelection(nextObsSetSelection);
+    if (nextObsSetSelection) {
+      setObsSetSelection(nextObsSetSelection);
+    }
     if (nextObsSetFilter) {
       setObsSetFilter(nextObsSetFilter);
     }
@@ -739,6 +796,10 @@ export function ObsSetsManagerSubscriber(props) {
       onError={setWarning}
       onCheckNode={onCheckNode}
       onFilterNode={onFilterNode}
+      onFilterToOnlyNode={onFilterToOnlyNode}
+      onFilterToOthersInSiblings={onFilterToOthersInSiblings}
+      onFilterToOthersInGroup={onFilterToOthersInGroup}
+      onSelectComplement={onSelectComplement}
       onExpandNode={onExpandNode}
       onDropNode={onDropNode}
       onCheckLevel={onCheckLevel}
@@ -764,7 +825,9 @@ export function ObsSetsManagerSubscriber(props) {
     obsSetFilter, obsFilterMode,
     cellSets, checkedLevel, onCheckLevel, onCheckNode, onComplement, onCreateLevelZeroNode,
     onDropNode, onExpandNode, onExportLevelZeroNodeJSON, onExportLevelZeroNodeTabular,
-    onExportSetJSON, onFilterNode, onImportTree, onIntersection, onNodeCheckNewName, onNodeRemove,
+    onExportSetJSON, onFilterNode, onFilterToOnlyNode, onFilterToOthersInSiblings,
+    onFilterToOthersInGroup, onSelectComplement,
+    onImportTree, onIntersection, onNodeCheckNewName, onNodeRemove,
     onNodeSetColor, onNodeSetName, onNodeView, onUnion, setWarning, theme,
   ]);
 

--- a/packages/view-types/obs-sets-manager/src/SetsManager.js
+++ b/packages/view-types/obs-sets-manager/src/SetsManager.js
@@ -1,7 +1,12 @@
 /* eslint-disable no-underscore-dangle */
 import React, { useState, useMemo } from 'react';
 import { isEqual } from 'lodash-es';
-import { nodeToRenderProps, pathToKey } from '@vitessce/sets-utils';
+import {
+  nodeToRenderProps,
+  pathToKey,
+  isPathFilterIncluded,
+  isPathFilterPartiallyIncluded,
+} from '@vitessce/sets-utils';
 import { getDefaultColor } from '@vitessce/utils';
 import Tree from './Tree.js';
 import TreeNode from './TreeNode.js';
@@ -60,8 +65,14 @@ function getAllKeys(node, path = []) {
  * By default, true.
  * @prop {boolean} importable Whether to enable importing hierarchies from files.
  * By default, true.
+ * @prop {string[][]|null} setFilter The paths of the sets which meet the current filtering
+ * criteria. A null value means that every set is included.
+ * @prop {boolean} isSetFilterActive Whether the set-level filtering criteria are the ones
+ * currently in effect (as opposed to item-level filtering criteria).
  * @prop {function} onError Function to call with error messages (failed import validation, etc).
  * @prop {function} onCheckNode Function to call when a single node has been checked or un-checked.
+ * @prop {function} onFilterNode Function to call when a single node has been included in or
+ * excluded from the filtering criteria.
  * @prop {function} onExpandNode Function to call when a node has been expanded.
  * @prop {function} onDropNode Function to call when a node has been dragged-and-dropped.
  * @prop {function} onCheckLevel Function to call when an entire hierarchy level has been selected,
@@ -99,6 +110,8 @@ export default function SetsManager(props) {
     setColor,
     levelSelection: checkedLevel,
     setSelection,
+    setFilter,
+    isSetFilterActive = true,
     setExpansion,
     hasColorEncoding,
     datatype,
@@ -111,6 +124,7 @@ export default function SetsManager(props) {
     importable = true,
     onError,
     onCheckNode,
+    onFilterNode,
     onExpandNode,
     onDropNode,
     onCheckLevel,
@@ -169,6 +183,12 @@ export default function SetsManager(props) {
     }
     return nodes.map((node) => {
       const newPath = [...currPath, node.name];
+      // Filtering: a set which does not meet the filtering criteria cannot be
+      // selected, since the selection must not be a superset of the filter.
+      // A partially-included set is a superset of the included sets within its
+      // own subtree, so it cannot be selected either.
+      const isFilterIncluded = isPathFilterIncluded(setFilter, newPath);
+      const isFilterPartiallyIncluded = isPathFilterPartiallyIncluded(setFilter, newPath);
       return (
         <TreeNode
           theme={theme}
@@ -189,7 +209,13 @@ export default function SetsManager(props) {
           checkedLevelPath={checkedLevel ? checkedLevel.levelZeroPath : null}
           checkedLevelIndex={checkedLevel ? checkedLevel.levelIndex : null}
 
+          isSetFilterActive={isSetFilterActive}
+          isFilterIncluded={isFilterIncluded}
+          isFilterPartiallyIncluded={isFilterPartiallyIncluded}
+          disableCheckbox={!isFilterIncluded}
+
           onCheckNode={onCheckNode}
+          onFilterNode={onFilterNode}
           onCheckLevel={onCheckLevel}
           onNodeView={onNodeView}
           onNodeSetColor={onNodeSetColor}

--- a/packages/view-types/obs-sets-manager/src/SetsManager.js
+++ b/packages/view-types/obs-sets-manager/src/SetsManager.js
@@ -47,6 +47,30 @@ function getAllKeys(node, path = []) {
 }
 
 /**
+ * Collect the keys of every node in a sets tree whose set meets the current
+ * filtering criteria. Used when the selection is null, since a null selection
+ * means that every set which meets the filtering criteria is selected.
+ * @param {object} sets A sets tree object.
+ * @param {string[][]|null} setFilter The paths of the sets which meet the
+ * current filtering criteria.
+ * @returns {string[]} Array of node keys.
+ */
+function getFilterIncludedKeys(sets, setFilter) {
+  const result = [];
+  function visitNode(node, prevPath) {
+    const nodePath = [...prevPath, node.name];
+    if (isPathFilterIncluded(setFilter, nodePath)) {
+      result.push(pathToKey(nodePath));
+    }
+    // A node which is included also has all of its descendants included,
+    // but an excluded node may still have included descendants.
+    node.children?.forEach(child => visitNode(child, nodePath));
+  }
+  sets?.tree?.forEach(lzn => visitNode(lzn, []));
+  return result;
+}
+
+/**
  * A generic hierarchical set manager component.
  * @prop {object} tree An object representing set hierarchies.
  * @prop {string} datatype The data type for sets (e.g. "cell")
@@ -73,6 +97,14 @@ function getAllKeys(node, path = []) {
  * @prop {function} onCheckNode Function to call when a single node has been checked or un-checked.
  * @prop {function} onFilterNode Function to call when a single node has been included in or
  * excluded from the filtering criteria.
+ * @prop {function} onFilterToOnlyNode Function to call to narrow the filtering criteria down
+ * to a single node.
+ * @prop {function} onFilterToOthersInSiblings Function to call to narrow the filtering criteria
+ * down to a node's immediate siblings.
+ * @prop {function} onFilterToOthersInGroup Function to call to narrow the filtering criteria
+ * down to the rest of a node's hierarchy.
+ * @prop {function} onSelectComplement Function to call to select every filter-included node
+ * except one.
  * @prop {function} onExpandNode Function to call when a node has been expanded.
  * @prop {function} onDropNode Function to call when a node has been dragged-and-dropped.
  * @prop {function} onCheckLevel Function to call when an entire hierarchy level has been selected,
@@ -125,6 +157,10 @@ export default function SetsManager(props) {
     onError,
     onCheckNode,
     onFilterNode,
+    onFilterToOnlyNode,
+    onFilterToOthersInSiblings,
+    onFilterToOthersInGroup,
+    onSelectComplement,
     onExpandNode,
     onDropNode,
     onCheckLevel,
@@ -163,7 +199,18 @@ export default function SetsManager(props) {
     : []
   );
 
-  const allSetSelectionKeys = (setSelection || []).map(pathToKey);
+  // A null selection means that every set which meets the filtering criteria
+  // is selected, so in that case the checked state is derived from the trees
+  // rather than from an explicit list of paths. An empty array, on the other
+  // hand, means that nothing is selected.
+  const allSetSelectionKeys = useMemo(() => (
+    Array.isArray(setSelection)
+      ? setSelection.map(pathToKey)
+      : [
+        ...getFilterIncludedKeys(processedSets, setFilter),
+        ...getFilterIncludedKeys(processedAdditionalSets, setFilter),
+      ]
+  ), [setSelection, setFilter, processedSets, processedAdditionalSets]);
   const allSetExpansionKeys = (setExpansion || []).map(pathToKey);
 
   const setSelectionKeys = allSetSelectionKeys.filter(k => !additionalSetKeys.includes(k));
@@ -216,6 +263,10 @@ export default function SetsManager(props) {
 
           onCheckNode={onCheckNode}
           onFilterNode={onFilterNode}
+          onFilterToOnlyNode={onFilterToOnlyNode}
+          onFilterToOthersInSiblings={onFilterToOthersInSiblings}
+          onFilterToOthersInGroup={onFilterToOthersInGroup}
+          onSelectComplement={onSelectComplement}
           onCheckLevel={onCheckLevel}
           onNodeView={onNodeView}
           onNodeSetColor={onNodeSetColor}

--- a/packages/view-types/obs-sets-manager/src/TreeNode.js
+++ b/packages/view-types/obs-sets-manager/src/TreeNode.js
@@ -1,6 +1,6 @@
 /* eslint-disable max-len */
 /* eslint-disable react-refresh/only-export-components */
-import React, { useState } from 'react';
+import React, { useState, useRef, useEffect } from 'react';
 import clsx from 'clsx';
 import RcTreeNode from 'rc-tree/es/TreeNode.js';
 import { getDataAndAria } from 'rc-tree/es/util.js';
@@ -23,6 +23,7 @@ function makeNodeViewMenuConfig(props) {
     level,
     height,
     onCheckNode,
+    onFilterNode,
     onNodeRemove,
     onNodeSetIsEditing,
     onExportLevelZeroNodeJSON,
@@ -32,9 +33,17 @@ function makeNodeViewMenuConfig(props) {
     editable,
     exportable,
     checked,
+    isFilterIncluded = true,
   } = props;
 
   return [
+    ...(onFilterNode ? [
+      {
+        title: (isFilterIncluded ? 'Exclude from filter' : 'Include in filter'),
+        handler: () => { onFilterNode(path, !isFilterIncluded); },
+        handlerKey: 'f',
+      },
+    ] : []),
     ...(editable ? [
       {
         title: 'Rename',
@@ -65,7 +74,9 @@ function makeNodeViewMenuConfig(props) {
       ] : []),
     ] : []),
     ...(level > 0 ? [
-      ...(checkable ? [
+      // A set which does not meet the filtering criteria cannot be checked,
+      // but a set which is already checked can always be un-checked.
+      ...(checkable && (checked || isFilterIncluded) ? [
         {
           title: (checked ? 'Uncheck' : 'Check'),
           handler: () => { onCheckNode(path, !checked); },
@@ -82,6 +93,62 @@ function makeNodeViewMenuConfig(props) {
       ] : []),
     ] : []),
   ];
+}
+
+/**
+ * The checkbox which controls whether a set meets the current
+ * filtering criteria. Distinct from the (square) checkbox which controls
+ * whether a set is selected.
+ * @param {object} props The props for the TreeNode component.
+ */
+function FilterCheckbox(props) {
+  const {
+    path,
+    datatype,
+    isSetFilterActive,
+    isFilterIncluded,
+    isFilterPartiallyIncluded,
+    onFilterNode,
+    disableTooltip,
+  } = props;
+  const inputRef = useRef();
+  // The "partially included" state has no declarative equivalent,
+  // so it must be set on the DOM node imperatively.
+  useEffect(() => {
+    if (inputRef.current) {
+      inputRef.current.indeterminate = Boolean(isFilterPartiallyIncluded);
+    }
+  }, [isFilterPartiallyIncluded]);
+
+  let tooltipText;
+  if (!isSetFilterActive) {
+    tooltipText = `Set-level filtering is inactive, since individual ${datatype} items are currently being filtered. Click to filter by set instead.`;
+  } else if (isFilterIncluded) {
+    tooltipText = 'Exclude this set from the filtering criteria';
+  } else if (isFilterPartiallyIncluded) {
+    tooltipText = 'Some sets below this one are excluded from the filtering criteria. Click to include all of them.';
+  } else {
+    tooltipText = 'Include this set in the filtering criteria';
+  }
+  const tooltipProps = (disableTooltip ? { visible: false } : {});
+
+  const { classes } = useStyles();
+  return (
+    <HelpTooltip title={tooltipText} {...tooltipProps}>
+      <span className={classes.filterCheckboxWrapper}>
+        <input
+          ref={inputRef}
+          className={clsx(classes.filterCheckbox, {
+            [classes.filterCheckboxInactive]: !isSetFilterActive,
+          })}
+          type="checkbox"
+          aria-label={tooltipText}
+          checked={Boolean(isFilterIncluded)}
+          onChange={e => onFilterNode(path, e.target.checked)}
+        />
+      </span>
+    </HelpTooltip>
+  );
 }
 
 /**
@@ -110,7 +177,13 @@ function NamedSetNodeStatic(props) {
     datatype,
     editable,
     theme,
+    onFilterNode,
+    isFilterIncluded = true,
+    isFilterPartiallyIncluded = false,
   } = props;
+  // A set is fully excluded when neither it nor any of its
+  // descendants meet the current filtering criteria.
+  const isFilterExcluded = !isFilterIncluded && !isFilterPartiallyIncluded;
   const shouldCheckNextLevel = (level === 0 && !expanded);
   const nextLevelToCheck = (
     (checkedLevelIndex && isEqual(path, checkedLevelPath) && checkedLevelIndex < height)
@@ -120,7 +193,11 @@ function NamedSetNodeStatic(props) {
   const numberFormatter = new Intl.NumberFormat('en-US');
   const niceSize = numberFormatter.format(size);
   let tooltipText;
-  if (shouldCheckNextLevel) {
+  if (isFilterExcluded) {
+    // Filtered-out sets cannot be selected, so explain that rather than
+    // describing the coloring behavior that is unavailable.
+    tooltipText = 'Excluded by the current filtering criteria, so it cannot be selected. Use the round checkbox to include it again.';
+  } else if (shouldCheckNextLevel) {
     tooltipText = getLevelTooltipText(nextLevelToCheck);
   } else if (isLeaf || !expanded) {
     tooltipText = `Color individual set (${niceSize} ${datatype}${(size === 1 ? '' : 's')})`;
@@ -146,7 +223,10 @@ function NamedSetNodeStatic(props) {
           type="button"
           onClick={onClick}
           onKeyPress={e => callbackOnKeyPress(e, 'v', () => onNodeView(path))}
-          className={classes.titleButton}
+          className={clsx(classes.titleButton, {
+            [classes.titleButtonFilterExcluded]: isFilterExcluded,
+          })}
+          disabled={isFilterExcluded}
         >
           {title}
         </button>
@@ -162,8 +242,17 @@ function NamedSetNodeStatic(props) {
           </span>
         </PopoverMenu>
       ) : null}
+      {onFilterNode ? (<FilterCheckbox {...props} />) : null}
       {level > 0 && isChecking ? checkbox : null}
-      {level > 0 && (<span className={classes.nodeSizeLabel}>{niceSize}</span>)}
+      {level > 0 && (
+        <span
+          className={clsx(classes.nodeSizeLabel, {
+            [classes.nodeSizeLabelFilterExcluded]: isFilterExcluded,
+          })}
+        >
+          {niceSize}
+        </span>
+      )}
     </span>
   );
 }

--- a/packages/view-types/obs-sets-manager/src/TreeNode.js
+++ b/packages/view-types/obs-sets-manager/src/TreeNode.js
@@ -24,6 +24,10 @@ function makeNodeViewMenuConfig(props) {
     height,
     onCheckNode,
     onFilterNode,
+    onFilterToOnlyNode,
+    onFilterToOthersInSiblings,
+    onFilterToOthersInGroup,
+    onSelectComplement,
     onNodeRemove,
     onNodeSetIsEditing,
     onExportLevelZeroNodeJSON,
@@ -42,6 +46,41 @@ function makeNodeViewMenuConfig(props) {
         title: (isFilterIncluded ? 'Exclude from filter' : 'Include in filter'),
         handler: () => { onFilterNode(path, !isFilterIncluded); },
         handlerKey: 'f',
+      },
+    ] : []),
+    ...(onFilterToOnlyNode ? [
+      {
+        title: 'Filter to only this',
+        subtitle: (level === 0 ? '(hierarchy)' : '(set)'),
+        handler: () => { onFilterToOnlyNode(path); },
+        handlerKey: 'o',
+      },
+    ] : []),
+    // "All others" is only meaningful relative to a scope. A level-one node's
+    // immediate siblings are its whole group of sets, so the two scopes
+    // coincide there and only the sibling-scoped option is offered.
+    ...(onFilterToOthersInSiblings && level > 0 ? [
+      {
+        title: 'Filter to all others',
+        subtitle: '(within immediate siblings)',
+        handler: () => { onFilterToOthersInSiblings(path); },
+        handlerKey: 'a',
+      },
+    ] : []),
+    ...(onFilterToOthersInGroup && level > 1 ? [
+      {
+        title: 'Filter to all others',
+        subtitle: '(within this group of sets)',
+        handler: () => { onFilterToOthersInGroup(path); },
+        handlerKey: 'g',
+      },
+    ] : []),
+    ...(onSelectComplement && level > 0 ? [
+      {
+        title: 'Select complement',
+        subtitle: '(within filter-included sets)',
+        handler: () => { onSelectComplement(path); },
+        handlerKey: 'c',
       },
     ] : []),
     ...(editable ? [

--- a/packages/view-types/obs-sets-manager/src/styles.js
+++ b/packages/view-types/obs-sets-manager/src/styles.js
@@ -82,6 +82,46 @@ export const useStyles = makeStyles()(theme => ({
     fontSize: '12px',
     color: theme.palette.primaryForegroundD15,
   },
+  nodeSizeLabelFilterExcluded: {
+    textDecoration: 'line-through',
+    opacity: 0.5,
+  },
+  filterCheckboxWrapper: {
+    display: 'inline-block',
+    verticalAlign: 'middle',
+    lineHeight: 0,
+  },
+  filterCheckbox: {
+    cursor: 'pointer',
+    appearance: 'none',
+    boxSizing: 'border-box',
+    width: '13px',
+    height: '13px',
+    // Important needed due to Jupyter Notebook conflicting styles
+    padding: '0 !important',
+    margin: '0 6px 0 3px',
+    border: `2px solid ${theme.palette.primaryForegroundL10}`,
+    /* A circle, so that the filter checkbox is distinguishable from the
+       (rounded square) selection checkbox rendered next to it. */
+    borderRadius: '50%',
+    backgroundColor: 'transparent',
+    position: 'relative',
+    top: '-1px',
+    float: 'none',
+    '&:checked': {
+      backgroundColor: theme.palette.primaryForegroundL10,
+    },
+    '&:indeterminate': {
+      /* A ring, for the state in which only some of the descendant sets
+         meet the filtering criteria. */
+      backgroundColor: theme.palette.primaryForegroundL10,
+      backgroundClip: 'content-box',
+      padding: '2px !important',
+    },
+  },
+  filterCheckboxInactive: {
+    opacity: 0.45,
+  },
   levelButtonsContainer: {
     height: '20px',
     width: '100%',
@@ -126,6 +166,19 @@ export const useStyles = makeStyles()(theme => ({
     verticalAlign: 'top',
     fontSize: '14px',
     cursor: 'pointer',
+    /* To accomodate the filter checkbox, the selection checkbox,
+       and the node menu button. */
+    maxWidth: 'calc(100% - 68px)',
+    overflow: 'hidden',
+    textOverflow: 'ellipsis',
+  },
+  titleButtonFilterExcluded: {
+    /* Sets which do not meet the filtering criteria are still rendered here,
+       since this control view is where the criteria are edited, but they are
+       struck through to indicate that they cannot be selected. */
+    textDecoration: 'line-through',
+    opacity: 0.5,
+    cursor: 'not-allowed',
   },
   titleButtonWithInput: {
     padding: 0,
@@ -242,8 +295,9 @@ export function SetsManagerTreeGlobalStyles(props) {
         },
         '.rc-tree-treenode .rc-tree-node-content-wrapper > span .title-button': {
           position: 'relative',
-          /* To accomodate the checkbox and node menu button. */
-          maxWidth: 'calc(100% - 45px)',
+          /* To accomodate the filter checkbox, the selection checkbox,
+             and the node menu button. */
+          maxWidth: 'calc(100% - 68px)',
           overflow: 'hidden',
           textOverflow: 'ellipsis',
         },
@@ -312,6 +366,13 @@ export function SetsManagerTreeGlobalStyles(props) {
           borderLeft: '0',
           transform: 'scale(1)',
           content: "' '",
+        },
+        /* The selection checkbox is disabled for any set which does not meet
+           the current filtering criteria, since the selection must not be a
+           superset of the filter. */
+        '.rc-tree-treenode span.rc-tree-checkbox.rc-tree-checkbox-disabled': {
+          cursor: 'not-allowed',
+          opacity: '0.35',
         },
         '.rc-tree:not(.rc-tree-show-line) .rc-treenode .rc-tree-switcher-noop': {
           background: 'none',

--- a/packages/view-types/statistical-plots/src/Treemap.js
+++ b/packages/view-types/statistical-plots/src/Treemap.js
@@ -5,8 +5,18 @@ import { select } from 'd3-selection';
 import { treemap, treemapBinary, hierarchy as d3_hierarchy } from 'd3-hierarchy';
 import { rollup as d3_rollup } from 'd3-array';
 import { isEqual } from 'lodash-es';
-import { pluralize as plur } from '@vitessce/utils';
+import { colorArrayToString } from '@vitessce/sets-utils';
+import { pluralize as plur, getDefaultColor } from '@vitessce/utils';
 import { getColorScale } from './utils.js';
+
+// Rectangles which meet the selection criteria are emphasized,
+// while those which are filter-included but un-selected are
+// still rendered, but de-emphasized.
+const SELECTED_FILL_OPACITY = 0.8;
+const UNSELECTED_FILL_OPACITY = 0.3;
+const SELECTED_TEXT_OPACITY = 1.0;
+const UNSELECTED_TEXT_OPACITY = 0.5;
+const HIGHLIGHT_STROKE_WIDTH = 2;
 
 // Based on Observable's built-in DOM.uid function.
 // This is intended to be used with SVG clipPaths
@@ -41,33 +51,38 @@ export default function Treemap(props) {
     sampleType,
     obsSetColor,
     sampleSetColor,
-    obsSetSelection,
-    sampleSetSelection,
+    // The set paths which meet the filtering criteria.
+    obsSetPaths,
+    sampleSetPaths,
+    // The set paths which are currently highlighted, if any.
+    highlightedObsSetPath,
+    highlightedSampleSetPath,
     marginTop = 5,
     marginRight = 5,
     marginLeft = 80,
     marginBottom,
     onNodeClick,
+    onNodeHighlight,
   } = props;
 
   const hierarchyData = useMemo(() => {
     // Support both sampleSet->obsSet and
     // obsSet->sampleSet hierarchy modes
-    if (!obsCounts) {
+    if (!obsCounts || obsCounts.length === 0) {
       return null;
     }
     let map;
     if (isEqual(hierarchyLevels, ['sampleSet', 'obsSet'])) {
       map = d3_rollup(
         obsCounts,
-        D => D[0].value,
+        D => D[0],
         d => d.sampleSetPath,
         d => d.obsSetPath,
       );
     } else if (isEqual(hierarchyLevels, ['obsSet', 'sampleSet'])) {
       map = d3_rollup(
         obsCounts,
-        D => D[0].value,
+        D => D[0],
         d => d.obsSetPath,
         d => d.sampleSetPath,
       );
@@ -77,12 +92,28 @@ export default function Treemap(props) {
     return d3_hierarchy(map);
   }, [obsCounts, hierarchyLevels]);
 
+  // The leaf node key corresponds to the second hierarchy level,
+  // and the parent node key corresponds to the first hierarchy level.
+  const [getObsSetPath, getSampleSetPath] = useMemo(() => {
+    const isObsSetPrimary = hierarchyLevels[0] === 'obsSet';
+    return [
+      d => (isObsSetPrimary ? d.parent?.data?.[0] : d.data?.[0]),
+      d => (isObsSetPrimary ? d.data?.[0] : d.parent?.data?.[0]),
+    ];
+  }, [hierarchyLevels]);
+
+  // Sets which meet the filtering criteria still need colors,
+  // even when they are un-selected, so the color scale domains
+  // are the filter-included set paths.
   const [obsSetColorScale, sampleSetColorScale] = useMemo(() => [
-      getColorScale(obsSetSelection, obsSetColor, theme),
-      getColorScale(sampleSetSelection, sampleSetColor, theme),
-    ], [obsSetSelection, sampleSetSelection, sampleSetColor, obsSetColor, theme]);
+      getColorScale(obsSetPaths, obsSetColor, theme),
+      getColorScale(sampleSetPaths, sampleSetColor, theme),
+    ], [obsSetPaths, sampleSetPaths, sampleSetColor, obsSetColor, theme]);
 
   const treemapLeaves = useMemo(() => {
+    if (!hierarchyData) {
+      return null;
+    }
     const treemapFunc = treemap()
       .tile(treemapBinary)
       .size([width, height])
@@ -91,17 +122,22 @@ export default function Treemap(props) {
 
     // When d3.hierarchy is passed a Map object,
     // the nodes are represented like [key, value] tuples.
-    // So in `.sum` and `.sort` below,
-    // `d[1]` accesses the value (i.e., cell count).
+    // So in `.sum` below, `d[1]` accesses the value
+    // (i.e., the object containing the observation count).
     // Reference: https://d3js.org/d3-hierarchy/hierarchy#hierarchy
     const treemapLayout = treemapFunc(hierarchyData
-      .sum(d => d[1])
-      .sort((a, b) => b[1] - a[1]));
+      .sum(d => d[1]?.value || 0)
+      // Note: unlike `.sum`, `.sort` receives nodes rather than node data,
+      // and `.sum` has already run, so `node.value` is available here.
+      .sort((a, b) => b.value - a.value));
     return treemapLayout.leaves();
   }, [hierarchyData, width, height]);
 
   const svgRef = useRef();
 
+  // Render the treemap. Note that highlighting is intentionally _not_
+  // handled here, so that hovering does not cause the elements
+  // being hovered to be removed and re-created.
   useEffect(() => {
     const domElement = svgRef.current;
 
@@ -117,9 +153,14 @@ export default function Treemap(props) {
       .attr('viewBox', [0, 0, width, height])
       .attr('style', 'font: 10px sans-serif');
 
-    if (!treemapLeaves || !obsSetSelection) {
+    // Note: when no filtering criteria are in effect, there is a single
+    // rectangle representing all of the observations, since "no criteria"
+    // means that every observation is included.
+    if (!treemapLeaves) {
       return;
     }
+
+    const getIsSelected = d => Boolean(d.data?.[1]?.isSelected);
 
     // Add a group for each leaf of the hierarchy.
     const leaf = svg.selectAll('g')
@@ -130,10 +171,15 @@ export default function Treemap(props) {
     // Append a tooltip.
     leaf.append('title')
         .text((d) => {
-          const cellCount = d.data?.[1];
-          const primaryPathString = JSON.stringify(d.data[0]);
-          const secondaryPathString = JSON.stringify(d.parent.data[0]);
-          return `${cellCount.toLocaleString()} ${plur(obsType, cellCount)} in ${primaryPathString} and ${secondaryPathString}`;
+          const obsCount = d.data?.[1]?.value || 0;
+          const setPathStrings = [getObsSetPath(d), getSampleSetPath(d)]
+            .filter(Boolean)
+            .map(setPath => JSON.stringify(setPath));
+          const inClause = setPathStrings.length > 0
+            ? ` in ${setPathStrings.join(' and ')}`
+            : '';
+          const selectionClause = getIsSelected(d) ? '' : ' (not selected)';
+          return `${obsCount.toLocaleString()} ${plur(obsType, obsCount)}${inClause}${selectionClause}`;
         });
 
     const getLeafUid = uidGenerator('leaf');
@@ -142,12 +188,13 @@ export default function Treemap(props) {
     const colorScale = obsColorEncoding === 'sampleSetSelection'
       ? sampleSetColorScale
       : obsSetColorScale;
-    const getPathForColoring = d => (
-      // eslint-disable-next-line no-nested-ternary
-      obsColorEncoding === 'sampleSetSelection'
-        ? (hierarchyLevels[0] === 'obsSet' ? d.data?.[0] : d.parent?.data?.[0])
-        : (hierarchyLevels[0] === 'sampleSet' ? d.data?.[0] : d.parent?.data?.[0])
-    );
+    const getPathForColoring = obsColorEncoding === 'sampleSetSelection'
+      ? getSampleSetPath
+      : getObsSetPath;
+
+    // De-emphasized rectangles use the theme's default (gray) color.
+    const deemphasizedColor = colorArrayToString(getDefaultColor(theme));
+    const highlightColor = (theme === 'dark' ? 'white' : 'black');
 
     // Append a color rectangle for each leaf.
     leaf.append('rect')
@@ -156,16 +203,28 @@ export default function Treemap(props) {
           d.leafUid = getLeafUid();
           return d.leafUid.id;
         })
-        .attr('fill', d => colorScale(getPathForColoring(d)))
-        .attr('fill-opacity', 0.8)
+        .attr('cursor', 'pointer')
+        .attr('fill', d => (getIsSelected(d)
+          ? (colorScale(getPathForColoring(d)) || deemphasizedColor)
+          : deemphasizedColor
+        ))
+        .attr('fill-opacity', d => (getIsSelected(d)
+          ? SELECTED_FILL_OPACITY
+          : UNSELECTED_FILL_OPACITY
+        ))
+        // The stroke width is set by the highlighting effect below.
+        .attr('stroke', highlightColor)
+        .attr('stroke-width', 0)
         .attr('width', d => d.x1 - d.x0)
         .attr('height', d => d.y1 - d.y0)
         .on('click', (e, d) => {
-          const obsSetPath = (hierarchyLevels[0] === 'obsSet'
-            ? d.parent?.data?.[0]
-            : d.data?.[0]
-          );
-          onNodeClick(obsSetPath);
+          onNodeClick(getObsSetPath(d));
+        })
+        .on('mouseenter', (e, d) => {
+          onNodeHighlight(getObsSetPath(d));
+        })
+        .on('mouseleave', () => {
+          onNodeHighlight(null);
         });
 
     // Append a clipPath to ensure text does not overflow.
@@ -178,39 +237,59 @@ export default function Treemap(props) {
       .append('use')
         .attr('xlink:href', d => d.leafUid.href);
 
-    const hasSampleSetSelection = Array.isArray(sampleSetSelection);
-
     // Append multiline text.
     leaf.append('text')
         .attr('clip-path', d => `url(${d.clipUid.href})`)
+        .attr('fill-opacity', d => (getIsSelected(d)
+          ? SELECTED_TEXT_OPACITY
+          : UNSELECTED_TEXT_OPACITY
+        ))
       .selectAll('tspan')
-      .data(d => ([
-        // Each element in this array corresponds to a line of text.
-        ...(
-          hasSampleSetSelection
-          ? ([
-            d.data?.[0]?.at(-1),
-            d.parent?.data?.[0]?.at(-1),
-          ]) : ([
-            // Only use the cell set name
-            // for the line of text
-            // (since no sample set selection)
-            hierarchyLevels[0] === 'obsSet'
-              ? d.parent?.data?.[0].at(-1)
-              : d.data?.[0].at(-1),
-          ])
-        ),
-        `${d.data?.[1].toLocaleString()} ${plur(obsType, d.data?.[1])}`,
-      ]))
+      // Each element in this array corresponds to a line of text,
+      // ordered from the primary to the secondary hierarchy level.
+      // Null set names (i.e., when there are no obsSets or sampleSets
+      // to partition by) are omitted.
+      .data((d) => {
+        const obsCount = d.data?.[1]?.value || 0;
+        return [
+          ...(hierarchyLevels[0] === 'obsSet'
+            ? [getSampleSetPath(d)?.at(-1), getObsSetPath(d)?.at(-1)]
+            : [getObsSetPath(d)?.at(-1), getSampleSetPath(d)?.at(-1)]
+          ),
+          `${obsCount.toLocaleString()} ${plur(obsType, obsCount)}`,
+        ].filter(Boolean);
+      })
       .join('tspan')
         .attr('x', 3)
         // eslint-disable-next-line no-unused-vars
         .attr('y', (d, i, nodes) => `${(i === nodes.length - 1) * 0.3 + 1.1 + i * 0.9}em`)
         .text(d => d);
   }, [width, height, marginLeft, marginBottom, theme, marginTop, marginRight,
-    obsType, sampleType, treemapLeaves, sampleSetColor, sampleSetSelection,
-    obsSetSelection, obsSetColor, obsSetColorScale, sampleSetColorScale,
-    obsColorEncoding, hierarchyLevels, onNodeClick,
+    obsType, sampleType, treemapLeaves, sampleSetColor, sampleSetPaths,
+    obsSetPaths, obsSetColor, obsSetColorScale, sampleSetColorScale,
+    obsColorEncoding, hierarchyLevels, onNodeClick, onNodeHighlight,
+    getObsSetPath, getSampleSetPath,
+  ]);
+
+  // Highlighting: outline the rectangles which correspond to the
+  // highlighted set(s). This runs after the rendering effect above,
+  // so it also applies to newly-created rectangles.
+  useEffect(() => {
+    const domElement = svgRef.current;
+    if (!domElement) {
+      return;
+    }
+    // A leaf is highlighted when it matches every non-null highlighted path.
+    const getIsHighlighted = d => Boolean(
+      (highlightedObsSetPath || highlightedSampleSetPath)
+      && (!highlightedObsSetPath || isEqual(highlightedObsSetPath, getObsSetPath(d)))
+      && (!highlightedSampleSetPath || isEqual(highlightedSampleSetPath, getSampleSetPath(d))),
+    );
+    select(domElement)
+      .selectAll('g rect')
+        .attr('stroke-width', d => (getIsHighlighted(d) ? HIGHLIGHT_STROKE_WIDTH : 0));
+  }, [highlightedObsSetPath, highlightedSampleSetPath,
+    getObsSetPath, getSampleSetPath, treemapLeaves,
   ]);
 
   return (

--- a/packages/view-types/statistical-plots/src/TreemapSubscriber.js
+++ b/packages/view-types/statistical-plots/src/TreemapSubscriber.js
@@ -118,6 +118,85 @@ function useFilteredSetPaths(mergedSets, setFilter, setSelection, isIdFilterMode
   }, [mergedSets, setFilter, setSelection, isIdFilterMode]);
 }
 
+/**
+ * Group set paths by the hierarchy (i.e., the level-zero node) they belong to.
+ * @param {string[][]|null} setPaths Array of set paths.
+ * @returns {Map<string,string[][]>|null} Map from hierarchy name to the set
+ * paths within that hierarchy, or null if there are no usable paths.
+ */
+function groupSetPathsByHierarchy(setPaths) {
+  if (!Array.isArray(setPaths) || setPaths.length === 0) {
+    return null;
+  }
+  const result = new Map();
+  setPaths.forEach((setPath) => {
+    if (!Array.isArray(setPath) || setPath.length === 0) {
+      return;
+    }
+    const hierarchyName = setPath[0];
+    if (!result.has(hierarchyName)) {
+      result.set(hierarchyName, []);
+    }
+    result.get(hierarchyName).push(setPath);
+  });
+  return result.size > 0 ? result : null;
+}
+
+/**
+ * Split the filter-included set paths into the paths which partition the
+ * treemap and the paths which only constrain which items are included.
+ *
+ * Hierarchies overlap with each other: an observation or sample belongs to one
+ * set per hierarchy, so the paths of two hierarchies cannot be combined into a
+ * single categorical partition (each item would fall into more than one
+ * rectangle). The treemap therefore partitions by one hierarchy at a time --
+ * the hierarchy which the current selection is within, when possible -- and
+ * treats the paths of every other hierarchy as an additional criterion which
+ * each item must also meet.
+ * @param {string[][]|null} filteredSetPaths The set paths which meet the
+ * filtering criteria.
+ * @param {string[][]|null} setSelection Value of obsSetSelection
+ * or sampleSetSelection.
+ * @returns {array} Tuple of [partitioningSetPaths, constrainingSetPathsArr],
+ * where partitioningSetPaths is null if no set-level criteria are in effect,
+ * and constrainingSetPathsArr contains one array of set paths per
+ * remaining hierarchy.
+ */
+function usePartitionedSetPaths(filteredSetPaths, setSelection) {
+  return useMemo(() => {
+    const pathsByHierarchy = groupSetPathsByHierarchy(filteredSetPaths);
+    if (!pathsByHierarchy) {
+      return [null, []];
+    }
+    const hierarchyNames = Array.from(pathsByHierarchy.keys());
+    const selectedHierarchyName = (Array.isArray(setSelection)
+      ? setSelection.map(setPath => setPath?.[0]).find(name => pathsByHierarchy.has(name))
+      : null);
+    const partitioningName = selectedHierarchyName || hierarchyNames[0];
+    return [
+      pathsByHierarchy.get(partitioningName),
+      hierarchyNames
+        .filter(name => name !== partitioningName)
+        .map(name => pathsByHierarchy.get(name)),
+    ];
+  }, [filteredSetPaths, setSelection]);
+}
+
+/**
+ * Build one item ID to set path map per hierarchy, to be used for checking
+ * whether an item meets the criteria expressed by that hierarchy's set paths.
+ * @param {object} mergedSets A merged sets tree object.
+ * @param {string[][][]} setPathsArr One array of set paths per hierarchy.
+ * @returns {Map<string,string[]>[]} One map per hierarchy.
+ */
+function useConstraintMaps(mergedSets, setPathsArr) {
+  return useMemo(() => (
+    mergedSets
+      ? setPathsArr.map(setPaths => treeToSelectedSetMap(mergedSets, setPaths))
+      : []
+  ), [mergedSets, setPathsArr]);
+}
+
 export function TreemapSubscriber(props) {
   const {
     coordinationScopes: coordinationScopesRaw,
@@ -266,27 +345,41 @@ export function TreemapSubscriber(props) {
     sampleFilterMode === 'sampleFilter',
   );
 
+  // The filtering criteria may span multiple hierarchies, but only one
+  // hierarchy per axis can define the categorical partitioning of the treemap.
+  const [partitionObsSetPaths, constrainingObsSetPaths] = usePartitionedSetPaths(
+    filteredObsSetPaths, obsSetSelection,
+  );
+  const [partitionSampleSetPaths, constrainingSampleSetPaths] = usePartitionedSetPaths(
+    filteredSampleSetPaths, sampleSetSelection,
+  );
+
   // Filtering: determine which individual observations/samples
   // are considered at all (when the ID-list mode is active).
   const filteredObsIds = useIdSet(obsFilter, obsFilterMode === 'obsFilter');
   const filteredSampleIds = useIdSet(sampleFilter, sampleFilterMode === 'sampleFilter');
 
   const [obsIdToSetMap, sampleIdToSetMap] = useMemo(() => ([
-    mergedObsSets && filteredObsSetPaths
-      ? treeToSelectedSetMap(mergedObsSets, filteredObsSetPaths)
+    mergedObsSets && partitionObsSetPaths
+      ? treeToSelectedSetMap(mergedObsSets, partitionObsSetPaths)
       : null,
-    mergedSampleSets && filteredSampleSetPaths
-      ? treeToSelectedSetMap(mergedSampleSets, filteredSampleSetPaths)
+    mergedSampleSets && partitionSampleSetPaths
+      ? treeToSelectedSetMap(mergedSampleSets, partitionSampleSetPaths)
       : null,
-  ]), [mergedObsSets, mergedSampleSets, filteredObsSetPaths, filteredSampleSetPaths]);
+  ]), [mergedObsSets, mergedSampleSets, partitionObsSetPaths, partitionSampleSetPaths]);
+
+  // Filtering: the criteria expressed by the hierarchies which do not
+  // partition the treemap still have to be met.
+  const obsSetConstraintMaps = useConstraintMaps(mergedObsSets, constrainingObsSetPaths);
+  const sampleSetConstraintMaps = useConstraintMaps(mergedSampleSets, constrainingSampleSetPaths);
 
   // Compute the number of observations per (obsSet, sampleSet) pair,
   // considering only those observations which meet the filtering criteria.
   const [obsCountsWithoutSelection, filteredSampleCount] = useMemo(() => {
     const obsResult = new InternMap([], JSON.stringify);
 
-    const obsSetKeys = filteredObsSetPaths || [null];
-    const sampleSetKeys = filteredSampleSetPaths || [null];
+    const obsSetKeys = partitionObsSetPaths || [null];
+    const sampleSetKeys = partitionSampleSetPaths || [null];
 
     // First level: cell set
     obsSetKeys.forEach((obsSetPath) => {
@@ -303,20 +396,26 @@ export function TreemapSubscriber(props) {
         const obsId = obsIndex[i];
         const sampleId = sampleEdges?.get(obsId);
 
-        const obsSetPath = filteredObsSetPaths ? obsIdToSetMap?.get(obsId) : null;
-        const sampleSetPath = (sampleId && filteredSampleSetPaths)
+        const obsSetPath = partitionObsSetPaths ? obsIdToSetMap?.get(obsId) : null;
+        const sampleSetPath = (sampleId && partitionSampleSetPaths)
           ? sampleIdToSetMap?.get(sampleId)
           : null;
 
         const meetsFilterCriteria = (
           // The observation itself is included.
           (!filteredObsIds || filteredObsIds.has(obsId))
-          // The observation is in one of the included obsSets.
-          && (!filteredObsSetPaths || Boolean(obsSetPath))
+          // The observation is in one of the included obsSets
+          // of the partitioning hierarchy, and of every other hierarchy
+          // which the filtering criteria constrain.
+          && (!partitionObsSetPaths || Boolean(obsSetPath))
+          && obsSetConstraintMaps.every(idToSetMap => idToSetMap.has(obsId))
           // The observation's sample is included.
           && (!filteredSampleIds || (sampleId && filteredSampleIds.has(sampleId)))
           // The observation's sample is in one of the included sampleSets.
-          && (!filteredSampleSetPaths || Boolean(sampleSetPath))
+          && (!partitionSampleSetPaths || Boolean(sampleSetPath))
+          && (!sampleId || sampleSetConstraintMaps.every(
+            idToSetMap => idToSetMap.has(sampleId),
+          ))
         );
 
         if (meetsFilterCriteria) {
@@ -334,7 +433,8 @@ export function TreemapSubscriber(props) {
         const sampleId = sampleIndex[i];
         const meetsFilterCriteria = (
           (!filteredSampleIds || filteredSampleIds.has(sampleId))
-          && (!filteredSampleSetPaths || Boolean(sampleIdToSetMap?.get(sampleId)))
+          && (!partitionSampleSetPaths || Boolean(sampleIdToSetMap?.get(sampleId)))
+          && sampleSetConstraintMaps.every(idToSetMap => idToSetMap.has(sampleId))
         );
         if (meetsFilterCriteria) {
           sampleCount += 1;
@@ -347,7 +447,8 @@ export function TreemapSubscriber(props) {
       sampleCount,
     ];
   }, [obsIndex, sampleIndex, sampleEdges, obsIdToSetMap, sampleIdToSetMap,
-    filteredObsSetPaths, filteredSampleSetPaths, filteredObsIds, filteredSampleIds,
+    partitionObsSetPaths, partitionSampleSetPaths, filteredObsIds, filteredSampleIds,
+    obsSetConstraintMaps, sampleSetConstraintMaps,
   ]);
 
   // Selection: determine which of the sets that meet the filtering
@@ -474,8 +575,8 @@ export function TreemapSubscriber(props) {
           sampleType={sampleType}
           obsSetColor={obsSetColor}
           sampleSetColor={sampleSetColor}
-          obsSetPaths={filteredObsSetPaths}
-          sampleSetPaths={filteredSampleSetPaths}
+          obsSetPaths={partitionObsSetPaths}
+          sampleSetPaths={partitionSampleSetPaths}
           highlightedObsSetPath={highlightedObsSetPath}
           highlightedSampleSetPath={highlightedSampleSetPath}
           onNodeClick={onNodeClick}

--- a/packages/view-types/statistical-plots/src/TreemapSubscriber.js
+++ b/packages/view-types/statistical-plots/src/TreemapSubscriber.js
@@ -14,15 +14,109 @@ import {
   useCoordinationScopes,
 } from '@vitessce/vit-s';
 import { ViewType, COMPONENT_COORDINATION_TYPES, ViewHelpMapping } from '@vitessce/constants-internal';
-import { treeToSelectedSetMap, treeToSetSizesBySetNames, mergeObsSets } from '@vitessce/sets-utils';
+import {
+  treeToSelectedSetMap, mergeObsSets, treeFindNodeByNamePath, isEqualOrPrefix,
+} from '@vitessce/sets-utils';
 import { pluralize as plur, commaNumber, unnestMap, capitalize } from '@vitessce/utils';
 import { InternMap } from 'internmap';
-import { isEqual } from 'lodash-es';
 import Treemap from './Treemap.js';
 import { useStyles } from './styles.js';
 import TreemapOptions from './TreemapOptions.js';
 
 const DEFAULT_HIERARCHY_LEVELS = ['obsSet', 'sampleSet'];
+
+// Set paths are arrays of strings, so they must be serialized
+// before being used as Set/Map keys.
+const pathKey = path => JSON.stringify(path);
+
+/**
+ * Convert a list of observation/sample IDs to a Set for O(1) lookups,
+ * but only when the corresponding behavior-modifier coordination
+ * value indicates that the ID list should be used.
+ * @param {string[]|null} ids Value of obsFilter or sampleFilter.
+ * @param {boolean} isActive Whether the ID list is the active criteria.
+ * @returns {Set<string>|null} Set of IDs, or null if unconstrained.
+ */
+function useIdSet(ids, isActive) {
+  return useMemo(() => (
+    isActive && Array.isArray(ids) && ids.length > 0
+      ? new Set(ids)
+      : null
+  ), [ids, isActive]);
+}
+
+/**
+ * Determine the sibling sets of each of the provided set paths, i.e., the sets
+ * which share a parent with (and therefore sit at the same hierarchy level as)
+ * one of the provided set paths. Used to expand a selection into the full list
+ * of sets that the selection could have been made from.
+ *
+ * Paths at different levels of the same hierarchy each expand at their own
+ * corresponding level. Any resulting path which is an ancestor of another
+ * resulting path is then discarded, since the two would otherwise overlap.
+ *
+ * Note that a level-zero (hierarchy root) path is returned as-is, since
+ * hierarchies overlap with each other: an observation or sample belongs to one
+ * set per hierarchy, so expanding to sibling hierarchies would double-count.
+ * @param {object} mergedSets A merged sets tree object.
+ * @param {string[][]|null} setPaths Array of set paths, such as obsSetSelection.
+ * @returns {string[][]|null} Array of set paths, or null if none could be determined.
+ */
+function getSiblingSetPaths(mergedSets, setPaths) {
+  if (!mergedSets?.tree || !Array.isArray(setPaths) || setPaths.length === 0) {
+    return null;
+  }
+  const result = [];
+  const resultKeys = new Set();
+  function appendPath(setPath) {
+    if (!resultKeys.has(pathKey(setPath))) {
+      resultKeys.add(pathKey(setPath));
+      result.push(setPath);
+    }
+  }
+  setPaths.forEach((setPath) => {
+    if (!Array.isArray(setPath) || setPath.length === 0) {
+      return;
+    }
+    const parentPath = setPath.slice(0, -1);
+    const parentNode = parentPath.length > 0
+      ? treeFindNodeByNamePath(mergedSets, parentPath)
+      : null;
+    if (parentNode?.children) {
+      parentNode.children.forEach(child => appendPath([...parentPath, child.name]));
+    } else {
+      // Level-zero paths, and paths whose parent cannot be resolved
+      // (for example while the sets are still loading), are used as-is.
+      appendPath(setPath);
+    }
+  });
+  // Discard the ancestors of other resulting paths, to avoid overlap.
+  const nonOverlappingResult = result.filter(setPath => !result.some(
+    otherPath => otherPath.length > setPath.length && isEqualOrPrefix(setPath, otherPath),
+  ));
+  return nonOverlappingResult.length > 0 ? nonOverlappingResult : null;
+}
+
+/**
+ * Determine which set paths meet the current filtering criteria.
+ * @param {object} mergedSets A merged sets tree object.
+ * @param {string[][]|null} setFilter Value of obsSetFilter or sampleSetFilter.
+ * @param {string[][]|null} setSelection Value of obsSetSelection or sampleSetSelection.
+ * @param {boolean} isIdFilterMode Whether the ID-list filtering mode is active,
+ * in which case the set-level filter does not apply.
+ * @returns {string[][]|null} Array of set paths, or null if none could be determined.
+ */
+function useFilteredSetPaths(mergedSets, setFilter, setSelection, isIdFilterMode) {
+  return useMemo(() => {
+    if (!isIdFilterMode && Array.isArray(setFilter) && setFilter.length > 0) {
+      return setFilter;
+    }
+    // Without a set-level filter, no set-level filtering criteria are in
+    // effect, so every set is included. The un-selected sets are still
+    // rendered as (de-emphasized) nodes rather than being omitted.
+    return getSiblingSetPaths(mergedSets, setSelection);
+  }, [mergedSets, setFilter, setSelection, isIdFilterMode]);
+}
 
 export function TreemapSubscriber(props) {
   const {
@@ -43,6 +137,7 @@ export function TreemapSubscriber(props) {
     featureType,
     featureValueType,
     obsFilter,
+    obsFilterMode,
     obsHighlight,
     obsSetSelection,
     obsSetFilter,
@@ -70,6 +165,7 @@ export function TreemapSubscriber(props) {
     setObsSelectionMode,
     setObsFilterMode,
     setObsHighlight,
+    setObsSetHighlight,
     setObsSetColor,
     setObsColorEncoding,
     setAdditionalObsSets,
@@ -86,6 +182,8 @@ export function TreemapSubscriber(props) {
     COMPONENT_COORDINATION_TYPES[ViewType.TREEMAP],
     coordinationScopes,
   );
+
+  console.log(sampleSetFilter, sampleSetSelection);
 
   const [width, height, containerRef] = useGridItemSize();
 
@@ -156,97 +254,193 @@ export function TreemapSubscriber(props) {
     [sampleSets],
   );
 
-  // TODO: use obsFilter / sampleFilter to display
-  // _all_ cells/samples in gray / transparent in background,
-  // and use obsSetSelection/sampleSetSelection to display
-  // the _selected_ samples in color in the foreground.
-  const [obsCounts, sampleCounts] = useMemo(() => {
+  // Filtering: determine which sets are considered at all.
+  // These sets define the categorical partitioning of the treemap,
+  // so sets which do not meet the filtering criteria are not rendered.
+  // When there is no set-level filter, every set is included, so the
+  // un-selected sets are still rendered as (de-emphasized) nodes,
+  // broken down by the sets of the other hierarchy level.
+  const filteredObsSetPaths = useFilteredSetPaths(
+    mergedObsSets, obsSetFilter, obsSetSelection, obsFilterMode === 'obsFilter',
+  );
+  const filteredSampleSetPaths = useFilteredSetPaths(
+    mergedSampleSets, sampleSetFilter, sampleSetSelection,
+    sampleFilterMode === 'sampleFilter',
+  );
+
+  // Filtering: determine which individual observations/samples
+  // are considered at all (when the ID-list mode is active).
+  const filteredObsIds = useIdSet(obsFilter, obsFilterMode === 'obsFilter');
+  const filteredSampleIds = useIdSet(sampleFilter, sampleFilterMode === 'sampleFilter');
+
+  const [obsIdToSetMap, sampleIdToSetMap] = useMemo(() => ([
+    mergedObsSets && filteredObsSetPaths
+      ? treeToSelectedSetMap(mergedObsSets, filteredObsSetPaths)
+      : null,
+    mergedSampleSets && filteredSampleSetPaths
+      ? treeToSelectedSetMap(mergedSampleSets, filteredSampleSetPaths)
+      : null,
+  ]), [mergedObsSets, mergedSampleSets, filteredObsSetPaths, filteredSampleSetPaths]);
+
+  // Compute the number of observations per (obsSet, sampleSet) pair,
+  // considering only those observations which meet the filtering criteria.
+  const [obsCountsWithoutSelection, filteredSampleCount] = useMemo(() => {
     const obsResult = new InternMap([], JSON.stringify);
-    const sampleResult = new InternMap([], JSON.stringify);
 
-    const hasSampleSetSelection = (
-      Array.isArray(sampleSetSelection)
-      && sampleSetSelection.length > 0
-    );
-    const hasCellSetSelection = (
-      Array.isArray(obsSetSelection)
-      && obsSetSelection.length > 0
-    );
-
-    const sampleSetKeys = hasSampleSetSelection ? sampleSetSelection : [null];
-    const cellSetKeys = hasCellSetSelection ? obsSetSelection : [null];
+    const obsSetKeys = filteredObsSetPaths || [null];
+    const sampleSetKeys = filteredSampleSetPaths || [null];
 
     // First level: cell set
-    cellSetKeys.forEach((cellSetKey) => {
-      obsResult.set(cellSetKey, new InternMap([], JSON.stringify));
+    obsSetKeys.forEach((obsSetPath) => {
+      const innerResult = new InternMap([], JSON.stringify);
       // Second level: sample set
-      sampleSetKeys.forEach((sampleSetKey) => {
-        obsResult.get(cellSetKey).set(sampleSetKey, 0);
+      sampleSetKeys.forEach((sampleSetPath) => {
+        innerResult.set(sampleSetPath, 0);
       });
+      obsResult.set(obsSetPath, innerResult);
     });
 
-    const sampleSetSizes = hasSampleSetSelection ? treeToSetSizesBySetNames(
-      mergedSampleSets, sampleSetSelection, sampleSetSelection, sampleSetColor, theme,
-    ) : null;
-
-    sampleSetKeys.forEach((sampleSetKey) => {
-      const sampleSetSize = sampleSetSizes?.find(d => isEqual(d.setNamePath, sampleSetKey))?.size;
-      sampleResult.set(sampleSetKey, sampleSetSize || 0);
-    });
-
-    if (mergedObsSets && obsSetSelection && obsIndex) {
-      const sampleIdToSetMap = sampleSets && sampleSetSelection
-        ? treeToSelectedSetMap(sampleSets, sampleSetSelection)
-        : null;
-      const cellIdToSetMap = treeToSelectedSetMap(mergedObsSets, obsSetSelection);
-
+    if (obsIndex) {
       for (let i = 0; i < obsIndex.length; i += 1) {
         const obsId = obsIndex[i];
-
-        const cellSet = cellIdToSetMap?.get(obsId);
         const sampleId = sampleEdges?.get(obsId);
-        const sampleSet = sampleId && hasSampleSetSelection
+
+        const obsSetPath = filteredObsSetPaths ? obsIdToSetMap?.get(obsId) : null;
+        const sampleSetPath = (sampleId && filteredSampleSetPaths)
           ? sampleIdToSetMap?.get(sampleId)
           : null;
 
-        if (hasSampleSetSelection && !sampleSet) {
-          // Skip this sample if it is not in the selected sample set.
-          // eslint-disable-next-line no-continue
-          continue;
+        const meetsFilterCriteria = (
+          // The observation itself is included.
+          (!filteredObsIds || filteredObsIds.has(obsId))
+          // The observation is in one of the included obsSets.
+          && (!filteredObsSetPaths || Boolean(obsSetPath))
+          // The observation's sample is included.
+          && (!filteredSampleIds || (sampleId && filteredSampleIds.has(sampleId)))
+          // The observation's sample is in one of the included sampleSets.
+          && (!filteredSampleSetPaths || Boolean(sampleSetPath))
+        );
+
+        if (meetsFilterCriteria) {
+          const innerResult = obsResult.get(obsSetPath);
+          if (innerResult) {
+            innerResult.set(sampleSetPath, (innerResult.get(sampleSetPath) ?? 0) + 1);
+          }
         }
-        const prevObsCount = obsResult.get(cellSet)?.get(sampleSet);
-        obsResult.get(cellSet)?.set(sampleSet, prevObsCount + 1);
+      }
+    }
+
+    let sampleCount = 0;
+    if (sampleIndex) {
+      for (let i = 0; i < sampleIndex.length; i += 1) {
+        const sampleId = sampleIndex[i];
+        const meetsFilterCriteria = (
+          (!filteredSampleIds || filteredSampleIds.has(sampleId))
+          && (!filteredSampleSetPaths || Boolean(sampleIdToSetMap?.get(sampleId)))
+        );
+        if (meetsFilterCriteria) {
+          sampleCount += 1;
+        }
       }
     }
 
     return [
       unnestMap(obsResult, ['obsSetPath', 'sampleSetPath', 'value']),
-      unnestMap(sampleResult, ['sampleSetPath', 'value']),
+      sampleCount,
     ];
-  }, [obsIndex, sampleEdges, sampleSets, obsSetColor,
-    sampleSetColor, mergedObsSets, obsSetSelection, mergedSampleSets,
-    sampleSetSelection, obsIndex,
-    // TODO: consider filtering-related coordination values
+  }, [obsIndex, sampleIndex, sampleEdges, obsIdToSetMap, sampleIdToSetMap,
+    filteredObsSetPaths, filteredSampleSetPaths, filteredObsIds, filteredSampleIds,
+  ]);
+
+  // Selection: determine which of the sets that meet the filtering
+  // criteria should be visually emphasized. A null value means that
+  // there is no selection, so everything is emphasized.
+  const selectedObsSetKeys = useMemo(() => {
+    if (obsSelectionMode === 'obsSelection') {
+      // The selection is defined per-observation. Since the treemap renders
+      // sets rather than individual observations, resolve the selected
+      // observations to the sets which contain them.
+      if (!Array.isArray(obsSelection) || obsSelection.length === 0 || !obsIdToSetMap) {
+        return null;
+      }
+      return new Set(obsSelection
+        .map(obsId => obsIdToSetMap.get(obsId))
+        .filter(Boolean)
+        .map(pathKey));
+    }
+    if (Array.isArray(obsSetSelection) && obsSetSelection.length > 0) {
+      return new Set(obsSetSelection.map(pathKey));
+    }
+    return null;
+  }, [obsSelectionMode, obsSelection, obsSetSelection, obsIdToSetMap]);
+
+  const selectedSampleSetKeys = useMemo(() => {
+    if (sampleSelectionMode === 'sampleSelection') {
+      if (!Array.isArray(sampleSelection) || sampleSelection.length === 0 || !sampleIdToSetMap) {
+        return null;
+      }
+      return new Set(sampleSelection
+        .map(sampleId => sampleIdToSetMap.get(sampleId))
+        .filter(Boolean)
+        .map(pathKey));
+    }
+    if (Array.isArray(sampleSetSelection) && sampleSetSelection.length > 0) {
+      return new Set(sampleSetSelection.map(pathKey));
+    }
+    return null;
+  }, [sampleSelectionMode, sampleSelection, sampleSetSelection, sampleIdToSetMap]);
+
+  const obsCounts = useMemo(() => obsCountsWithoutSelection.map(d => ({
+    ...d,
+    isSelected: (
+      (!selectedObsSetKeys || selectedObsSetKeys.has(pathKey(d.obsSetPath)))
+      && (!selectedSampleSetKeys || selectedSampleSetKeys.has(pathKey(d.sampleSetPath)))
+    ),
+  })), [obsCountsWithoutSelection, selectedObsSetKeys, selectedSampleSetKeys]);
+
+  // Highlighting: an observation- or sample-level highlight is resolved
+  // to the set(s) which contain it, since the treemap renders sets
+  // rather than individual observations.
+  const [highlightedObsSetPath, highlightedSampleSetPath] = useMemo(() => {
+    if (obsHighlight) {
+      const sampleId = sampleEdges?.get(obsHighlight);
+      return [
+        obsIdToSetMap?.get(obsHighlight) || null,
+        (sampleId && sampleIdToSetMap?.get(sampleId)) || null,
+      ];
+    }
+    if (sampleHighlight) {
+      return [null, sampleIdToSetMap?.get(sampleHighlight) || null];
+    }
+    return [obsSetHighlight || null, null];
+  }, [obsHighlight, obsSetHighlight, sampleHighlight,
+    obsIdToSetMap, sampleIdToSetMap, sampleEdges,
   ]);
 
   const totalObsCount = obsIndex?.length || 0;
   const totalSampleCount = sampleIndex?.length || 0;
 
-  const selectedObsCount = obsCounts.reduce((a, h) => a + h.value, 0);
-  const selectedSampleCount = sampleCounts.reduce((a, h) => a + h.value, 0);
+  const filteredObsCount = obsCountsWithoutSelection.reduce((a, h) => a + h.value, 0);
 
-  const unselectedObsCount = totalObsCount - selectedObsCount;
-  const unselectedSampleCount = totalSampleCount - selectedSampleCount;
-
+  const omittedObsCount = totalObsCount - filteredObsCount;
+  const omittedSampleCount = totalSampleCount - filteredSampleCount;
 
   const onNodeClick = useCallback((obsSetPath) => {
-    setObsSetSelection([obsSetPath]);
+    // Clicking a node updates the selection (i.e., which sets are
+    // emphasized), rather than the filtering criteria.
+    if (obsSetPath) {
+      setObsSetSelection([obsSetPath]);
+    }
   }, [setObsSetSelection]);
+
+  const onNodeHighlight = useCallback((obsSetPath) => {
+    setObsSetHighlight(obsSetPath || null);
+  }, [setObsSetHighlight]);
 
   return (
     <TitleInfo
       title={`Treemap of ${capitalize(plur(obsType, 2))}`}
-      info={`${commaNumber(selectedObsCount)} ${plur(obsType, selectedObsCount)} from ${commaNumber(selectedSampleCount)} ${plur(sampleType, selectedSampleCount)}`}
+      info={`${commaNumber(filteredObsCount)} ${plur(obsType, filteredObsCount)} from ${commaNumber(filteredSampleCount)} ${plur(sampleType, filteredSampleCount)}`}
       removeGridComponent={removeGridComponent}
       urls={urls}
       theme={theme}
@@ -273,24 +467,26 @@ export function TreemapSubscriber(props) {
       <div ref={containerRef} className={classes.vegaContainer}>
         <Treemap
           obsCounts={obsCounts}
-          sampleCounts={sampleCounts}
           obsColorEncoding={obsColorEncoding}
           hierarchyLevels={hierarchyLevels || DEFAULT_HIERARCHY_LEVELS}
           theme={theme}
           width={width}
-          height={Math.max(height * (selectedObsCount / totalObsCount), 40)}
+          height={Math.max(height * (filteredObsCount / totalObsCount), 40)}
           obsType={obsType}
           sampleType={sampleType}
           obsSetColor={obsSetColor}
           sampleSetColor={sampleSetColor}
-          obsSetSelection={obsSetSelection}
-          sampleSetSelection={sampleSetSelection}
+          obsSetPaths={filteredObsSetPaths}
+          sampleSetPaths={filteredSampleSetPaths}
+          highlightedObsSetPath={highlightedObsSetPath}
+          highlightedSampleSetPath={highlightedSampleSetPath}
           onNodeClick={onNodeClick}
+          onNodeHighlight={onNodeHighlight}
         />
       </div>
       <div style={{ position: 'absolute', right: '2px', bottom: '2px', fontSize: '10px' }}>
-        {unselectedObsCount > 0 ? (
-          <span>{`${commaNumber(unselectedObsCount)} ${plur(obsType, unselectedObsCount)} from ${commaNumber(unselectedSampleCount)} ${plur(sampleType, unselectedSampleCount)} currently omitted`}</span>
+        {omittedObsCount > 0 ? (
+          <span>{`${commaNumber(omittedObsCount)} ${plur(obsType, omittedObsCount)} from ${commaNumber(omittedSampleCount)} ${plur(sampleType, omittedSampleCount)} currently omitted`}</span>
         ) : null}
       </div>
     </TitleInfo>

--- a/packages/view-types/statistical-plots/src/TreemapSubscriber.js
+++ b/packages/view-types/statistical-plots/src/TreemapSubscriber.js
@@ -183,8 +183,6 @@ export function TreemapSubscriber(props) {
     coordinationScopes,
   );
 
-  console.log(sampleSetFilter, sampleSetSelection);
-
   const [width, height, containerRef] = useGridItemSize();
 
   // TODO: how to deal with multimodal cases (multiple obsIndex, one per modality)?


### PR DESCRIPTION
<!-- Credit (as a starting template): https://github.com/visgl/deck.gl/blob/master/.github/pull_request_template.md -->
<!-- For feature, feature enhancement or bug fix, create an issue first and finish To Do List there -->
<!-- Anything doesn't work as expected is a bug, including code, doc and test -->
Fixes #
<!-- For other PRs without open issue -->
#### Background
<!-- For all the PRs -->
#### Change List

### TODO
- [ ] ~~Review/check filtering logic in callback functions - some should be simplified so that the selected sets and filtered sets are just specified as the same lists~~
- [ ] ~~Improve styling of filter checkbox~~
- [ ] ~~Test with hierarchies of sets~~
- [ ] T~~est with user-defined sets~~


Update following recent meeting:

- [ ] Pull out the setting of the context/background into a different view
- [ ] MVP for filtering: allow user to say "treat my current selected cell sets as filtered sets"
- [ ] Ensure that filtering criteria can be orthogonal to selection criteria - (e.g., filter to sets in Group A, select sets in Group B)
- [ ] Keep cell set manager with its current complexity - do not introduce the filtering logic there
- [ ] Terminology: "background/foreground"



#### Checklist
 - [ ] Have tested PR with one or more demo configurations
 - [ ] Documentation added, updated, or not applicable
