### PR TITLE
NickAkhmetov/Improve obs set coloring performance for large datasets (#2563, #2566)

### DIFF
--- a/.changeset/olive-mice-clap.md
+++ b/.changeset/olive-mice-clap.md
@@ -1,0 +1,13 @@
+---
+"@vitessce/sets-utils": patch
+"@vitessce/workers": patch
+"@vitessce/scatterplot": patch
+"@vitessce/scatterplot-embedding": patch
+"@vitessce/scatterplot-gating": patch
+"@vitessce/types": patch
+"@vitessce/zarr": patch
+"@vitessce/csv": patch
+"@vitessce/json": patch
+---
+
+Improve obs set performance on large datasets: accumulate set colors, memberships, and color indices in linear rather than quadratic time; color the embedding and gating scatterplots from a positional typed array instead of an observation-ID-keyed Map; and build the observation set membership encoding in a web worker, dispatched during idle time and transferred as typed arrays, falling back to the main thread when workers are unavailable. Also fixes `treeToMembershipMap` reporting duplicate set paths for leaf sets shallower than the height of their hierarchy.

--- a/packages/file-types/csv/src/csv-loaders/ObsSetsCsv.js
+++ b/packages/file-types/csv/src/csv-loaders/ObsSetsCsv.js
@@ -1,5 +1,5 @@
 import { LoaderResult } from '@vitessce/abstract';
-import { initializeCellSetColor, treeToMembershipMap, dataToCellSetsTree } from '@vitessce/sets-utils';
+import { initializeCellSetColor, lazyTreeToMembershipMap, dataToCellSetsTree } from '@vitessce/sets-utils';
 import CsvLoader from './CsvLoader.js';
 
 export default class ObsSetsCsvLoader extends CsvLoader {
@@ -25,7 +25,7 @@ export default class ObsSetsCsvLoader extends CsvLoader {
       cellSetIds,
       cellSetScores,
     ], setsArr);
-    const obsSetsMembership = treeToMembershipMap(cellSetsTree);
+    const obsSetsMembership = lazyTreeToMembershipMap(cellSetsTree, obsIndex);
 
     const coordinationValues = {};
     const { tree } = cellSetsTree;

--- a/packages/file-types/csv/src/csv-loaders/SampleSetsCsv.js
+++ b/packages/file-types/csv/src/csv-loaders/SampleSetsCsv.js
@@ -1,5 +1,5 @@
 import { LoaderResult } from '@vitessce/abstract';
-import { initializeCellSetColor, treeToMembershipMap, dataToCellSetsTree } from '@vitessce/sets-utils';
+import { initializeCellSetColor, lazyTreeToMembershipMap, dataToCellSetsTree } from '@vitessce/sets-utils';
 import CsvLoader from './CsvLoader.js';
 
 export default class SampleSetsCsvLoader extends CsvLoader {
@@ -25,7 +25,7 @@ export default class SampleSetsCsvLoader extends CsvLoader {
       cellSetIds,
       cellSetScores,
     ], setsArr);
-    const obsSetsMembership = treeToMembershipMap(cellSetsTree);
+    const obsSetsMembership = lazyTreeToMembershipMap(cellSetsTree, obsIndex);
 
     const coordinationValues = {};
     // Create a list of sample set objects with color mappings.

--- a/packages/file-types/json/src/json-loaders/ObsSetsJson.js
+++ b/packages/file-types/json/src/json-loaders/ObsSetsJson.js
@@ -2,7 +2,7 @@ import {
   tryUpgradeTreeToLatestSchema,
   initializeCellSetColor,
   nodeToSet,
-  treeToMembershipMap,
+  lazyTreeToMembershipMap,
 } from '@vitessce/sets-utils';
 import { LoaderResult } from '@vitessce/abstract';
 import { obsSetsSchema } from '@vitessce/schemas';
@@ -25,12 +25,11 @@ export default class ObsSetsJsonLoader extends JsonLoader {
       obsSetSelection: [],
       obsSetColor: [],
     };
-    let obsSetsMembership = new Map();
+    let obsSetsMembership = lazyTreeToMembershipMap(null);
 
     // Set up the initial coordination values.
     if (upgradedData && upgradedData.tree.length >= 1) {
       const { tree } = upgradedData;
-      obsSetsMembership = treeToMembershipMap(upgradedData);
       const newAutoSetSelectionParentName = tree[0].name;
       // Create a list of set paths to initally select.
       const newAutoSetSelections = tree[0].children
@@ -41,6 +40,10 @@ export default class ObsSetsJsonLoader extends JsonLoader {
       coordinationValues.obsSetColor = newAutoSetColors;
 
       obsIndex = nodeToSet(tree[0]).map(d => d[0]);
+      // Built after obsIndex, which the positional encoding is aligned to. obsIndex
+      // covers only the first hierarchy here, so any set member outside it makes the
+      // lookup fall back to the main-thread map rather than answer incorrectly.
+      obsSetsMembership = lazyTreeToMembershipMap(upgradedData, obsIndex);
     }
     return Promise.resolve(new LoaderResult({
       obsIndex,

--- a/packages/file-types/zarr/src/anndata-loaders/ObsSetsAnndataLoader.js
+++ b/packages/file-types/zarr/src/anndata-loaders/ObsSetsAnndataLoader.js
@@ -1,7 +1,7 @@
 import { LoaderResult, AbstractTwoStepLoader } from '@vitessce/abstract';
 import {
   initializeCellSetColor,
-  treeToMembershipMap,
+  lazyTreeToMembershipMap,
   dataToCellSetsTree,
 } from '@vitessce/sets-utils';
 
@@ -60,7 +60,7 @@ export default class ObsSetsAnndataLoader extends AbstractTwoStepLoader {
       ]).then(data => [data[0], dataToCellSetsTree([data[1], data[2], data[3]], options.obsSets)]);
     }
     const [obsIndex, obsSets] = await this.cachedResult;
-    const obsSetsMembership = treeToMembershipMap(obsSets);
+    const obsSetsMembership = lazyTreeToMembershipMap(obsSets, obsIndex);
     const coordinationValues = {};
     const { tree } = obsSets;
     const newAutoSetSelectionParentName = tree[0].name;

--- a/packages/file-types/zarr/src/anndata-loaders/SampleSetsAnndataLoader.js
+++ b/packages/file-types/zarr/src/anndata-loaders/SampleSetsAnndataLoader.js
@@ -1,7 +1,7 @@
 import { LoaderResult, AbstractTwoStepLoader } from '@vitessce/abstract';
 import {
   initializeCellSetColor,
-  treeToMembershipMap,
+  lazyTreeToMembershipMap,
   dataToCellSetsTree,
 } from '@vitessce/sets-utils';
 
@@ -57,7 +57,7 @@ export default class SampleSetsAnndataLoader extends AbstractTwoStepLoader {
       ]));
     }
     const [obsIndex, obsSets] = await this.cachedResult;
-    const obsSetsMembership = treeToMembershipMap(obsSets);
+    const obsSetsMembership = lazyTreeToMembershipMap(obsSets, obsIndex);
     const coordinationValues = {};
     const { tree } = obsSets;
     const newAutoSetSelectionParentName = tree[0].name;

--- a/packages/types/src/data-types.ts
+++ b/packages/types/src/data-types.ts
@@ -63,10 +63,20 @@ export type ObsLabelsData = {
   obsLabelsMap: Map<string, string>;
 };
 
+// A Map-like lookup from observation ID to the set paths containing it. Loaders
+// return a lazy implementation that only materializes the underlying Map on first
+// lookup, so this is narrowed to the members consumers actually use rather than
+// being typed as a full Map.
+export type ObsSetsMembership = {
+  get: (obsId: string) => string[][] | undefined;
+  has: (obsId: string) => boolean;
+  readonly size: number;
+};
+
 export type ObsSetsData = {
   obsIndex: string[];
   obsSets: SetsTree;
-  obsSetsMembership: Map<string, string[][]>;
+  obsSetsMembership: ObsSetsMembership;
 };
 
 // Imaging

--- a/packages/types/src/index.ts
+++ b/packages/types/src/index.ts
@@ -10,6 +10,7 @@ export type {
   ComparisonMetadata,
   FeatureStatsData,
   ObsLabelsData,
+  ObsSetsMembership,
   ObsSetsData,
   ObsSegmentationsPolygons,
   ObsSegmentationsBitmask,

--- a/packages/utils/sets-utils/package.json
+++ b/packages/utils/sets-utils/package.json
@@ -34,6 +34,7 @@
     "@turf/helpers": "catalog:turf",
     "@vitessce/schemas": "workspace:*",
     "@vitessce/utils": "workspace:*",
+    "@vitessce/workers": "workspace:*",
     "@vitessce/globals": "workspace:*",
     "concaveman": "^1.2.1",
     "d3-dsv": "catalog:",

--- a/packages/utils/sets-utils/src/cell-set-utils.js
+++ b/packages/utils/sets-utils/src/cell-set-utils.js
@@ -403,7 +403,10 @@ function colorMixWithUncertainty(originalColor, p, mixingColor = [128, 128, 128]
  * and cellColors is an object mapping cellIds to color [r,g,b] arrays.
  */
 export function treeToCellColorsBySetNames(currTree, selectedNamePaths, cellSetColor, theme) {
-  let cellColorsArray = [];
+  // Insert into the Map directly rather than accumulating an intermediate array of
+  // [cellId, color] tuples. Spreading the accumulator once per selected set is
+  // O(numObservations * numSelectedSets); this is O(numObservations).
+  const cellColors = new Map();
   selectedNamePaths.forEach((setNamePath) => {
     const node = treeFindNodeByNamePath(currTree, setNamePath);
     if (node) {
@@ -412,16 +415,15 @@ export function treeToCellColorsBySetNames(currTree, selectedNamePaths, cellSetC
         cellSetColor?.find(d => isEqual(d.path, setNamePath))?.color
         || getDefaultColor(theme)
       );
-      cellColorsArray = [
-        ...cellColorsArray,
-        ...nodeSet.map(([cellId, prob]) => [
+      nodeSet.forEach(([cellId, prob]) => {
+        cellColors.set(
           cellId,
           (isNil(prob) ? nodeColor : colorMixWithUncertainty(nodeColor, prob)),
-        ]),
-      ];
+        );
+      });
     }
   });
-  return new Map(cellColorsArray);
+  return cellColors;
 }
 
 /**
@@ -438,25 +440,24 @@ export function treeToCellColorsBySetNames(currTree, selectedNamePaths, cellSetC
  * and cellColors is an object mapping cellIds to color [r,g,b] arrays.
  */
 export function treeToSelectedSetMap(currTree, selectedNamePaths) {
-  let result = [];
+  const result = new Map();
   selectedNamePaths.forEach((setNamePath) => {
     const node = treeFindNodeByNamePath(currTree, setNamePath);
     if (node) {
       const nodeSet = nodeToSet(node);
-      result = [
-        ...result,
-        ...nodeSet.map(([cellId]) => [
+      nodeSet.forEach(([cellId]) => {
+        result.set(
           cellId,
           // TODO: should this be the full path
           // (rather than only the node name)?
           // Or the index of the selected set
           // with respect to the selectedNamePaths array?
           setNamePath,
-        ]),
-      ];
+        );
+      });
     }
   });
-  return new Map(result);
+  return result;
 }
 
 /**
@@ -472,22 +473,109 @@ export function treeToSelectedSetMap(currTree, selectedNamePaths) {
  * and cellColors is an object mapping cellIds to color [r,g,b] arrays.
  */
 export function treeToCellSetColorIndicesBySetNames(currTree, selectedNamePaths, cellSetColor) {
-  let cellColorsArray = [];
+  const cellColorIndices = new Map();
   selectedNamePaths?.forEach((setNamePath) => {
     const node = treeFindNodeByNamePath(currTree, setNamePath);
     if (node) {
       const nodeSet = nodeToSet(node);
       const nodeColorIndex = cellSetColor?.findIndex(d => isEqual(d.path, setNamePath));
-      cellColorsArray = [
-        ...cellColorsArray,
-        ...nodeSet.map(([cellId]) => [
-          cellId,
-          nodeColorIndex,
-        ]),
-      ];
+      nodeSet.forEach(([cellId]) => {
+        cellColorIndices.set(cellId, nodeColorIndex);
+      });
     }
   });
-  return new Map(cellColorsArray);
+  return cellColorIndices;
+}
+
+// Cache of observation-ID-to-position lookups, keyed weakly by the obsIndex array
+// itself. Loaders memoize obsIndex per store path, so views that share an
+// observation axis share the one Map rather than each building their own.
+const obsIndexMapCache = new WeakMap();
+
+/**
+ * Get a mapping from observation ID to its position in obsIndex, memoized on the
+ * obsIndex array reference.
+ * @param {string[]} obsIndex The observation index.
+ * @returns {Map<string, number>} Mapping from observation ID to integer position.
+ */
+export function getObsIndexMap(obsIndex) {
+  let obsIndexMap = obsIndexMapCache.get(obsIndex);
+  if (!obsIndexMap) {
+    obsIndexMap = new Map();
+    for (let i = 0; i < obsIndex.length; i += 1) {
+      obsIndexMap.set(obsIndex[i], i);
+    }
+    obsIndexMapCache.set(obsIndex, obsIndexMap);
+  }
+  return obsIndexMap;
+}
+
+/**
+ * Build a positionally-indexed color encoding for a set selection.
+ *
+ * Unlike treeToCellColorsBySetNames, the result is aligned to obsIndex by position
+ * rather than keyed by observation ID, so consumers index into it with the same
+ * integer they already use to read coordinates. That avoids both a per-observation
+ * string hash lookup on every render and the per-observation color array that
+ * uncertainty mixing would otherwise allocate.
+ *
+ * @param {object} currTree A tree object.
+ * @param {array} selectedNamePaths Array of arrays of strings, representing set "paths".
+ * @param {object[]} cellSetColor Array of objects with the properties `path` and `color`.
+ * @param {string[]} obsIndex The observation index to align the result to.
+ * @param {string} theme "light" or "dark" for the vitessce theme.
+ * @returns {object} An object `{ colorIndices, colorProbs, colors }` where
+ * `colorIndices` is a typed array parallel to obsIndex, holding 0 for observations
+ * in no selected set and `i + 1` for those in `selectedNamePaths[i]`;
+ * `colors` holds the [r, g, b] color per selected set;
+ * and `colorProbs` is a Float32Array of per-observation confidence scores, or null
+ * when no selected set carries them.
+ */
+export function treeToColorIndicesArray(
+  currTree, selectedNamePaths, cellSetColor, obsIndex, theme,
+) {
+  const numObs = obsIndex?.length || 0;
+  const paths = selectedNamePaths || [];
+  // Reserve 0 for "in no selected set", so the palette needs paths.length + 1 values.
+  // eslint-disable-next-line no-nested-ternary
+  const IndicesArrayType = paths.length + 1 <= 256
+    ? Uint8Array
+    : (paths.length + 1 <= 65536 ? Uint16Array : Uint32Array);
+  const colorIndices = new IndicesArrayType(numObs);
+  const colors = [];
+  // Allocated lazily: most set hierarchies carry no confidence scores, and skipping
+  // the array entirely lets consumers take a cheaper code path.
+  let colorProbs = null;
+
+  // Built for every selected path, including paths absent from the tree, so that
+  // colors[colorIndices[i] - 1] stays aligned with selectedNamePaths.
+  const obsIndexMap = numObs > 0 ? getObsIndexMap(obsIndex) : null;
+  paths.forEach((setNamePath, i) => {
+    colors.push(
+      cellSetColor?.find(d => isEqual(d.path, setNamePath))?.color
+      || getDefaultColor(theme),
+    );
+    const node = obsIndexMap && treeFindNodeByNamePath(currTree, setNamePath);
+    if (node) {
+      const nodeSet = nodeToSet(node);
+      nodeSet.forEach(([cellId, prob]) => {
+        const obsI = obsIndexMap.get(cellId);
+        if (obsI !== undefined) {
+          // Later paths overwrite earlier ones, matching treeToCellColorsBySetNames.
+          colorIndices[obsI] = i + 1;
+          if (!isNil(prob)) {
+            if (colorProbs === null) {
+              colorProbs = new Float32Array(numObs).fill(1);
+            }
+            colorProbs[obsI] = prob;
+          } else if (colorProbs !== null) {
+            colorProbs[obsI] = 1;
+          }
+        }
+      });
+    }
+  });
+  return { colorIndices, colorProbs, colors };
 }
 
 /**
@@ -504,7 +592,7 @@ export function treeToCellSetColorIndicesBySetNames(currTree, selectedNamePaths,
  * `obsId`, `name`, and `color`.
  */
 export function treeToObjectsBySetNames(currTree, selectedNamePaths, setColor, theme) {
-  let cellsArray = [];
+  const cellsArray = [];
   for (let i = 0; i < selectedNamePaths.length; i += 1) {
     const setNamePath = selectedNamePaths[i];
     const node = treeFindNodeByNamePath(currTree, setNamePath);
@@ -514,11 +602,13 @@ export function treeToObjectsBySetNames(currTree, selectedNamePaths, setColor, t
         setColor?.find(d => isEqual(d.path, setNamePath))?.color
         || getDefaultColor(theme)
       );
-      cellsArray = cellsArray.concat(nodeSet.map(([cellId]) => ({
-        obsId: cellId,
-        name: node.name,
-        color: nodeColor,
-      })));
+      nodeSet.forEach(([cellId]) => {
+        cellsArray.push({
+          obsId: cellId,
+          name: node.name,
+          color: nodeColor,
+        });
+      });
     }
   }
   return cellsArray;
@@ -527,7 +617,7 @@ export function treeToObjectsBySetNames(currTree, selectedNamePaths, setColor, t
 export function treeToCellPolygonsBySetNames(
   currTree, obsIndex, obsEmbedding, selectedNamePaths, cellSetColor, theme,
 ) {
-  const obsIndexMap = new Map(obsIndex.map((key, i) => ([key, i])));
+  const obsIndexMap = getObsIndexMap(obsIndex);
   const cellSetPolygons = [];
   selectedNamePaths.forEach((setNamePath) => {
     const node = treeFindNodeByNamePath(currTree, setNamePath);
@@ -798,30 +888,47 @@ export function getCellSetPolygons(params) {
   return [];
 }
 
+/**
+ * Get every leaf set in a tree, with the path that identifies it.
+ *
+ * A single depth-first walk visits each leaf exactly once. Iterating one level at a
+ * time instead re-emitted any leaf shallower than the tree height once per remaining
+ * level, and re-resolved each path against the tree to find its node.
+ *
+ * @param {object} currTree A tree object.
+ * @returns {{ path: string[], set: array[] }[]} The leaf sets, in tree order.
+ */
+export function treeToLeafSets(currTree) {
+  const leafSets = [];
+  function visitNode(node, prevPath) {
+    const nodePath = [...prevPath, node.name];
+    if (node.children) {
+      node.children.forEach(child => visitNode(child, nodePath));
+    } else {
+      leafSets.push({ path: nodePath, set: nodeToSet(node) });
+    }
+  }
+  if (currTree) {
+    currTree.tree.forEach(lzn => visitNode(lzn, []));
+  }
+  return leafSets;
+}
+
+/**
+ * Get a mapping from observation ID to the paths of the leaf sets containing it.
+ * @param {object} currTree A tree object.
+ * @returns {Map<string, string[][]>} Mapping from observation ID to set paths.
+ */
 export function treeToMembershipMap(currTree) {
   const result = new Map();
-  if (currTree) {
-    currTree.tree.forEach((lzn) => {
-      const height = nodeToHeight(lzn);
-      range(height).forEach((i) => {
-        const levelIndex = i + 1;
-        const levelNodePaths = nodeToLevelDescendantNamePaths(lzn, levelIndex, [], true);
-        levelNodePaths.forEach((setNamePath) => {
-          const node = treeFindNodeByNamePath(currTree, setNamePath);
-          // If this is a child node, then we are interested.
-          if (node && !node.children) {
-            const nodeSet = nodeToSet(node);
-            nodeSet.forEach(([obsId]) => {
-              if (result.has(obsId)) {
-                result.get(obsId).push(setNamePath);
-              } else {
-                result.set(obsId, [setNamePath]);
-              }
-            });
-          }
-        });
-      });
+  treeToLeafSets(currTree).forEach(({ path, set }) => {
+    set.forEach(([obsId]) => {
+      if (result.has(obsId)) {
+        result.get(obsId).push(path);
+      } else {
+        result.set(obsId, [path]);
+      }
     });
-  }
+  });
   return result;
 }

--- a/packages/utils/sets-utils/src/cell-set-utils.test.fixtures.js
+++ b/packages/utils/sets-utils/src/cell-set-utils.test.fixtures.js
@@ -69,3 +69,22 @@ export const tree = {
     },
   ],
 };
+
+// A tree whose sets carry per-observation confidence scores, as produced by the
+// `scorePath` obsSets option. Used to exercise the uncertainty-mixing branch of
+// treeToCellColorsBySetNames.
+export const treeWithScores = {
+  version: '0.1.3',
+  datatype: 'cell',
+  tree: [
+    {
+      name: 'Cell Type Annotations',
+      children: [
+        {
+          name: 'Pericytes',
+          set: [['cell_1', 1.0], ['cell_2', 0.5], ['cell_3', 0.0]],
+        },
+      ],
+    },
+  ],
+};

--- a/packages/utils/sets-utils/src/cell-set-utils.test.js
+++ b/packages/utils/sets-utils/src/cell-set-utils.test.js
@@ -15,12 +15,20 @@ import {
   treeExport,
   filterNode,
   treeToSetSizesBySetNames,
+  treeToCellColorsBySetNames,
+  treeToSelectedSetMap,
+  treeToCellSetColorIndicesBySetNames,
+  treeToObjectsBySetNames,
+  treeToColorIndicesArray,
+  getObsIndexMap,
+  treeToMembershipMap,
 } from './cell-set-utils.js';
 
 import {
   levelTwoNodeLeaf,
   levelZeroNode,
   tree,
+  treeWithScores,
 } from './cell-set-utils.test.fixtures.js';
 
 describe('Hierarchical sets cell-set-utils', () => {
@@ -273,6 +281,190 @@ describe('Hierarchical sets cell-set-utils', () => {
       expect(exportedTree.tree[0].children[0].name).toEqual(tree.tree[0].children[0].name);
       expect(exportedTree.tree[0].children[0].children[0].name)
         .toEqual(tree.tree[0].children[0].children[0].name);
+    });
+  });
+
+  describe('Map observations to colors by set', () => {
+    const PERICYTES = ['Cell Type Annotations', 'Vasculature', 'Pericytes'];
+    const ENDOTHELIAL = ['Cell Type Annotations', 'Vasculature', 'Endothelial'];
+    const MISSING = ['Cell Type Annotations', 'Vasculature', 'Does Not Exist'];
+    // Pericytes and Endothelial both contain cell_3, so the later selected path wins.
+    const setColor = [
+      { path: PERICYTES, color: [255, 0, 0] },
+      { path: ENDOTHELIAL, color: [0, 255, 0] },
+    ];
+
+    it('treeToCellColorsBySetNames assigns each set its color', () => {
+      const cellColors = treeToCellColorsBySetNames(
+        tree, [PERICYTES, ENDOTHELIAL], setColor, 'light',
+      );
+      expect(cellColors.size).toEqual(5);
+      expect(cellColors.get('cell_1')).toEqual([255, 0, 0]);
+      expect(cellColors.get('cell_2')).toEqual([255, 0, 0]);
+      // cell_3 is in both sets; the later path in selectedNamePaths wins.
+      expect(cellColors.get('cell_3')).toEqual([0, 255, 0]);
+      expect(cellColors.get('cell_4')).toEqual([0, 255, 0]);
+      expect(cellColors.get('cell_5')).toEqual([0, 255, 0]);
+    });
+
+    it('treeToCellColorsBySetNames falls back to the theme default color', () => {
+      const cellColors = treeToCellColorsBySetNames(tree, [PERICYTES], [], 'light');
+      expect(cellColors.get('cell_1')).toEqual([200, 200, 200]);
+    });
+
+    it('treeToCellColorsBySetNames mixes in per-observation uncertainty', () => {
+      const cellColors = treeToCellColorsBySetNames(
+        treeWithScores,
+        [['Cell Type Annotations', 'Pericytes']],
+        [{ path: ['Cell Type Annotations', 'Pericytes'], color: [255, 0, 0] }],
+        'light',
+      );
+      // A score of 1.0 keeps the set color, 0.0 collapses to the [128, 128, 128]
+      // mixing color, and 0.5 lands halfway between.
+      expect(cellColors.get('cell_1')).toEqual([255, 0, 0]);
+      expect(cellColors.get('cell_2')).toEqual([191.5, 64, 64]);
+      expect(cellColors.get('cell_3')).toEqual([128, 128, 128]);
+    });
+
+    it('treeToCellColorsBySetNames skips paths absent from the tree', () => {
+      const cellColors = treeToCellColorsBySetNames(
+        tree, [PERICYTES, MISSING], setColor, 'light',
+      );
+      expect(cellColors.size).toEqual(3);
+      expect(treeToCellColorsBySetNames(tree, [], setColor, 'light').size).toEqual(0);
+    });
+
+    it('treeToSelectedSetMap maps each observation to its set path', () => {
+      const setMap = treeToSelectedSetMap(tree, [PERICYTES, ENDOTHELIAL]);
+      expect(setMap.size).toEqual(5);
+      expect(setMap.get('cell_1')).toEqual(PERICYTES);
+      expect(setMap.get('cell_3')).toEqual(ENDOTHELIAL);
+      expect(treeToSelectedSetMap(tree, [MISSING]).size).toEqual(0);
+    });
+
+    it('treeToCellSetColorIndicesBySetNames maps observations to palette indices', () => {
+      const colorIndices = treeToCellSetColorIndicesBySetNames(
+        tree, [PERICYTES, ENDOTHELIAL], setColor,
+      );
+      expect(colorIndices.size).toEqual(5);
+      expect(colorIndices.get('cell_1')).toEqual(0);
+      expect(colorIndices.get('cell_3')).toEqual(1);
+      expect(colorIndices.get('cell_5')).toEqual(1);
+    });
+
+    it('treeToCellSetColorIndicesBySetNames tolerates a null selection', () => {
+      expect(treeToCellSetColorIndicesBySetNames(tree, null, setColor).size).toEqual(0);
+    });
+
+    it('treeToObjectsBySetNames returns one entry per set membership', () => {
+      const objects = treeToObjectsBySetNames(tree, [PERICYTES, ENDOTHELIAL], setColor, 'light');
+      // An array rather than a Map, so cell_3 appears once per set it belongs to.
+      expect(objects.length).toEqual(6);
+      expect(objects[0]).toEqual({ obsId: 'cell_1', name: 'Pericytes', color: [255, 0, 0] });
+      expect(objects[3]).toEqual({ obsId: 'cell_3', name: 'Endothelial', color: [0, 255, 0] });
+      expect(objects.filter(d => d.obsId === 'cell_3').length).toEqual(2);
+      expect(treeToObjectsBySetNames(tree, [], setColor, 'light')).toEqual([]);
+    });
+  });
+
+  describe('Positionally-indexed set colors', () => {
+    const PERICYTES = ['Cell Type Annotations', 'Vasculature', 'Pericytes'];
+    const ENDOTHELIAL = ['Cell Type Annotations', 'Vasculature', 'Endothelial'];
+    const setColor = [
+      { path: PERICYTES, color: [255, 0, 0] },
+      { path: ENDOTHELIAL, color: [0, 255, 0] },
+    ];
+    // cell_6 and cell_7 are in the observation index but in neither selected set.
+    const obsIndex = ['cell_1', 'cell_2', 'cell_3', 'cell_4', 'cell_5', 'cell_6', 'cell_7'];
+
+    it('getObsIndexMap maps IDs to positions and memoizes on the array', () => {
+      const map = getObsIndexMap(obsIndex);
+      expect(map.get('cell_1')).toEqual(0);
+      expect(map.get('cell_7')).toEqual(6);
+      // Same array reference returns the very same Map, so views can share it.
+      expect(getObsIndexMap(obsIndex)).toBe(map);
+      expect(getObsIndexMap([...obsIndex])).not.toBe(map);
+    });
+
+    it('treeToColorIndicesArray aligns indices to obsIndex positions', () => {
+      const { colorIndices, colorProbs, colors } = treeToColorIndicesArray(
+        tree, [PERICYTES, ENDOTHELIAL], setColor, obsIndex, 'light',
+      );
+      expect(colors).toEqual([[255, 0, 0], [0, 255, 0]]);
+      // 0 means "in no selected set"; cell_3 is in both, so the later path wins.
+      expect(Array.from(colorIndices)).toEqual([1, 1, 2, 2, 2, 0, 0]);
+      expect(colorProbs).toEqual(null);
+      // Small selections fit in the narrowest typed array.
+      expect(colorIndices.BYTES_PER_ELEMENT).toEqual(1);
+    });
+
+    it('treeToColorIndicesArray agrees with treeToCellColorsBySetNames', () => {
+      const paths = [PERICYTES, ENDOTHELIAL];
+      const cellColors = treeToCellColorsBySetNames(tree, paths, setColor, 'light');
+      const { colorIndices, colors } = treeToColorIndicesArray(
+        tree, paths, setColor, obsIndex, 'light',
+      );
+      obsIndex.forEach((obsId, i) => {
+        const expected = cellColors.get(obsId) || [200, 200, 200];
+        const actual = colorIndices[i] === 0 ? [200, 200, 200] : colors[colorIndices[i] - 1];
+        expect(actual).toEqual(expected);
+      });
+    });
+
+    it('treeToColorIndicesArray carries per-observation confidence scores', () => {
+      const path = ['Cell Type Annotations', 'Pericytes'];
+      const { colorIndices, colorProbs } = treeToColorIndicesArray(
+        treeWithScores, [path], [{ path, color: [255, 0, 0] }],
+        ['cell_1', 'cell_2', 'cell_3', 'cell_4'], 'light',
+      );
+      expect(Array.from(colorIndices)).toEqual([1, 1, 1, 0]);
+      // Observations outside any scored set default to full confidence.
+      expect(Array.from(colorProbs)).toEqual([1, 0.5, 0, 1]);
+    });
+
+    it('treeToColorIndicesArray keeps colors aligned when a path is absent', () => {
+      const MISSING = ['Cell Type Annotations', 'Vasculature', 'Does Not Exist'];
+      const { colorIndices, colors } = treeToColorIndicesArray(
+        tree, [MISSING, PERICYTES], setColor, obsIndex, 'light',
+      );
+      // The missing path still consumes index 1, so Pericytes must land on index 2.
+      expect(colors.length).toEqual(2);
+      expect(Array.from(colorIndices)).toEqual([2, 2, 2, 0, 0, 0, 0]);
+      expect(colors[colorIndices[0] - 1]).toEqual([255, 0, 0]);
+    });
+
+    it('treeToColorIndicesArray handles empty and absent inputs', () => {
+      const empty = treeToColorIndicesArray(tree, [], setColor, obsIndex, 'light');
+      expect(Array.from(empty.colorIndices)).toEqual([0, 0, 0, 0, 0, 0, 0]);
+      expect(treeToColorIndicesArray(tree, null, setColor, obsIndex, 'light').colors)
+        .toEqual([]);
+      const noObs = treeToColorIndicesArray(tree, [PERICYTES], setColor, [], 'light');
+      expect(noObs.colorIndices.length).toEqual(0);
+      // The palette is still built, so it stays usable regardless of obsIndex.
+      expect(noObs.colors).toEqual([[255, 0, 0]]);
+      // Observations in a selected set but absent from obsIndex are skipped.
+      const partial = treeToColorIndicesArray(
+        tree, [PERICYTES], setColor, ['cell_2'], 'light',
+      );
+      expect(Array.from(partial.colorIndices)).toEqual([1]);
+    });
+  });
+
+  describe('Observation set membership', () => {
+    const PERICYTES = ['Cell Type Annotations', 'Vasculature', 'Pericytes'];
+    const ENDOTHELIAL = ['Cell Type Annotations', 'Vasculature', 'Endothelial'];
+    const SQUAMOUS = ['Cell Type Annotations', 'Vasculature', 'Epithelial', 'Squamous'];
+
+    it('treeToMembershipMap records each leaf set once per observation', () => {
+      const membership = treeToMembershipMap(tree);
+      // Pericytes and Endothelial are leaves at depth 3, Squamous at depth 4.
+      // Leaves shallower than the tree height must not be recorded more than once.
+      expect(membership.get('cell_1')).toEqual([PERICYTES]);
+      expect(membership.get('cell_3')).toEqual([PERICYTES, ENDOTHELIAL]);
+      expect(membership.get('cell_5')).toEqual([ENDOTHELIAL, SQUAMOUS]);
+      expect(membership.get('cell_7')).toEqual([SQUAMOUS]);
+      expect(membership.size).toEqual(7);
+      expect(treeToMembershipMap(null).size).toEqual(0);
     });
   });
 });

--- a/packages/utils/sets-utils/src/index.js
+++ b/packages/utils/sets-utils/src/index.js
@@ -2,6 +2,8 @@ export {
   treeToSelectedSetMap,
   treeToCellColorsBySetNames,
   treeToCellSetColorIndicesBySetNames,
+  treeToColorIndicesArray,
+  getObsIndexMap,
   treeToSetSizesBySetNames,
   treeToObjectsBySetNames,
   treeToObsIdsBySetNames,
@@ -25,8 +27,12 @@ export {
   nodeToRenderProps,
   getCellSetPolygons,
   treeToMembershipMap,
+  treeToLeafSets,
   nodeToSet,
 } from './cell-set-utils.js';
+export {
+  lazyTreeToMembershipMap,
+} from './membership.js';
 export {
   findLongestCommonPath,
   filterPathsByExpansionAndSelection,

--- a/packages/utils/sets-utils/src/membership.js
+++ b/packages/utils/sets-utils/src/membership.js
@@ -1,0 +1,172 @@
+import { ObsSetsWorker, packStrings } from '@vitessce/workers';
+import { treeToLeafSets, treeToMembershipMap, getObsIndexMap } from './cell-set-utils.js';
+
+// Built membership encodings, keyed weakly by the set tree they came from, so that
+// repeated loader invocations and multiple views over one tree share the result.
+const membershipCache = new WeakMap();
+
+/**
+ * Run a task on a fresh obs sets worker.
+ * @param {object} payload The message payload.
+ * @param {Transferable[]} transfers Buffers to transfer rather than copy.
+ * @returns {Promise<object>} The worker's reply.
+ */
+function runInWorker(payload, transfers) {
+  return new Promise((resolve, reject) => {
+    let worker;
+    try {
+      worker = new ObsSetsWorker();
+    } catch (e) {
+      // No worker support, or the bundle could not construct one.
+      reject(e);
+      return;
+    }
+    const settle = (fn, value) => {
+      worker.terminate();
+      fn(value);
+    };
+    worker.onmessage = (event) => {
+      if (event.data?.error) {
+        settle(reject, new Error(event.data.error));
+      } else {
+        settle(resolve, event.data);
+      }
+    };
+    worker.onerror = e => settle(reject, e);
+    worker.postMessage(['buildMembership', payload], transfers);
+  });
+}
+
+/**
+ * Run a callback when the main thread is next idle.
+ * @param {Function} callback The callback to run.
+ */
+function whenIdle(callback) {
+  if (typeof requestIdleCallback === 'function') {
+    // The timeout bounds how long a busy page can defer this. The result is only
+    // needed once a tooltip is shown, so it does not need to be prompt.
+    requestIdleCallback(callback, { timeout: 5000 });
+  } else {
+    setTimeout(callback, 0);
+  }
+}
+
+/**
+ * Get an observation-ID-to-set-paths lookup that avoids blocking the main thread.
+ *
+ * The encoding is built in a worker and returned as transferable typed arrays, so
+ * neither the set tree nor a per-observation Map is ever serialized across the
+ * worker boundary. Packing and dispatch are deferred to idle time, and until the
+ * worker replies, lookups fall back to building the map synchronously — so this is
+ * never less correct than doing the work eagerly, only less costly.
+ *
+ * @param {object} currTree A tree object.
+ * @param {string[]} [obsIndex] The observation index to align the encoding to. When
+ * omitted, no worker is used and the map is built lazily on the main thread.
+ * @returns {{ get: Function, has: Function, size: number }} A Map-like lookup
+ * exposing the subset of the Map interface that consumers use.
+ */
+export function lazyTreeToMembershipMap(currTree, obsIndex = undefined) {
+  let state = currTree ? membershipCache.get(currTree) : undefined;
+  if (!state) {
+    state = { csr: null, leafSets: null, syncMap: null, dispatched: false };
+    if (currTree) {
+      membershipCache.set(currTree, state);
+    }
+  }
+
+  function getSyncMap() {
+    if (!state.syncMap) {
+      state.syncMap = treeToMembershipMap(currTree);
+    }
+    return state.syncMap;
+  }
+
+  function dispatchToWorker() {
+    if (state.dispatched || state.csr || !currTree || !obsIndex?.length) {
+      return;
+    }
+    state.dispatched = true;
+    whenIdle(() => {
+      if (state.csr || state.syncMap) {
+        // Already answered synchronously, so the worker would be wasted effort.
+        return;
+      }
+      let payload;
+      let transfers;
+      try {
+        const leafSets = treeToLeafSets(currTree);
+        const setSizes = new Uint32Array(leafSets.length);
+        const setObsIds = [];
+        leafSets.forEach(({ set }, i) => {
+          setSizes[i] = set.length;
+          set.forEach(([obsId]) => setObsIds.push(obsId));
+        });
+        const obsIndexBuffer = packStrings(obsIndex);
+        const setObsIdsBuffer = packStrings(setObsIds);
+        payload = { obsIndexBuffer, setObsIdsBuffer, setSizes };
+        transfers = [obsIndexBuffer.buffer, setObsIdsBuffer.buffer];
+        state.leafSets = leafSets;
+      } catch (e) {
+        // Fall back to the synchronous path on the next lookup.
+        return;
+      }
+      runInWorker(payload, transfers).then(({ offsets, setIds }) => {
+        // Observations that are in a set but missing from obsIndex cannot be
+        // represented positionally. Rather than answer for them incorrectly, keep
+        // using the synchronous map.
+        let expected = 0;
+        payload.setSizes.forEach((n) => { expected += n; });
+        if (setIds.length === expected) {
+          state.csr = { offsets, setIds };
+        }
+      }).catch(() => {
+        // Worker unavailable or failed; the synchronous path still answers.
+      });
+    });
+  }
+
+  dispatchToWorker();
+
+  function get(obsId) {
+    const { csr, leafSets } = state;
+    if (csr && leafSets) {
+      const obsI = getObsIndexMap(obsIndex).get(obsId);
+      if (obsI === undefined) {
+        return undefined;
+      }
+      const start = csr.offsets[obsI];
+      const end = csr.offsets[obsI + 1];
+      if (start === end) {
+        return undefined;
+      }
+      const paths = new Array(end - start);
+      for (let i = start; i < end; i += 1) {
+        paths[i - start] = leafSets[csr.setIds[i]].path;
+      }
+      return paths;
+    }
+    if (!currTree) {
+      return undefined;
+    }
+    return getSyncMap().get(obsId);
+  }
+
+  return {
+    get,
+    has: obsId => get(obsId) !== undefined,
+    get size() {
+      const { csr } = state;
+      if (csr) {
+        let count = 0;
+        for (let i = 0; i < csr.offsets.length - 1; i += 1) {
+          if (csr.offsets[i + 1] > csr.offsets[i]) {
+            count += 1;
+          }
+        }
+        return count;
+      }
+      return currTree ? getSyncMap().size : 0;
+    },
+  };
+}

--- a/packages/utils/sets-utils/src/membership.test.js
+++ b/packages/utils/sets-utils/src/membership.test.js
@@ -1,0 +1,106 @@
+import { describe, it, expect } from 'vitest';
+import { cloneDeep } from 'lodash-es';
+import { buildMembershipCsr } from '@vitessce/workers';
+import { treeToLeafSets, treeToMembershipMap } from './cell-set-utils.js';
+import { lazyTreeToMembershipMap } from './membership.js';
+import { tree } from './cell-set-utils.test.fixtures.js';
+
+const PERICYTES = ['Cell Type Annotations', 'Vasculature', 'Pericytes'];
+
+// Decode a CSR encoding the way the membership store's lookup does.
+function decode(csr, leafSets, obsIndex, obsId) {
+  const obsI = obsIndex.indexOf(obsId);
+  if (obsI === -1) return undefined;
+  const start = csr.offsets[obsI];
+  const end = csr.offsets[obsI + 1];
+  if (start === end) return undefined;
+  return Array.from(csr.setIds.slice(start, end)).map(id => leafSets[id].path);
+}
+
+describe('obs set membership store', () => {
+  const obsIndex = ['cell_1', 'cell_2', 'cell_3', 'cell_4', 'cell_5', 'cell_6', 'cell_7'];
+
+  it('the worker encoding decodes to the same answer as the main-thread map', () => {
+    // This is the composition the worker path performs: pack the leaf sets, build
+    // the CSR off-thread, then resolve set IDs back to paths on lookup.
+    const leafSets = treeToLeafSets(tree);
+    const setSizes = new Uint32Array(leafSets.length);
+    const setObsIds = [];
+    leafSets.forEach(({ set }, i) => {
+      setSizes[i] = set.length;
+      set.forEach(([obsId]) => setObsIds.push(obsId));
+    });
+    const csr = buildMembershipCsr(obsIndex, setObsIds, setSizes);
+    const expected = treeToMembershipMap(tree);
+    obsIndex.forEach((obsId) => {
+      expect(decode(csr, leafSets, obsIndex, obsId)).toEqual(expected.get(obsId));
+    });
+    // Every membership was representable, which is what lets the store accept it.
+    expect(csr.setIds.length).toEqual(setObsIds.length);
+  });
+
+  it('answers correctly before any worker result arrives', () => {
+    // Worker construction is unavailable under jsdom, so this exercises the
+    // synchronous fallback that also covers browsers without worker support.
+    const membership = lazyTreeToMembershipMap(tree, obsIndex);
+    const expected = treeToMembershipMap(tree);
+    obsIndex.forEach((obsId) => {
+      expect(membership.get(obsId)).toEqual(expected.get(obsId));
+    });
+    expect(membership.size).toEqual(expected.size);
+    expect(membership.has('cell_1')).toEqual(true);
+    expect(membership.has('not_a_cell')).toEqual(false);
+    expect(membership.get('not_a_cell')).toEqual(undefined);
+  });
+
+  it('does no work until first lookup', () => {
+    // Traversal has to read `tree`, so an untouched getter proves the map was never
+    // built. The value is stable because the traversal reads it more than once.
+    const treeValue = cloneDeep(tree).tree;
+    let reads = 0;
+    const spyTree = {
+      version: '0.1.3',
+      datatype: 'cell',
+      get tree() {
+        reads += 1;
+        return treeValue;
+      },
+    };
+    const membership = lazyTreeToMembershipMap(spyTree);
+    expect(reads).toEqual(0);
+    expect(membership.get('cell_1')).toEqual([PERICYTES]);
+    expect(reads).toBeGreaterThan(0);
+  });
+
+  it('builds once and shares across instances', () => {
+    const treeValue = cloneDeep(tree).tree;
+    let reads = 0;
+    const spyTree = {
+      version: '0.1.3',
+      datatype: 'cell',
+      get tree() {
+        reads += 1;
+        return treeValue;
+      },
+    };
+    const first = lazyTreeToMembershipMap(spyTree);
+    const second = lazyTreeToMembershipMap(spyTree);
+    first.get('cell_1');
+    const readsAfterFirstBuild = reads;
+    first.get('cell_2');
+    // Memoized on the tree, so a second store over the same tree — a repeated
+    // loader invocation, or another view — reuses the built map.
+    second.get('cell_3');
+    expect(second.size).toEqual(first.size);
+    expect(reads).toEqual(readsAfterFirstBuild);
+  });
+
+  it('tolerates an absent tree and an absent obsIndex', () => {
+    expect(lazyTreeToMembershipMap(null, obsIndex).get('cell_1')).toEqual(undefined);
+    expect(lazyTreeToMembershipMap(null, obsIndex).size).toEqual(0);
+    expect(lazyTreeToMembershipMap(null, obsIndex).has('cell_1')).toEqual(false);
+    // Without an obsIndex there is nothing to align to, so it stays on the
+    // main-thread path.
+    expect(lazyTreeToMembershipMap(tree).get('cell_1')).toEqual([PERICYTES]);
+  });
+});

--- a/packages/view-types/scatterplot-embedding/src/EmbeddingScatterplotSubscriber.js
+++ b/packages/view-types/scatterplot-embedding/src/EmbeddingScatterplotSubscriber.js
@@ -28,8 +28,8 @@ import {
   useCoordinationScopes,
 } from '@vitessce/vit-s';
 import {
-  setObsSelection, mergeObsSets, getCellSetPolygons, getCellColors,
-  stratifyArrays,
+  setObsSelection, mergeObsSets, getCellSetPolygons, treeToColorIndicesArray,
+  getObsIndexMap, stratifyArrays,
 } from '@vitessce/sets-utils';
 import { pluralize as plur, commaNumber, aggregateFeatureArrays } from '@vitessce/utils';
 import {
@@ -278,14 +278,12 @@ export function EmbeddingScatterplotSubscriber(props) {
   }, [additionalCellSets, cellSetColor, setCellColorEncoding,
     setAdditionalCellSets, setCellSetColor, setCellSetSelection]);
 
-  const cellColors = useMemo(() => getCellColors({
-    cellSets: mergedCellSets,
-    cellSetSelection,
-    cellSetColor,
-    obsIndex: matrixObsIndex,
-    theme,
-  }), [mergedCellSets, theme,
-    cellSetSelection, cellSetColor, matrixObsIndex]);
+  // Positional rather than keyed by observation ID: at atlas scale an ID-keyed color
+  // Map costs one string hash lookup per point per render, plus a per-observation
+  // color array whenever the selected sets carry confidence scores.
+  const obsColorIndices = useMemo(() => treeToColorIndicesArray(
+    mergedCellSets, cellSetSelection, cellSetColor, obsEmbeddingIndex, theme,
+  ), [mergedCellSets, cellSetSelection, cellSetColor, obsEmbeddingIndex, theme]);
 
   // cellSetPolygonCache is an array of tuples like [(key0, val0), (key1, val1), ...],
   // where the keys are cellSetSelection arrays.
@@ -314,8 +312,6 @@ export function EmbeddingScatterplotSubscriber(props) {
   }, [cellSetPolygonsVisible, cellSetPolygonCache, cellSetLabelsVisible, theme,
     obsEmbeddingIndex, obsEmbedding, mergedCellSets, cellSetSelection, cellSetColor]);
 
-
-  const cellSelection = useMemo(() => Array.from(cellColors.keys()), [cellColors]);
 
   const [xRange, yRange, xExtent, yExtent, numCells] = useMemo(() => {
     if (obsEmbedding && obsEmbedding.data && obsEmbedding.shape) {
@@ -373,10 +369,12 @@ export function EmbeddingScatterplotSubscriber(props) {
     observationsLabel, obsLabelsTypes, obsLabelsData, obsSetsMembership,
   );
 
-  const cellSelectionSet = useMemo(() => new Set(cellSelection), [cellSelection]);
+  // With no set selection every observation counts as selected, matching the
+  // behavior of the ID-keyed color map this replaced.
+  const allCellsSelected = !(cellSetSelection && mergedCellSets);
   const getCellIsSelected = useCallback((object, { index }) => (
-    (cellSelectionSet || new Set([])).has(obsEmbeddingIndex[index]) ? 1.0 : 0.0
-  ), [cellSelectionSet, obsEmbeddingIndex]);
+    (allCellsSelected || obsColorIndices.colorIndices[index] !== 0) ? 1.0 : 0.0
+  ), [allCellsSelected, obsColorIndices]);
 
   const cellRadius = (cellRadiusMode === 'manual' ? cellRadiusFixed : dynamicCellRadius);
   const cellOpacity = (cellOpacityMode === 'manual' ? cellOpacityFixed : dynamicCellOpacity);
@@ -469,7 +467,7 @@ export function EmbeddingScatterplotSubscriber(props) {
   const [alignedEmbeddingIndex, alignedEmbeddingData] = useMemo(() => {
     // Sort the embedding data according to the matrix obsIndex.
     if (obsEmbedding?.data && obsEmbeddingIndex && matrixObsIndex) {
-      const matrixIndexMap = new Map(matrixObsIndex.map((key, i) => ([key, i])));
+      const matrixIndexMap = getObsIndexMap(matrixObsIndex);
       const toMatrixIndex = obsEmbeddingIndex.map(key => matrixIndexMap.get(key));
 
       const newEmbeddingIndex = new Array(obsEmbeddingIndex.length);
@@ -602,9 +600,8 @@ export function EmbeddingScatterplotSubscriber(props) {
         obsEmbeddingIndex={obsEmbeddingIndex}
         obsEmbedding={obsEmbedding}
         cellFilter={cellFilter}
-        cellSelection={cellSelection}
         cellHighlight={cellHighlight}
-        cellColors={cellColors}
+        obsColorIndices={obsColorIndices}
         cellSetPolygons={cellSetPolygons}
         cellSetLabelSize={cellSetLabelSize}
         cellSetLabelsVisible={cellSetLabelsVisible}

--- a/packages/view-types/scatterplot-gating/src/GatingSubscriber.js
+++ b/packages/view-types/scatterplot-gating/src/GatingSubscriber.js
@@ -24,7 +24,7 @@ import {
   useCoordinationScopes,
 } from '@vitessce/vit-s';
 import {
-  getCellSetPolygons, mergeObsSets, setObsSelection, getCellColors,
+  getCellSetPolygons, mergeObsSets, setObsSelection, treeToColorIndicesArray,
 } from '@vitessce/sets-utils';
 import {
   Scatterplot, ScatterplotTooltipSubscriber, ScatterplotOptions,
@@ -268,14 +268,12 @@ export function GatingSubscriber(props) {
   }, [additionalCellSets, cellSetColor, setCellColorEncoding,
     setAdditionalCellSets, setCellSetColor, setCellSetSelection]);
 
-  const cellColors = useMemo(() => getCellColors({
-    cellSets: mergedCellSets,
-    cellSetSelection,
-    cellSetColor,
-    obsIndex,
-    theme,
-  }), [mergedCellSets, theme,
-    cellSetSelection, cellSetColor, obsIndex]);
+  // Positional rather than keyed by observation ID: at atlas scale an ID-keyed color
+  // Map costs one string hash lookup per point per render, plus a per-observation
+  // color array whenever the selected sets carry confidence scores.
+  const obsColorIndices = useMemo(() => treeToColorIndicesArray(
+    mergedCellSets, cellSetSelection, cellSetColor, obsIndex, theme,
+  ), [mergedCellSets, cellSetSelection, cellSetColor, obsIndex, theme]);
 
   // cellSetPolygonCache is an array of tuples like [(key0, val0), (key1, val1), ...],
   // where the keys are cellSetSelection arrays.
@@ -304,8 +302,6 @@ export function GatingSubscriber(props) {
   }, [cellSetPolygonsVisible, cellSetPolygonCache, cellSetLabelsVisible, theme,
     obsIndex, obsXY, mergedCellSets, cellSetSelection, cellSetColor]);
 
-
-  const cellSelection = useMemo(() => Array.from(cellColors.keys()), [cellColors]);
 
   const [xRange, yRange, xExtent, yExtent, numCells] = useMemo(() => {
     if (obsXY && obsXY.data && obsXY.shape) {
@@ -357,10 +353,12 @@ export function GatingSubscriber(props) {
   }, [xRange, yRange, xExtent, yExtent, numCells,
     width, height, zoom, initialTargetX, initialTargetY, averageFillDensity]);
 
-  const cellSelectionSet = useMemo(() => new Set(cellSelection), [cellSelection]);
+  // With no set selection every observation counts as selected, matching the
+  // behavior of the ID-keyed color map this replaced.
+  const allCellsSelected = !(cellSetSelection && mergedCellSets);
   const getCellIsSelected = useCallback((object, { index }) => (
-    (cellSelectionSet || new Set([])).has(obsIndex[index]) ? 1.0 : 0.0
-  ), [cellSelectionSet, obsIndex]);
+    (allCellsSelected || obsColorIndices.colorIndices[index] !== 0) ? 1.0 : 0.0
+  ), [allCellsSelected, obsColorIndices]);
 
   const cellRadius = (cellRadiusMode === 'manual' ? cellRadiusFixed : dynamicCellRadius);
   const cellOpacity = (cellOpacityMode === 'manual' ? cellOpacityFixed : dynamicCellOpacity);
@@ -472,9 +470,8 @@ export function GatingSubscriber(props) {
         obsEmbeddingIndex={obsIndex}
         obsEmbedding={obsXY}
         cellFilter={cellFilter}
-        cellSelection={cellSelection}
         cellHighlight={cellHighlight}
-        cellColors={cellColors}
+        obsColorIndices={obsColorIndices}
         cellSetPolygons={cellSetPolygons}
         cellSetLabelSize={cellSetLabelSize}
         cellSetLabelsVisible={cellSetLabelsVisible}

--- a/packages/view-types/scatterplot/src/Scatterplot.js
+++ b/packages/view-types/scatterplot/src/Scatterplot.js
@@ -26,11 +26,39 @@ const TEXT_LAYER_Z_INDEX = 0;
 // certain zoom levels.
 const POINT_LAYER_Z_INDEX = 0;
 
+// The gray that set colors are mixed toward as confidence drops. Must match the
+// mixing color used by treeToCellColorsBySetNames in @vitessce/sets-utils.
+const UNCERTAINTY_MIXING_COLOR = 128;
+
 // Default getter function props.
 const makeDefaultGetCellColors = (cellColors, obsIndex, theme) => (object, { index }) => {
   const [r, g, b, a] = (cellColors && obsIndex && cellColors.get(obsIndex[index]))
     || getDefaultColor(theme);
   return [r, g, b, 255 * (a || 1)];
+};
+// Positional equivalent of makeDefaultGetCellColors, for callers that supply
+// obsColorIndices. Reads a typed array by index rather than hashing an
+// observation ID string on every point.
+const makeColorIndicesGetCellColors = (obsColorIndices, theme) => {
+  const { colorIndices, colorProbs, colors } = obsColorIndices;
+  const defaultColor = getDefaultColor(theme);
+  return (object, { index }) => {
+    const colorIndex = colorIndices[index];
+    if (colorIndex === 0) {
+      return [defaultColor[0], defaultColor[1], defaultColor[2], 255];
+    }
+    const color = colors[colorIndex - 1] || defaultColor;
+    if (colorProbs) {
+      const p = colorProbs[index];
+      return [
+        ((color[0] - UNCERTAINTY_MIXING_COLOR) * p) + UNCERTAINTY_MIXING_COLOR,
+        ((color[1] - UNCERTAINTY_MIXING_COLOR) * p) + UNCERTAINTY_MIXING_COLOR,
+        ((color[2] - UNCERTAINTY_MIXING_COLOR) * p) + UNCERTAINTY_MIXING_COLOR,
+        255,
+      ];
+    }
+    return [color[0], color[1], color[2], 255];
+  };
 };
 const makeDefaultGetObsCoords = obsEmbedding => i => ([
   obsEmbedding.data[0][i],
@@ -69,8 +97,11 @@ const contourGetPosition = (object, { index, data, target }) => {
  * @param {object} props.cells
  * @param {string} props.mapping The name of the coordinate mapping field,
  * for each cell, for example "PCA" or "t-SNE".
- * @param {Map} props.cellColors Mapping of cell IDs to colors.
- * @param {array} props.cellSelection Array of selected cell IDs.
+ * @param {Map} props.cellColors Mapping of cell IDs to colors. Its keys are also
+ * the set of selected cell IDs. Ignored when props.obsColorIndices is provided.
+ * @param {object} props.obsColorIndices Positional set-color encoding aligned to
+ * props.obsEmbeddingIndex, as returned by treeToColorIndicesArray. Preferred over
+ * props.cellColors, which costs a string hash lookup per point.
  * @param {array} props.cellFilter Array of filtered cell IDs. By default, null.
  * @param {number} props.cellRadius The value for `radiusScale` to pass
  * to the deck.gl cells ScatterplotLayer.
@@ -221,12 +252,14 @@ class Scatterplot extends AbstractSpatialOrScatterplot {
       cellRadius = 1.0,
       cellOpacity = 1.0,
       // cellFilter,
-      cellSelection,
       setCellHighlight,
       setComponentHover,
       getCellIsSelected,
       cellColors,
-      getCellColor = makeDefaultGetCellColors(cellColors, obsIndex, theme),
+      obsColorIndices,
+      getCellColor = (obsColorIndices
+        ? makeColorIndicesGetCellColors(obsColorIndices, theme)
+        : makeDefaultGetCellColors(cellColors, obsIndex, theme)),
       getExpressionValue,
       onCellClick,
       geneExpressionColormap,
@@ -276,8 +309,8 @@ class Scatterplot extends AbstractSpatialOrScatterplot {
       onHover: getOnHoverCallback(obsIndex, setCellHighlight, setComponentHover),
       updateTriggers: {
         getExpressionValue,
-        getFillColor: [cellColorEncoding, cellSelection, cellColors],
-        getLineColor: [cellColorEncoding, cellSelection, cellColors],
+        getFillColor: [cellColorEncoding, cellColors, obsColorIndices],
+        getLineColor: [cellColorEncoding, cellColors, obsColorIndices],
         getCellIsSelected,
       },
     });
@@ -524,7 +557,7 @@ class Scatterplot extends AbstractSpatialOrScatterplot {
     }
 
     if ([
-      'obsEmbeddingIndex', 'obsEmbedding', 'cellFilter', 'cellSelection', 'cellColors',
+      'obsEmbeddingIndex', 'obsEmbedding', 'cellFilter', 'cellColors', 'obsColorIndices',
       'cellRadius', 'cellOpacity', 'cellRadiusMode', 'geneExpressionColormap',
       'geneExpressionColormapRange', 'geneSelection', 'cellColorEncoding',
       'getExpressionValue', 'embeddingPointsVisible',

--- a/packages/workers/src/index.js
+++ b/packages/workers/src/index.js
@@ -1,2 +1,6 @@
 /* eslint-disable import/no-unresolved */
 export { default as HeatmapWorker } from 'web-worker:./heatmap.worker';
+export { default as ObsSetsWorker } from 'web-worker:./obs-sets.worker';
+export {
+  packStrings, unpackStrings, buildMembershipCsr, buildMembershipFromBuffers,
+} from './obs-sets.js';

--- a/packages/workers/src/obs-sets.js
+++ b/packages/workers/src/obs-sets.js
@@ -1,0 +1,103 @@
+// Observation IDs are packed into one string so that a single TextEncoder call can
+// produce a transferable buffer. Sending the set tree itself would mean structured-
+// cloning millions of small arrays on the calling thread, which costs more than
+// building the membership encoding there in the first place.
+export const OBS_ID_SEPARATOR = '\n';
+
+/**
+ * Pack an array of strings into a transferable buffer.
+ * @param {string[]} strings The strings to pack.
+ * @returns {Uint8Array} The packed, separator-delimited, UTF-8 encoded bytes.
+ */
+export function packStrings(strings) {
+  return new TextEncoder().encode(strings.join(OBS_ID_SEPARATOR));
+}
+
+/**
+ * Unpack a buffer produced by packStrings.
+ * @param {ArrayBuffer|Uint8Array} buffer The packed bytes.
+ * @returns {string[]} The unpacked strings.
+ */
+export function unpackStrings(buffer) {
+  const bytes = buffer instanceof Uint8Array ? buffer : new Uint8Array(buffer);
+  if (bytes.byteLength === 0) {
+    return [];
+  }
+  return new TextDecoder().decode(bytes).split(OBS_ID_SEPARATOR);
+}
+
+/**
+ * Build a CSR-style encoding of which sets each observation belongs to.
+ *
+ * The result is positional with respect to obsIndex, so it is made entirely of
+ * typed arrays and can be transferred back to the main thread without a copy.
+ *
+ * @param {string[]} obsIndex The observation index to align the result to.
+ * @param {string[]} setObsIds The observation IDs of every leaf set, concatenated
+ * in set order.
+ * @param {Uint32Array|number[]} setSizes The number of observation IDs belonging to
+ * each leaf set, in the same order.
+ * @returns {{ offsets: Uint32Array, setIds: Uint32Array }} `offsets` has one entry
+ * per observation plus a trailing total; the set IDs for observation `i` are
+ * `setIds[offsets[i]]` through `setIds[offsets[i + 1] - 1]`, where each set ID
+ * indexes into the caller's leaf set list.
+ */
+export function buildMembershipCsr(obsIndex, setObsIds, setSizes) {
+  const numObs = obsIndex.length;
+  const obsIndexMap = new Map();
+  for (let i = 0; i < numObs; i += 1) {
+    obsIndexMap.set(obsIndex[i], i);
+  }
+  // First pass: count memberships per observation, so the exact output size is
+  // known before allocating.
+  const offsets = new Uint32Array(numObs + 1);
+  for (let i = 0; i < setObsIds.length; i += 1) {
+    const obsI = obsIndexMap.get(setObsIds[i]);
+    if (obsI !== undefined) {
+      offsets[obsI + 1] += 1;
+    }
+  }
+  for (let i = 0; i < numObs; i += 1) {
+    offsets[i + 1] += offsets[i];
+  }
+  // Second pass: place each membership, walking the concatenated IDs set by set.
+  const setIds = new Uint32Array(offsets[numObs]);
+  const cursor = new Uint32Array(numObs);
+  let flatI = 0;
+  for (let setI = 0; setI < setSizes.length; setI += 1) {
+    const end = flatI + setSizes[setI];
+    for (; flatI < end; flatI += 1) {
+      const obsI = obsIndexMap.get(setObsIds[flatI]);
+      if (obsI !== undefined) {
+        setIds[offsets[obsI] + cursor[obsI]] = setI;
+        cursor[obsI] += 1;
+      }
+    }
+  }
+  return { offsets, setIds };
+}
+
+/**
+ * Build the membership encoding from packed buffers.
+ * @param {object} params
+ * @param {ArrayBuffer} params.obsIndexBuffer Packed observation index.
+ * @param {ArrayBuffer} params.setObsIdsBuffer Packed concatenated leaf set members.
+ * @param {Uint32Array} params.setSizes Size of each leaf set.
+ * @returns {{ offsets: Uint32Array, setIds: Uint32Array }} The membership encoding.
+ */
+export function buildMembershipFromBuffers({ obsIndexBuffer, setObsIdsBuffer, setSizes }) {
+  const obsIndex = unpackStrings(obsIndexBuffer);
+  const setObsIds = unpackStrings(setObsIdsBuffer);
+  let expectedMembers = 0;
+  for (let i = 0; i < setSizes.length; i += 1) {
+    expectedMembers += setSizes[i];
+  }
+  if (setObsIds.length !== expectedMembers) {
+    // An observation ID containing the separator would silently misalign every
+    // membership after it, so refuse rather than return a wrong answer.
+    throw new Error(
+      `Packed observation IDs did not round-trip: expected ${expectedMembers}, got ${setObsIds.length}.`,
+    );
+  }
+  return buildMembershipCsr(obsIndex, setObsIds, setSizes);
+}

--- a/packages/workers/src/obs-sets.test.js
+++ b/packages/workers/src/obs-sets.test.js
@@ -1,0 +1,67 @@
+import { describe, it, expect } from 'vitest';
+import {
+  packStrings, unpackStrings, buildMembershipCsr, buildMembershipFromBuffers,
+} from './obs-sets.js';
+
+describe('obs sets membership encoding', () => {
+  const obsIndex = ['cell_1', 'cell_2', 'cell_3', 'cell_4'];
+  // Two leaf sets: {cell_1, cell_2, cell_3} and {cell_3, cell_4}.
+  const setObsIds = ['cell_1', 'cell_2', 'cell_3', 'cell_3', 'cell_4'];
+  const setSizes = new Uint32Array([3, 2]);
+
+  const membershipOf = (csr, i) => Array.from(csr.setIds.slice(csr.offsets[i], csr.offsets[i + 1]));
+
+  it('packs and unpacks strings', () => {
+    expect(unpackStrings(packStrings(obsIndex))).toEqual(obsIndex);
+    expect(unpackStrings(packStrings([]))).toEqual([]);
+    expect(unpackStrings(packStrings(['only']))).toEqual(['only']);
+    // The packed form is a single view over one buffer, which is what makes it
+    // transferable rather than structured-cloned.
+    const packed = packStrings(obsIndex);
+    expect(ArrayBuffer.isView(packed)).toEqual(true);
+    expect(packed.buffer.byteLength).toBeGreaterThan(0);
+  });
+
+  it('builds a CSR encoding aligned to obsIndex', () => {
+    const csr = buildMembershipCsr(obsIndex, setObsIds, setSizes);
+    expect(Array.from(csr.offsets)).toEqual([0, 1, 2, 4, 5]);
+    expect(membershipOf(csr, 0)).toEqual([0]);
+    expect(membershipOf(csr, 1)).toEqual([0]);
+    // cell_3 is in both sets.
+    expect(membershipOf(csr, 2)).toEqual([0, 1]);
+    expect(membershipOf(csr, 3)).toEqual([1]);
+  });
+
+  it('skips set members that are absent from obsIndex', () => {
+    const csr = buildMembershipCsr(['cell_2'], setObsIds, setSizes);
+    expect(Array.from(csr.offsets)).toEqual([0, 1]);
+    expect(membershipOf(csr, 0)).toEqual([0]);
+    // The shortfall is detectable, so callers can decline the encoding.
+    expect(csr.setIds.length).toBeLessThan(setObsIds.length);
+  });
+
+  it('handles observations in no set', () => {
+    const csr = buildMembershipCsr(obsIndex, ['cell_2'], new Uint32Array([1]));
+    expect(membershipOf(csr, 0)).toEqual([]);
+    expect(membershipOf(csr, 1)).toEqual([0]);
+  });
+
+  it('round-trips through packed buffers', () => {
+    const csr = buildMembershipFromBuffers({
+      obsIndexBuffer: packStrings(obsIndex),
+      setObsIdsBuffer: packStrings(setObsIds),
+      setSizes,
+    });
+    expect(Array.from(csr.offsets)).toEqual([0, 1, 2, 4, 5]);
+    expect(membershipOf(csr, 2)).toEqual([0, 1]);
+  });
+
+  it('refuses to answer when packed IDs do not round-trip', () => {
+    // A separator inside an observation ID would misalign every later membership.
+    expect(() => buildMembershipFromBuffers({
+      obsIndexBuffer: packStrings(obsIndex),
+      setObsIdsBuffer: packStrings(['cell_1', 'cell_2\nsneaky', 'cell_3', 'cell_3', 'cell_4']),
+      setSizes,
+    })).toThrow(/did not round-trip/);
+  });
+});

--- a/packages/workers/src/obs-sets.worker.js
+++ b/packages/workers/src/obs-sets.worker.js
@@ -1,0 +1,38 @@
+/* eslint-disable no-restricted-globals */
+import { buildMembershipFromBuffers } from './obs-sets.js';
+
+/**
+ * Build the observation set membership encoding off the main thread.
+ * @param {object} params
+ * @param {ArrayBuffer} params.obsIndexBuffer Packed observation index.
+ * @param {ArrayBuffer} params.setObsIdsBuffer Packed concatenated leaf set members.
+ * @param {Uint32Array} params.setSizes Size of each leaf set.
+ * @returns {array} [message, transfers]
+ */
+function buildMembership(params) {
+  const { offsets, setIds } = buildMembershipFromBuffers(params);
+  // Transfer rather than copy: these are the only large values crossing back.
+  return [{ offsets, setIds }, [offsets.buffer, setIds.buffer]];
+}
+
+/**
+ * Worker message passing logic.
+ */
+if (typeof self !== 'undefined') {
+  const nameToFunction = {
+    buildMembership,
+  };
+
+  self.addEventListener('message', (event) => {
+    if (Array.isArray(event.data)) {
+      const [name, args] = event.data;
+      try {
+        const [message, transfers] = nameToFunction[name](args);
+        self.postMessage(message, transfers);
+      } catch (e) {
+        // The caller falls back to building on the main thread.
+        self.postMessage({ error: e.message });
+      }
+    }
+  });
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1728,6 +1728,9 @@ importers:
       '@vitessce/utils':
         specifier: workspace:*
         version: link:../other-utils
+      '@vitessce/workers':
+        specifier: workspace:*
+        version: link:../../workers
       concaveman:
         specifier: ^1.2.1
         version: 1.2.1


### PR DESCRIPTION
Fixes #2563, fixes #2566

#### Background

Both issues surfaced while loading the 2,073,246-cell HuBMAP dataset `728d02be5fada1541decd1091a4b17e3` (two `scatterplot` views plus `obsSets` and `featureList`; `azimuth_label` has 113 categories, `leiden` has 59). After the network requests completed, the tab blocked indefinitely.

Two independent costs were responsible:

- **Quadratic accumulation (#2563).** Four functions in `cell-set-utils` rebuilt their whole accumulator on every iteration over the selected set paths (`[...acc, ...nodeSet.map(...)]`), i.e. `O(N·K)` copies for `N` observations across `K` selected sets. Because `ObsSetsAnndataLoader` auto-selects every child of the first hierarchy, `K` is large with no user action.
- **Per-cell string-keyed coloring (#2566).** `getCellColors` produced a `Map<obsId, [r,g,b]>` with one entry per observation, built independently per view, and the deck.gl accessor did a string hash lookup per point. On this dataset the map alone retained over 1 GB per scatterplot.

A third cost sat on the tooltip path: the observation → set-paths membership map was built synchronously on the main thread per view.

#### Change List

- **Linear-time accumulation** in `treeToCellColorsBySetNames`, `treeToSelectedSetMap`, `treeToCellSetColorIndicesBySetNames`, and `treeToObjectsBySetNames`.
- **Positional color encoding.** New `treeToColorIndicesArray` returns a typed array (`Uint8Array`/`Uint16Array`/`Uint32Array`, sized by selection count; `0` = "in no selected set") plus a palette, with lazily-allocated per-observation probabilities only when a selected set carries confidence scores. `Scatterplot` accepts it as `obsColorIndices` via `makeColorIndicesGetCellColors`; the embedding and gating subscribers use it in place of `getCellColors`, and the redundant `cellSelection` / `cellSelectionSet` containers are gone — `getCellIsSelected` reads the index array directly.
- **Membership encoding off the main thread.** New `lazyTreeToMembershipMap` (`@vitessce/sets-utils`) builds a CSR encoding in a new `ObsSetsWorker` (`@vitessce/workers`: `packStrings`, `buildMembershipCsr`, `buildMembershipFromBuffers`), dispatched during idle time with zero-copy transferable buffers. Until the worker replies, lookups fall back to building the map synchronously, and the result is cached per tree so multiple views share it. Adopted by the AnnData, CSV, and JSON obs-set loaders and the sample-set loaders.
- **Bug fix:** `treeToMembershipMap` reported duplicate set paths for leaf sets shallower than the height of their hierarchy.
- Types updated in `@vitessce/types`; tests added for the new encoding, the membership store, the worker functions, and the linear-time functions.

#### Checklist
 - [x] Have tested PR with one or more demo configurations — the 2M-cell HuBMAP config
 - [x] Documentation added, updated, or not applicable — internal performance change; no user-facing API changes
