### PR TITLE
NickAkhmetov/Cache zarr store reads and load categorical obs sets as raw codes (#2564)

### DIFF
--- a/.changeset/heavy-pugs-arrive.md
+++ b/.changeset/heavy-pugs-arrive.md
@@ -1,0 +1,10 @@
+---
+"@vitessce/zarr-utils": patch
+"@vitessce/zarr": patch
+"@vitessce/sets-utils": patch
+"@vitessce/types": patch
+"@vitessce/scatterplot-embedding": patch
+"@vitessce/scatterplot-gating": patch
+---
+
+Cache zarr store reads through the react-query client so concurrent requests for the same chunk share one download (fixes duplicate embedding chunk fetches), load contiguous embedding dims with a single sliced read, and read single-level categorical obs sets as raw codes end-to-end — building the sets tree, membership lookups, and the scatterplot color encoding from typed arrays instead of per-observation strings, with a fallback to the string-based route for scored, multi-level, or non-categorical columns.

--- a/.changeset/quiet-labels-agree.md
+++ b/.changeset/quiet-labels-agree.md
@@ -1,0 +1,7 @@
+---
+"@vitessce/utils": patch
+"@vitessce/sets-utils": patch
+"@vitessce/tooltip": patch
+---
+
+Render missing obs set labels consistently: tooltips, plot labels, and the sets manager now all show the same placeholder for observations whose categorical value is missing, instead of a blank in tooltips.

--- a/.changeset/quiet-labels-agree.md
+++ b/.changeset/quiet-labels-agree.md
@@ -4,4 +4,4 @@
 "@vitessce/tooltip": patch
 ---
 
-Render missing obs set labels consistently: tooltips, plot labels, and the sets manager now all show the same placeholder for observations whose categorical value is missing, instead of a blank in tooltips.
+Name the obs set that holds observations with a missing categorical value with a shared placeholder, so it renders identically in the sets manager, tooltips, and plots, and so selections of it survive view config serialization.

--- a/packages/file-types/zarr/src/AnnDataSource.js
+++ b/packages/file-types/zarr/src/AnnDataSource.js
@@ -1,8 +1,9 @@
 /* eslint-disable no-underscore-dangle */
-import { open as zarrOpen, get as zarrGet } from 'zarrita';
+import { open as zarrOpen, get as zarrGet, slice as zarrSlice } from 'zarrita';
 import { log } from '@vitessce/globals';
 import { dirname } from './utils.js';
 import ZarrDataSource from './ZarrDataSource.js';
+import { maybeDowncastInt64 } from './anndata-loaders/utils.js';
 /** @import { DataSourceParams } from '@vitessce/types' */
 /** @import { TypedArray as ZarrTypedArray, Chunk, ByteStringArray } from 'zarrita' */
 
@@ -93,22 +94,30 @@ export default class AnnDataSource extends ZarrDataSource {
   }
 
   /**
-   *
+   * Inspect a dataframe column's encoding and resolve where its data lives,
+   * without materializing per-observation values. Shared by the string-decoding
+   * path (_loadColumn) and the raw-codes path (loadObsColumnCodes).
    * @param {string} pathOrig
-   * @returns
+   * @returns {Promise<
+   *   { kind: 'stringArray', valuesPath: string }
+   *   | { kind: 'codes', codesPath: string, categoriesValues: string[] | undefined }
+   * >} For 'codes', categoriesValues is undefined when the column is numeric or
+   * when its categories could not be decoded; codes are then stringified directly.
    */
-  async _loadColumn(pathOrig) {
+  async _getColumnSpec(pathOrig) {
     const { storeRoot } = this;
 
     const path = prependSlash(pathOrig);
     const prefixOrig = dirname(path);
     const prefix = prependSlash(prefixOrig);
     const { categories, 'encoding-type': encodingType } = await this.getJson(`${path}/.zattrs`);
-    /** @type {string[]} */
+    /** @type {string[] | undefined} */
     let categoriesValues;
     /** @type {undefined | string} */
     let codesPath;
     if (categories) {
+      // AnnData 0.7-style: the column holds codes, and a sibling array
+      // (named by the `categories` attribute) holds the category strings.
       const { dtype } = await zarrOpen(
         storeRoot.resolve(`${prefix}/${categories}`),
         { kind: 'array' },
@@ -119,6 +128,7 @@ export default class AnnDataSource extends ZarrDataSource {
         );
       }
     } else if (encodingType === 'categorical') {
+      // AnnData 0.8+ style: the column is a group with codes/ and categories/.
       const categoriesZattrs = await this.getJson(`${path}/categories/.zattrs`);
       const categoriesEncodingType = categoriesZattrs?.['encoding-type'];
       if (categoriesEncodingType === 'nullable-string-array') {
@@ -136,20 +146,35 @@ export default class AnnDataSource extends ZarrDataSource {
       }
       codesPath = `${path}/codes`;
     } else if (encodingType === 'nullable-string-array') {
-      return this.getFlatArrDecompressed(`${path}/values`);
+      return { kind: 'stringArray', valuesPath: `${path}/values` };
     } else if (encodingType === 'string-array') {
-      return this.getFlatArrDecompressed(path);
+      return { kind: 'stringArray', valuesPath: path };
     } else {
       const { dtype } = await zarrOpen(
         storeRoot.resolve(path),
         { kind: 'array' },
       );
       if (dtype === 'v2:object' || dtype === '|O') {
-        return this.getFlatArrDecompressed(path);
+        return { kind: 'stringArray', valuesPath: path };
       }
     }
+    return { kind: 'codes', codesPath: codesPath || path, categoriesValues };
+  }
+
+  /**
+   *
+   * @param {string} pathOrig
+   * @returns
+   */
+  async _loadColumn(pathOrig) {
+    const { storeRoot } = this;
+    const spec = await this._getColumnSpec(pathOrig);
+    if (spec.kind === 'stringArray') {
+      return this.getFlatArrDecompressed(spec.valuesPath);
+    }
+    const { codesPath, categoriesValues } = spec;
     const arr = await zarrOpen(
-      storeRoot.resolve(codesPath || path),
+      storeRoot.resolve(codesPath),
       { kind: 'array' },
     );
     const values = await zarrGet(arr, [null]);
@@ -158,6 +183,47 @@ export default class AnnDataSource extends ZarrDataSource {
       i => (!categoriesValues ? String(i) : categoriesValues[/** @type {number} */ (i)]),
     );
     return mappedValues;
+  }
+
+  /**
+   * Load a categorical column as its raw integer codes plus the (small) list of
+   * category strings, skipping the per-observation string materialization that
+   * _loadColumn performs. Codes are positional along the column's dataframe axis;
+   * a negative code means the value is missing.
+   * @param {string} path A path to a dataframe column, like "obs/leiden".
+   * @returns {Promise<{
+   *   codes: ZarrTypedArray<any>, categories: string[],
+   * } | null>} Null when the column is not categorical (callers should fall back
+   * to the string-based path).
+   */
+  loadObsColumnCodes(path) {
+    if (!this.codesPromises) {
+      /** @type {Map<string, Promise<any>>} */
+      this.codesPromises = new Map();
+    }
+    if (!this.codesPromises.has(path)) {
+      const promise = (async () => {
+        const { storeRoot } = this;
+        const spec = await this._getColumnSpec(path);
+        if (spec.kind !== 'codes' || !spec.categoriesValues) {
+          return null;
+        }
+        const arr = await zarrOpen(
+          storeRoot.resolve(spec.codesPath),
+          { kind: 'array' },
+        );
+        const { data } = await zarrGet(arr, [null]);
+        // Codes index into a small category list, so int64 codes (BigInt64Array)
+        // are safely downcast for plain numeric indexing.
+        return { codes: maybeDowncastInt64(data), categories: spec.categoriesValues };
+      })().catch((err) => {
+        // Clear from cache if the promise rejects, then propagate.
+        this.codesPromises.delete(path);
+        throw err;
+      });
+      this.codesPromises.set(path, promise);
+    }
+    return this.codesPromises.get(path);
   }
 
   /**
@@ -183,6 +249,32 @@ export default class AnnDataSource extends ZarrDataSource {
   async loadNumericForDims(path, dims) {
     const { storeRoot } = this;
     const arr = zarrOpen(storeRoot.resolve(path), { kind: 'array' });
+    const minDim = Math.min(...dims);
+    const maxDim = Math.max(...dims);
+    if (maxDim - minDim + 1 === dims.length) {
+      // The dims form a contiguous run (the common case, e.g. [0, 1]), so a single
+      // sliced read covers all of them. Requesting each dim separately would fetch
+      // and decompress any chunk containing multiple requested dims once per dim.
+      const loadedArr = await arr;
+      const { data, shape, stride } = await zarrGet(
+        loadedArr, [null, zarrSlice(minDim, maxDim + 1)],
+      );
+      const numRows = shape[0];
+      const cols = dims.map((dim) => {
+        const colIndex = dim - minDim;
+        const col = new /** @type {any} */ (data.constructor)(numRows);
+        for (let i = 0; i < numRows; i += 1) {
+          col[i] = data[i * stride[0] + colIndex * stride[1]];
+        }
+        return col;
+      });
+      return {
+        data: /** @type {[ZarrTypedArray<any>, ZarrTypedArray<any>]} */ (cols),
+        shape: [dims.length, numRows],
+      };
+    }
+    // Non-contiguous dims: load per-dim. The store-level cache still coalesces
+    // concurrent reads of any shared chunks.
     return Promise.all(
       dims.map(dim => arr.then(
         loadedArr => zarrGet(loadedArr, [null, dim]),

--- a/packages/file-types/zarr/src/AnnDataSource.test.js
+++ b/packages/file-types/zarr/src/AnnDataSource.test.js
@@ -47,3 +47,88 @@ describe('sources/AnnDataSource', () => {
     });
   });
 });
+
+describe('AnnDataSource.loadNumericForDims', () => {
+  // Wrap the fixture store so that every chunk read is counted.
+  function createCountingStore(fixture) {
+    const inner = createStoreFromMapContents(fixture);
+    const calls = [];
+    return {
+      calls,
+      store: {
+        get: (key, opts) => {
+          calls.push(key);
+          return inner.get(key, opts);
+        },
+      },
+    };
+  }
+
+  it('reads each chunk once for contiguous dims', async () => {
+    const { store, calls } = createCountingStore(anndata_0_12_DenseFixture);
+    const dataSource = new AnnDataSource({
+      url: '@fixtures/zarr/anndata-0.12/anndata-dense.zarr',
+      store,
+    });
+    const result = await dataSource.loadNumericForDims('obsm/X_umap', [0, 1]);
+    expect(result.shape).toEqual([2, 3]);
+    expect(Array.from(result.data[0])).toEqual([-1, 0, 1]);
+    expect(Array.from(result.data[1])).toEqual([-1, 0, 1]);
+    // Both dims live in the single chunk 0.0; the contiguous-slice path
+    // must read it exactly once rather than once per dim.
+    const chunkReads = calls.filter(key => /X_umap\/(c\/0\/0|0\.0)$/.test(key));
+    expect(chunkReads.length).toEqual(1);
+  });
+
+  it('returns the same data for non-contiguous dims via the per-dim path', async () => {
+    const dataSource = new AnnDataSource({
+      url: '@fixtures/zarr/anndata-0.12/anndata-dense.zarr',
+      store: createStoreFromMapContents(anndata_0_12_DenseFixture),
+    });
+    // Both umap columns, requested in descending order: still a contiguous run.
+    const descending = await dataSource.loadNumericForDims('obsm/X_umap', [1, 0]);
+    expect(Array.from(descending.data[0])).toEqual([-1, 0, 1]);
+    expect(Array.from(descending.data[1])).toEqual([-1, 0, 1]);
+    // A single dim exercises the per-dim path (max - min + 1 === 1 === length,
+    // so it takes the slice path; a duplicated dim forces per-dim).
+    const duplicated = await dataSource.loadNumericForDims('obsm/X_umap', [1, 1]);
+    expect(Array.from(duplicated.data[0])).toEqual([-1, 0, 1]);
+    expect(Array.from(duplicated.data[1])).toEqual([-1, 0, 1]);
+  });
+});
+
+describe('AnnDataSource.loadObsColumnCodes', () => {
+  Object.entries({ 0.7: anndata_0_7_DenseFixture, 0.8: anndata_0_8_DenseFixture, 0.9: anndata_0_9_DenseFixture, '0.10': anndata_0_10_DenseFixture, 0.11: anndata_0_11_DenseFixture, 0.12: anndata_0_12_DenseFixture }).forEach(([version, fixture]) => {
+    it(`decodes to the same strings as loadObsColumns for AnnData v${version}`, async () => {
+      const dataSource = new AnnDataSource({
+        url: `@fixtures/zarr/anndata-${version}/anndata-dense.zarr`,
+        store: createStoreFromMapContents(fixture),
+      });
+      const result = await dataSource.loadObsColumnCodes('obs/leiden');
+      expect(result).not.toEqual(null);
+      const { codes, categories } = result;
+      const decoded = Array.from(codes).map(code => categories[code]);
+      const [expected] = await dataSource.loadObsColumns(['obs/leiden']);
+      expect(decoded).toEqual(expected);
+    });
+  });
+
+  it('returns null for a non-categorical column', async () => {
+    const dataSource = new AnnDataSource({
+      url: '@fixtures/zarr/anndata-0.8/anndata-dense.zarr',
+      store: createStoreFromMapContents(anndata_0_8_DenseFixture),
+    });
+    expect(await dataSource.loadObsColumnCodes('obs/_index')).toEqual(null);
+  });
+
+  it('caches the promise per column path', async () => {
+    const dataSource = new AnnDataSource({
+      url: '@fixtures/zarr/anndata-0.8/anndata-dense.zarr',
+      store: createStoreFromMapContents(anndata_0_8_DenseFixture),
+    });
+    const first = dataSource.loadObsColumnCodes('obs/leiden');
+    const second = dataSource.loadObsColumnCodes('obs/leiden');
+    expect(first).toBe(second);
+    expect((await first).codes).toBe((await second).codes);
+  });
+});

--- a/packages/file-types/zarr/src/ZarrDataSource.js
+++ b/packages/file-types/zarr/src/ZarrDataSource.js
@@ -15,13 +15,16 @@ export default class ZarrDataSource {
   /**
    * @param {DataSourceParams & { refSpecUrl?: string }} params The parameters object.
    */
-  constructor({ url, requestInit, refSpecUrl, store, fileType }) {
+  constructor({ url, requestInit, refSpecUrl, store, fileType, queryClient }) {
     log.info('Using a Zarr-based data source. 403 and 404 HTTP responses for Zarr metadata files (.zattrs, .zarray, .zgroup, zarr.json) are to be expected and do not necessarily indicate errors.');
+    this.queryClient = queryClient;
     if (store) {
       // TODO: check here that it is a valid Zarrita Readable?
       this.storeRoot = zarrRoot(store);
     } else if (url) {
-      this.storeRoot = zarrOpenRoot(url, fileType, { requestInit, refSpecUrl });
+      // The queryClient backs the store-level chunk cache, so that concurrent
+      // reads of the same chunk share one request. See CachedStore in zarr-utils.
+      this.storeRoot = zarrOpenRoot(url, fileType, { requestInit, refSpecUrl, queryClient });
     } else {
       throw new Error('Either a store or a URL must be provided to the ZarrDataSource constructor.');
     }

--- a/packages/file-types/zarr/src/anndata-loaders/ObsSetsAnndataLoader.js
+++ b/packages/file-types/zarr/src/anndata-loaders/ObsSetsAnndataLoader.js
@@ -3,6 +3,8 @@ import {
   initializeCellSetColor,
   lazyTreeToMembershipMap,
   dataToCellSetsTree,
+  codesToCellSetsTree,
+  membershipFromCodes,
 } from '@vitessce/sets-utils';
 
 
@@ -49,18 +51,84 @@ export default class ObsSetsAnndataLoader extends AbstractTwoStepLoader {
     return this.dataSource.loadObsColumns(cellSetScoreZarrLocation);
   }
 
+  /**
+   * Try to load every obsSets entry as raw categorical codes rather than
+   * per-observation strings. Applicable when this is the plain AnnData/MuData
+   * loader (not the SpatialData subclass), every entry is a single categorical
+   * column without scores, and all columns share one observation axis.
+   * @returns {Promise<object|null>} `{ obsIndex, columns }` where columns hold
+   * `{ name, path, codes, categories }` per entry, or null to fall back to the
+   * string-based route.
+   */
+  async loadCodesColumns() {
+    const { options } = this;
+    const entries = options.obsSets || [];
+    const eligible = entries.length > 0
+      && this.tablePath === null
+      && this.region === null
+      && typeof this.dataSource.loadObsColumnCodes === 'function'
+      && entries.every(entry => typeof entry.path === 'string' && !entry.scorePath);
+    if (!eligible) {
+      return null;
+    }
+    const codesResults = await Promise.all(
+      entries.map(entry => this.dataSource.loadObsColumnCodes(entry.path)),
+    );
+    if (codesResults.some(result => !result)) {
+      // At least one column is not categorical.
+      return null;
+    }
+    // The codes are positional along each column's dataframe axis; they can only
+    // be interpreted together when every column shares one observation index.
+    // loadObsIndex caches per obs path, so reference equality is the right check.
+    const columnObsIndices = await Promise.all(
+      entries.map(entry => this.dataSource.loadObsIndex(entry.path)),
+    );
+    const columnObsIndex = columnObsIndices[0];
+    if (
+      !columnObsIndices.every(obsIndex => obsIndex === columnObsIndex)
+      || codesResults.some(result => result.codes.length !== columnObsIndex.length)
+    ) {
+      return null;
+    }
+    return {
+      obsIndex: columnObsIndex,
+      columns: entries.map((entry, j) => ({
+        name: entry.name,
+        path: [entry.name],
+        codes: codesResults[j].codes,
+        categories: codesResults[j].categories,
+      })),
+    };
+  }
+
   async load() {
     if (!this.cachedResult) {
       const { options } = this;
-      this.cachedResult = Promise.all([
-        this.dataSource.loadObsIndex(this.tablePath),
-        this.loadObsIndices(),
-        this.loadCellSetIds(),
-        this.loadCellSetScores(),
-      ]).then(data => [data[0], dataToCellSetsTree([data[1], data[2], data[3]], options.obsSets)]);
+      this.cachedResult = (async () => {
+        const obsIndex = await this.dataSource.loadObsIndex(this.tablePath);
+        const codesData = await this.loadCodesColumns();
+        if (codesData) {
+          return [obsIndex, codesToCellSetsTree(codesData, options.obsSets), codesData];
+        }
+        const [obsIndices, cellSetIds, cellSetScores] = await Promise.all([
+          this.loadObsIndices(),
+          this.loadCellSetIds(),
+          this.loadCellSetScores(),
+        ]);
+        return [
+          obsIndex,
+          dataToCellSetsTree([obsIndices, cellSetIds, cellSetScores], options.obsSets),
+          null,
+        ];
+      })();
     }
-    const [obsIndex, obsSets] = await this.cachedResult;
-    const obsSetsMembership = lazyTreeToMembershipMap(obsSets, obsIndex);
+    const [obsIndex, obsSets, codesData] = await this.cachedResult;
+    // With codes available, membership lookups read the codes directly; otherwise
+    // the tree-based membership map is built lazily (in a worker when possible).
+    const obsSetsMembership = codesData
+      ? membershipFromCodes(codesData.obsIndex, codesData.columns)
+      : lazyTreeToMembershipMap(obsSets, obsIndex);
     const coordinationValues = {};
     const { tree } = obsSets;
     const newAutoSetSelectionParentName = tree[0].name;
@@ -73,6 +141,13 @@ export default class ObsSetsAnndataLoader extends AbstractTwoStepLoader {
     const newAutoSetColors = initializeCellSetColor(obsSets, []);
     coordinationValues.obsSetSelection = newAutoSetSelections;
     coordinationValues.obsSetColor = newAutoSetColors;
-    return new LoaderResult({ obsIndex, obsSets, obsSetsMembership }, null, coordinationValues);
+    return new LoaderResult({
+      obsIndex,
+      obsSets,
+      obsSetsMembership,
+      // The raw columns let views build positional color encodings without
+      // walking the tree; consumers must check obsSetsColumns.obsIndex alignment.
+      ...(codesData ? { obsSetsColumns: codesData } : {}),
+    }, null, coordinationValues);
   }
 }

--- a/packages/file-types/zarr/src/anndata-loaders/ObsSetsAnndataLoader.test.js
+++ b/packages/file-types/zarr/src/anndata-loaders/ObsSetsAnndataLoader.test.js
@@ -1,0 +1,91 @@
+/* eslint-disable func-names, camelcase */
+import { describe, it, expect } from 'vitest';
+import { LoaderResult } from '@vitessce/abstract';
+import { createStoreFromMapContents } from '@vitessce/zarr-utils';
+import ObsSetsAnndataLoader from './ObsSetsAnndataLoader.js';
+import AnnDataSource from '../AnnDataSource.js';
+import anndata_0_7_DenseFixture from '../json-fixtures/anndata-0.7/anndata-dense.json';
+import anndata_0_8_DenseFixture from '../json-fixtures/anndata-0.8/anndata-dense.json';
+import anndata_0_12_DenseFixture from '../json-fixtures/anndata-0.12/anndata-dense.json';
+
+const createLoader = (version, fixture, obsSets) => {
+  const store = createStoreFromMapContents(fixture);
+  const config = {
+    url: `@fixtures/zarr/anndata-${version}/anndata-dense.zarr`,
+    fileType: 'obsSets.anndata.zarr',
+    options: { obsSets },
+  };
+  const source = new AnnDataSource({ ...config, store });
+  return { loader: new ObsSetsAnndataLoader(source, config), source };
+};
+
+const LEIDEN_OPTIONS = [{ name: 'Leiden', path: 'obs/leiden' }];
+
+describe('loaders/ObsSetsAnndataLoader', () => {
+  Object.entries({
+    0.7: anndata_0_7_DenseFixture,
+    0.8: anndata_0_8_DenseFixture,
+    0.12: anndata_0_12_DenseFixture,
+  }).forEach(([version, fixture]) => {
+    describe(`AnnData v${version}`, () => {
+      it('codes route produces the same tree and membership as the string route', async () => {
+        const { loader: codesLoader } = createLoader(version, fixture, LEIDEN_OPTIONS);
+        const { loader: stringLoader, source: stringSource } = createLoader(
+          version, fixture, LEIDEN_OPTIONS,
+        );
+        // Force the reference loader onto the string-based route.
+        stringSource.loadObsColumnCodes = null;
+
+        const codesResult = await codesLoader.load();
+        const stringResult = await stringLoader.load();
+        expect(codesResult).toBeInstanceOf(LoaderResult);
+
+        // The tree must be byte-identical between routes.
+        expect(codesResult.data.obsSets).toEqual(stringResult.data.obsSets);
+        expect(codesResult.data.obsIndex).toEqual(stringResult.data.obsIndex);
+        // Membership answers must agree for every observation.
+        codesResult.data.obsIndex.forEach((obsId) => {
+          expect(codesResult.data.obsSetsMembership.get(obsId))
+            .toEqual(stringResult.data.obsSetsMembership.get(obsId));
+        });
+        // Initial coordination values (auto selections/colors) must agree.
+        expect(codesResult.coordinationValues).toEqual(stringResult.coordinationValues);
+
+        // Only the codes route carries raw columns for the view fast path.
+        expect(codesResult.data.obsSetsColumns).toBeDefined();
+        expect(stringResult.data.obsSetsColumns).toEqual(undefined);
+        const { obsIndex, columns } = codesResult.data.obsSetsColumns;
+        expect(columns.length).toEqual(1);
+        expect(columns[0].path).toEqual(['Leiden']);
+        expect(Array.from(columns[0].codes).length).toEqual(obsIndex.length);
+      });
+    });
+  });
+
+  it('falls back to the string route when a scorePath is present', async () => {
+    const { loader } = createLoader('0.8', anndata_0_8_DenseFixture, [
+      { name: 'Leiden', path: 'obs/leiden', scorePath: 'obs/leiden' },
+    ]);
+    const result = await loader.load();
+    expect(result.data.obsSetsColumns).toEqual(undefined);
+    expect(result.data.obsSets.tree.length).toEqual(1);
+  });
+
+  it('falls back to the string route for multi-level path arrays', async () => {
+    const { loader } = createLoader('0.8', anndata_0_8_DenseFixture, [
+      { name: 'Leiden', path: ['obs/leiden'] },
+    ]);
+    const result = await loader.load();
+    expect(result.data.obsSetsColumns).toEqual(undefined);
+    expect(result.data.obsSets.tree.length).toEqual(1);
+  });
+
+  it('falls back to the string route for non-categorical columns', async () => {
+    const { loader } = createLoader('0.8', anndata_0_8_DenseFixture, [
+      { name: 'Index', path: 'obs/_index' },
+    ]);
+    const result = await loader.load();
+    expect(result.data.obsSetsColumns).toEqual(undefined);
+    expect(result.data.obsSets.tree.length).toEqual(1);
+  });
+});

--- a/packages/tooltip/package.json
+++ b/packages/tooltip/package.json
@@ -35,7 +35,10 @@
     "@vitessce/utils": "workspace:*"
   },
   "devDependencies": {
+    "@testing-library/jest-dom": "catalog:",
+    "@testing-library/react": "catalog:",
     "react": "catalog:",
+    "react-dom": "catalog:",
     "vite": "catalog:",
     "vitest": "catalog:"
   },

--- a/packages/tooltip/src/TooltipContent.js
+++ b/packages/tooltip/src/TooltipContent.js
@@ -1,4 +1,5 @@
 import React, { useMemo } from 'react';
+import { MISSING_VALUE_PLACEHOLDER } from '@vitessce/utils';
 import { transformInfoValues } from './utils.js';
 
 export default function TooltipContent(props) {
@@ -21,7 +22,7 @@ export default function TooltipContent(props) {
         {Object.entries(mappedInfo).map(([key, value]) => (
           <tr key={key}>
             <th>{key}</th>
-            <td>{value}</td>
+            <td>{value ?? MISSING_VALUE_PLACEHOLDER}</td>
           </tr>
         ))}
       </tbody>

--- a/packages/tooltip/src/TooltipContent.test.jsx
+++ b/packages/tooltip/src/TooltipContent.test.jsx
@@ -1,0 +1,24 @@
+import React from 'react';
+import { describe, it, expect } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import { MISSING_VALUE_PLACEHOLDER } from '@vitessce/utils';
+
+import TooltipContent from './TooltipContent.js';
+
+describe('TooltipContent.js', () => {
+  it('renders the shared placeholder for a missing value', async () => {
+    // An observation whose categorical label is missing has an undefined set name;
+    // the sets manager shows the placeholder for it, so the tooltip must too.
+    render(<TooltipContent info={{ 'Cell ID': 'cell_1', 'Azimuth Label': undefined, Leiden: '3' }} />);
+    expect(await screen.findByText('cell_1'));
+    expect(await screen.findByText('Azimuth Label'));
+    expect(await screen.findByText(MISSING_VALUE_PLACEHOLDER));
+    expect(await screen.findByText('3'));
+  });
+
+  it('keeps legitimate falsy values', async () => {
+    render(<TooltipContent info={{ Count: 0, Flag: false }} />);
+    expect(await screen.findByText('0'));
+    expect(screen.queryByText(MISSING_VALUE_PLACEHOLDER)).toBeNull();
+  });
+});

--- a/packages/types/src/data-sources.ts
+++ b/packages/types/src/data-sources.ts
@@ -1,5 +1,19 @@
 import type { Readable } from 'zarrita';
 
+/**
+ * The subset of a TanStack Query QueryClient that data sources use, typed
+ * structurally so that consumers do not need a dependency on @tanstack/query-core.
+ */
+export type QueryClientLike = {
+  fetchQuery: (options: {
+    queryKey: unknown[],
+    queryFn: (ctx?: unknown) => Promise<unknown>,
+    staleTime?: number,
+    gcTime?: number,
+    meta?: Record<string, unknown>,
+  }) => Promise<unknown>,
+};
+
 export type DataSourceParams = {
   url?: string;
   /** Options to pass to fetch calls. */
@@ -8,4 +22,6 @@ export type DataSourceParams = {
   store?: Readable;
   /** The file type. */
   fileType: string;
+  /** A react-query QueryClient, used for request coalescing and caching. */
+  queryClient?: QueryClientLike;
 }

--- a/packages/types/src/data-types.ts
+++ b/packages/types/src/data-types.ts
@@ -73,10 +73,32 @@ export type ObsSetsMembership = {
   readonly size: number;
 };
 
+/**
+ * Raw categorical columns backing a single-level obs sets hierarchy, positional
+ * along `obsIndex`. Produced by loaders that can read codes directly (e.g.
+ * AnnData categorical columns), so that views can build positional color
+ * encodings without walking the sets tree. Consumers must confirm alignment by
+ * comparing this `obsIndex` (by reference) with their own observation index.
+ */
+export type ObsSetsColumns = {
+  obsIndex: string[];
+  columns: {
+    /** The hierarchy (level-zero node) name. */
+    name: string;
+    /** The hierarchy's path in the tree, e.g. ['Cell Type Annotations']. */
+    path: string[];
+    /** Category code per observation; negative means missing. */
+    codes: ArrayLike<number>;
+    /** Category names indexed by code. */
+    categories: string[];
+  }[];
+};
+
 export type ObsSetsData = {
   obsIndex: string[];
   obsSets: SetsTree;
   obsSetsMembership: ObsSetsMembership;
+  obsSetsColumns?: ObsSetsColumns;
 };
 
 // Imaging

--- a/packages/types/src/index.ts
+++ b/packages/types/src/index.ts
@@ -11,6 +11,7 @@ export type {
   FeatureStatsData,
   ObsLabelsData,
   ObsSetsMembership,
+  ObsSetsColumns,
   ObsSetsData,
   ObsSegmentationsPolygons,
   ObsSegmentationsBitmask,
@@ -20,6 +21,7 @@ export type {
 } from './data-types.js';
 export type {
   DataSourceParams,
+  QueryClientLike,
 } from './data-sources.js';
 export type {
   AbstractImageWrapper,

--- a/packages/utils/other-utils/src/index.ts
+++ b/packages/utils/other-utils/src/index.ts
@@ -11,6 +11,7 @@ export {
   getInitialCoordinationScopePrefix,
   getInitialCoordinationScopeName,
   unnestMap,
+  MISSING_VALUE_PLACEHOLDER,
 } from './root.js';
 // eslint-disable-next-line react-refresh/only-export-components
 export {

--- a/packages/utils/other-utils/src/root.ts
+++ b/packages/utils/other-utils/src/root.ts
@@ -207,3 +207,11 @@ export function unnestMap(
     };
   });
 }
+
+/**
+ * Display string for a value that is missing (undefined or null), such as the
+ * name of the obs set that holds observations with no category label.
+ * This matches the default title that rc-tree renders for an undefined title,
+ * so the sets manager, tooltips, and plots all show a missing value the same way.
+ */
+export const MISSING_VALUE_PLACEHOLDER = '---';

--- a/packages/utils/sets-utils/src/CellSetsZarrLoader.js
+++ b/packages/utils/sets-utils/src/CellSetsZarrLoader.js
@@ -7,6 +7,67 @@ import {
   SETS_DATATYPE_OBS,
 } from './constants.js';
 
+/**
+ * Build a cell sets tree from raw categorical codes, without materializing one
+ * string per observation. Output is identical to what dataToCellSetsTree produces
+ * for the equivalent single-level string columns: observed categories only, the
+ * same child ordering (via the same plain-object construction), and an
+ * undefined-named set for observations with a negative (missing) code.
+ * @param {object} params
+ * @param {string[]} params.obsIndex The observation index shared by all columns.
+ * @param {{ codes: ArrayLike<number>, categories: string[] }[]} params.columns
+ * Raw codes and category names, one entry per obsSets option.
+ * @param {{ name: string }[]} options The obsSets options, providing hierarchy names.
+ * @returns {object} A tree object.
+ */
+export function codesToCellSetsTree({ obsIndex, columns }, options) {
+  const cellSetsTree = treeInitialize(SETS_DATATYPE_OBS);
+  columns.forEach(({ codes, categories }, j) => {
+    const { name } = options[j];
+    let levelZeroNode = {
+      name,
+      children: [],
+    };
+    // Determine which categories are observed, since dataToCellSetsTree only
+    // creates sets for values that occur in the data.
+    const seen = new Uint8Array(categories.length);
+    let hasMissing = false;
+    for (let i = 0; i < codes.length; i += 1) {
+      const code = codes[i];
+      if (code >= 0) {
+        seen[code] = 1;
+      } else {
+        hasMissing = true;
+      }
+    }
+    const uniqueCellSetIds = categories.filter((_, k) => seen[k]);
+    if (hasMissing) {
+      // A negative code decodes to categories[-1] === undefined in the string
+      // path, which lands in an undefined-named set; sort() places it last.
+      uniqueCellSetIds.push(undefined);
+    }
+    uniqueCellSetIds.sort();
+    const clusters = {};
+    // eslint-disable-next-line no-return-assign
+    uniqueCellSetIds.forEach(id => (clusters[id] = { name: id, set: [] }));
+    // Resolve each observed code to its cluster once, so the per-observation
+    // loop is a typed-array read plus a push.
+    const clusterByCode = categories.map((cat, k) => (seen[k] ? clusters[cat] : null));
+    const missingCluster = hasMissing ? clusters[undefined] : null;
+    for (let i = 0; i < codes.length; i += 1) {
+      const code = codes[i];
+      const cluster = code >= 0 ? clusterByCode[code] : missingCluster;
+      cluster.set.push([obsIndex[i], null]);
+    }
+    Object.values(clusters).forEach(
+      // eslint-disable-next-line no-return-assign
+      cluster => (levelZeroNode = nodeAppendChild(levelZeroNode, cluster)),
+    );
+    cellSetsTree.tree.push(levelZeroNode);
+  });
+  return cellSetsTree;
+}
+
 export function dataToCellSetsTree(data, options) {
   // obsIndex is an array of all cell IDs, for the purposes of set complement operations only.
   // cellNames is per-cellSets arrays of cell IDs.

--- a/packages/utils/sets-utils/src/CellSetsZarrLoader.js
+++ b/packages/utils/sets-utils/src/CellSetsZarrLoader.js
@@ -1,4 +1,5 @@
 import { InternMap } from 'internmap';
+import { MISSING_VALUE_PLACEHOLDER } from '@vitessce/utils';
 import {
   treeInitialize,
   nodeAppendChild,
@@ -8,11 +9,33 @@ import {
 } from './constants.js';
 
 /**
+ * Whether a decoded set value is missing. A negative categorical code decodes to
+ * categories[-1] === undefined on the string route; other sources may yield null.
+ * @param {*} value A decoded set value.
+ * @returns {boolean} True when the value is missing.
+ */
+function isMissing(value) {
+  return value === undefined || value === null;
+}
+
+/**
+ * Name a decoded set value. Missing values share one set named by the shared
+ * placeholder, so the name is a real string that survives JSON serialization
+ * (an undefined name would be dropped) and that every view renders identically.
+ * @param {*} value A decoded set value.
+ * @returns {string} The set name.
+ */
+function toSetName(value) {
+  return isMissing(value) ? MISSING_VALUE_PLACEHOLDER : value;
+}
+
+/**
  * Build a cell sets tree from raw categorical codes, without materializing one
  * string per observation. Output is identical to what dataToCellSetsTree produces
  * for the equivalent single-level string columns: observed categories only, the
- * same child ordering (via the same plain-object construction), and an
- * undefined-named set for observations with a negative (missing) code.
+ * same child ordering (via the same plain-object construction), and a set named
+ * MISSING_VALUE_PLACEHOLDER, ordered last, for observations with a negative
+ * (missing) code.
  * @param {object} params
  * @param {string[]} params.obsIndex The observation index shared by all columns.
  * @param {{ codes: ArrayLike<number>, categories: string[] }[]} params.columns
@@ -40,20 +63,19 @@ export function codesToCellSetsTree({ obsIndex, columns }, options) {
         hasMissing = true;
       }
     }
-    const uniqueCellSetIds = categories.filter((_, k) => seen[k]);
+    const uniqueCellSetIds = categories.filter((_, k) => seen[k]).sort();
     if (hasMissing) {
-      // A negative code decodes to categories[-1] === undefined in the string
-      // path, which lands in an undefined-named set; sort() places it last.
-      uniqueCellSetIds.push(undefined);
+      // Observations with a negative (missing) code share one set, named by the
+      // placeholder and ordered after every real category, as in dataToCellSetsTree.
+      uniqueCellSetIds.push(MISSING_VALUE_PLACEHOLDER);
     }
-    uniqueCellSetIds.sort();
     const clusters = {};
     // eslint-disable-next-line no-return-assign
     uniqueCellSetIds.forEach(id => (clusters[id] = { name: id, set: [] }));
     // Resolve each observed code to its cluster once, so the per-observation
     // loop is a typed-array read plus a push.
     const clusterByCode = categories.map((cat, k) => (seen[k] ? clusters[cat] : null));
-    const missingCluster = hasMissing ? clusters[undefined] : null;
+    const missingCluster = hasMissing ? clusters[MISSING_VALUE_PLACEHOLDER] : null;
     for (let i = 0; i < codes.length; i += 1) {
       const code = codes[i];
       const cluster = code >= 0 ? clusterByCode[code] : missingCluster;
@@ -85,7 +107,7 @@ export function dataToCellSetsTree(data, options) {
       const levelSets = new InternMap([], JSON.stringify);
 
       cellNames[j].forEach((id, i) => {
-        const classes = cellSetIds.map(col => col[i]);
+        const classes = cellSetIds.map(col => toSetName(col[i]));
         if (levelSets.has(classes)) {
           levelSets.get(classes).push([id, null]);
         } else {
@@ -150,16 +172,26 @@ export function dataToCellSetsTree(data, options) {
     } else {
       // Single-level case.
       // Check for the optional corresponding confidence score column name.
-      const uniqueCellSetIds = Array.from(new Set(cellSetIds)).sort();
+      // Missing values share one set, named by the placeholder and ordered last.
+      const setNames = cellSetIds.map(toSetName);
+      const hasMissing = cellSetIds.some(isMissing);
+      const uniqueCellSetIds = Array.from(
+        new Set(hasMissing ? cellSetIds.filter(id => !isMissing(id)) : cellSetIds),
+      ).sort();
+      if (hasMissing) {
+        uniqueCellSetIds.push(MISSING_VALUE_PLACEHOLDER);
+      }
       const clusters = {};
       // eslint-disable-next-line no-return-assign
       uniqueCellSetIds.forEach(id => (clusters[id] = { name: id, set: [] }));
       if (cellSetScores[j]) {
-        cellSetIds
-          .forEach((id, i) => clusters[id].set.push([cellNames[j][i], cellSetScores[j][i]]));
+        setNames.forEach((setName, i) => (
+          clusters[setName].set.push([cellNames[j][i], cellSetScores[j][i]])
+        ));
       } else {
-        cellSetIds
-          .forEach((id, i) => clusters[id].set.push([cellNames[j][i], null]));
+        setNames.forEach((setName, i) => (
+          clusters[setName].set.push([cellNames[j][i], null])
+        ));
       }
       Object.values(clusters).forEach(
         // eslint-disable-next-line no-return-assign

--- a/packages/utils/sets-utils/src/CellSetsZarrLoader.test.js
+++ b/packages/utils/sets-utils/src/CellSetsZarrLoader.test.js
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import { dataToCellSetsTree } from './CellSetsZarrLoader.js';
+import { dataToCellSetsTree, codesToCellSetsTree } from './CellSetsZarrLoader.js';
 
 describe('loaders/CellSetsZarrLoader', () => {
   it('dataToCellSetsTree constructs a hierarchy from an array of columns', async () => {
@@ -160,5 +160,68 @@ describe('loaders/CellSetsZarrLoader', () => {
         },
       ],
     });
+  });
+});
+
+describe('loaders/codesToCellSetsTree', () => {
+  // Decode codes to strings the way AnnDataSource._loadColumn does, so that the
+  // string route (dataToCellSetsTree) can serve as the reference output.
+  const decode = (codes, categories) => Array.from(codes).map(c => categories[c]);
+
+  it('matches dataToCellSetsTree for unsorted categories with an unused one', () => {
+    const obsIndex = ['cell_1', 'cell_2', 'cell_3', 'cell_4', 'cell_5'];
+    // 'gamma' is unused: dataToCellSetsTree only creates sets for observed values.
+    const categories = ['beta', 'alpha', 'gamma'];
+    const codes = Int8Array.from([1, 0, 0, 1, 1]);
+    const options = [{ name: 'Cell Type' }];
+    const expected = dataToCellSetsTree(
+      [[obsIndex], [decode(codes, categories)], [undefined]], options,
+    );
+    const actual = codesToCellSetsTree({ obsIndex, columns: [{ codes, categories }] }, options);
+    expect(actual).toEqual(expected);
+  });
+
+  it('matches dataToCellSetsTree for negative (missing) codes', () => {
+    const obsIndex = ['cell_1', 'cell_2', 'cell_3'];
+    const categories = ['alpha', 'beta'];
+    // categories[-1] is undefined in the string route, which lands the
+    // observation in an undefined-named set.
+    const codes = Int8Array.from([0, -1, 1]);
+    const options = [{ name: 'Cell Type' }];
+    const expected = dataToCellSetsTree(
+      [[obsIndex], [decode(codes, categories)], [undefined]], options,
+    );
+    const actual = codesToCellSetsTree({ obsIndex, columns: [{ codes, categories }] }, options);
+    expect(actual).toEqual(expected);
+  });
+
+  it('matches dataToCellSetsTree for numeric-string categories (key-order quirk)', () => {
+    const obsIndex = ['cell_1', 'cell_2', 'cell_3', 'cell_4'];
+    // Integer-like names: plain-object key ordering places them in ascending
+    // numeric order regardless of the lexicographic sort. Both routes use the
+    // same construction, so both exhibit the same order.
+    const categories = ['10', '2', '1'];
+    const codes = Int8Array.from([0, 1, 2, 0]);
+    const options = [{ name: 'Leiden' }];
+    const expected = dataToCellSetsTree(
+      [[obsIndex], [decode(codes, categories)], [undefined]], options,
+    );
+    const actual = codesToCellSetsTree({ obsIndex, columns: [{ codes, categories }] }, options);
+    expect(actual).toEqual(expected);
+    expect(actual.tree[0].children.map(c => c.name)).toEqual(['1', '2', '10']);
+  });
+
+  it('matches dataToCellSetsTree across multiple hierarchies', () => {
+    const obsIndex = ['cell_1', 'cell_2', 'cell_3'];
+    const colA = { codes: Int8Array.from([0, 1, 0]), categories: ['T cell', 'B cell'] };
+    const colB = { codes: Int8Array.from([1, 1, 0]), categories: ['0', '1'] };
+    const options = [{ name: 'Cell Type' }, { name: 'Leiden' }];
+    const expected = dataToCellSetsTree([
+      [obsIndex, obsIndex],
+      [decode(colA.codes, colA.categories), decode(colB.codes, colB.categories)],
+      [undefined, undefined],
+    ], options);
+    const actual = codesToCellSetsTree({ obsIndex, columns: [colA, colB] }, options);
+    expect(actual).toEqual(expected);
   });
 });

--- a/packages/utils/sets-utils/src/CellSetsZarrLoader.test.js
+++ b/packages/utils/sets-utils/src/CellSetsZarrLoader.test.js
@@ -1,4 +1,5 @@
 import { describe, it, expect } from 'vitest';
+import { MISSING_VALUE_PLACEHOLDER } from '@vitessce/utils';
 import { dataToCellSetsTree, codesToCellSetsTree } from './CellSetsZarrLoader.js';
 
 describe('loaders/CellSetsZarrLoader', () => {
@@ -184,8 +185,8 @@ describe('loaders/codesToCellSetsTree', () => {
   it('matches dataToCellSetsTree for negative (missing) codes', () => {
     const obsIndex = ['cell_1', 'cell_2', 'cell_3'];
     const categories = ['alpha', 'beta'];
-    // categories[-1] is undefined in the string route, which lands the
-    // observation in an undefined-named set.
+    // categories[-1] is undefined in the string route; both routes place the
+    // observation in a set named by the shared placeholder, ordered last.
     const codes = Int8Array.from([0, -1, 1]);
     const options = [{ name: 'Cell Type' }];
     const expected = dataToCellSetsTree(
@@ -193,6 +194,29 @@ describe('loaders/codesToCellSetsTree', () => {
     );
     const actual = codesToCellSetsTree({ obsIndex, columns: [{ codes, categories }] }, options);
     expect(actual).toEqual(expected);
+    expect(actual.tree[0].children.map(c => c.name))
+      .toEqual(['alpha', 'beta', MISSING_VALUE_PLACEHOLDER]);
+    expect(actual.tree[0].children[2].set).toEqual([['cell_2', null]]);
+    // The name is a real string, so the tree (and any selection path into it)
+    // survives serialization; an undefined name would be dropped by JSON.
+    expect(JSON.parse(JSON.stringify(actual))).toEqual(actual);
+  });
+
+  it('dataToCellSetsTree names missing values consistently across levels', () => {
+    const obsIndex = ['cell_1', 'cell_2', 'cell_3'];
+    const options = [{ name: 'Subclass Levels' }];
+    // A missing value at either level of a multi-level hierarchy.
+    const tree = dataToCellSetsTree([
+      [obsIndex],
+      [[['Immune', undefined, 'Immune'], ['B cell', 'T cell', null]]],
+      [undefined],
+    ], options);
+    const levelOne = tree.tree[0].children;
+    expect(levelOne.map(n => n.name)).toEqual([MISSING_VALUE_PLACEHOLDER, 'Immune']);
+    expect(levelOne[0].children.map(n => n.name)).toEqual(['T cell']);
+    expect(levelOne[1].children.map(n => n.name)).toEqual([MISSING_VALUE_PLACEHOLDER, 'B cell']);
+    expect(levelOne[1].children[0].set).toEqual([['cell_3', null]]);
+    expect(JSON.parse(JSON.stringify(tree))).toEqual(tree);
   });
 
   it('matches dataToCellSetsTree for numeric-string categories (key-order quirk)', () => {

--- a/packages/utils/sets-utils/src/cell-set-utils.js
+++ b/packages/utils/sets-utils/src/cell-set-utils.js
@@ -4,7 +4,7 @@ import { isNil, isEqual, range } from 'lodash-es';
 import { featureCollection as turfFeatureCollection, point as turfPoint } from '@turf/helpers';
 import { centroid } from '@turf/centroid';
 import concaveman from 'concaveman';
-import { getDefaultColor, PALETTE } from '@vitessce/utils';
+import { getDefaultColor, PALETTE, MISSING_VALUE_PLACEHOLDER } from '@vitessce/utils';
 import {
   HIERARCHICAL_SCHEMAS,
 } from './constants.js';
@@ -360,7 +360,7 @@ export function treeInitialize(datatype) {
 export function nodeToRenderProps(node, path, cellSetColor) {
   const level = path.length - 1;
   return {
-    title: node.name,
+    title: node.name ?? MISSING_VALUE_PLACEHOLDER,
     nodeKey: pathToKey(path),
     path,
     size: getNodeLength(node),
@@ -682,7 +682,7 @@ export function treeToObjectsBySetNames(currTree, selectedNamePaths, setColor, t
       nodeSet.forEach(([cellId]) => {
         cellsArray.push({
           obsId: cellId,
-          name: node.name,
+          name: node.name ?? MISSING_VALUE_PLACEHOLDER,
           color: nodeColor,
         });
       });
@@ -770,7 +770,7 @@ export function treeToSetSizesBySetNames(
           || getDefaultColor(theme);
       const nodeProps = {
         key: generateKey(),
-        name: node.name,
+        name: node.name ?? MISSING_VALUE_PLACEHOLDER,
         size: nodeSet.length,
         color: nodeColor,
         setNamePath: clusterPath,
@@ -805,7 +805,7 @@ export function treeToObsIdsBySetNames(currTree, selectedNamePaths) {
       const nodeSet = nodeToSet(node);
       indices.push({
         key: generateKey(),
-        name: node.name,
+        name: node.name ?? MISSING_VALUE_PLACEHOLDER,
         path: setNamePath,
         size: nodeSet.length,
         // TODO: handle the case where the ID is in the set but missing
@@ -836,7 +836,7 @@ export function treeToObsIndicesBySetNames(currTree, selectedNamePaths, obsIndex
       const nodeSet = nodeToSet(node);
       indices.push({
         key: generateKey(),
-        name: node.name,
+        name: node.name ?? MISSING_VALUE_PLACEHOLDER,
         path: setNamePath,
         size: nodeSet.length,
         // TODO: handle the case where the ID is in the set but missing

--- a/packages/utils/sets-utils/src/cell-set-utils.js
+++ b/packages/utils/sets-utils/src/cell-set-utils.js
@@ -531,6 +531,83 @@ export function getObsIndexMap(obsIndex) {
  * and `colorProbs` is a Float32Array of per-observation confidence scores, or null
  * when no selected set carries them.
  */
+/**
+ * Build the positional color encoding directly from raw categorical codes,
+ * skipping the tree walk that treeToColorIndicesArray performs. Applicable when
+ * every selected path resolves to a (hierarchy, category) pair in the provided
+ * columns; selections that do not resolve — user-defined selections from
+ * additionalObsSets, paths deeper than two levels, or the undefined-named set
+ * for missing values — return null so the caller can fall back to the tree route.
+ *
+ * The output is identical to treeToColorIndicesArray for the tree built from the
+ * same columns: index 0 means "in no selected set", and where an observation is
+ * in multiple selected sets (across hierarchies), the later path wins.
+ *
+ * @param {object} params
+ * @param {{ path: string[], codes: ArrayLike<number>,
+ *   categories: string[] }[]} params.columns Raw codes per hierarchy; path is the
+ * hierarchy's path in the tree, e.g. ['Cell Type Annotations'].
+ * @param {string[]} params.obsIndex The observation index the columns align to.
+ * @param {array} params.selectedNamePaths Array of selected set "paths".
+ * @param {object[]} params.cellSetColor Array of objects with `path` and `color`.
+ * @param {string} params.theme "light" or "dark" for the vitessce theme.
+ * @returns {object|null} `{ colorIndices, colorProbs, colors }` as in
+ * treeToColorIndicesArray (colorProbs always null: the codes route carries no
+ * per-observation scores), or null when a selected path does not resolve.
+ */
+export function colorIndicesFromCodes({
+  columns, obsIndex, selectedNamePaths, cellSetColor, theme,
+}) {
+  const numObs = obsIndex?.length || 0;
+  const paths = selectedNamePaths || [];
+  // Per column, a map from category code to (selected path index + 1). Later
+  // selected paths overwrite earlier ones within a column; across columns, the
+  // max index per observation reproduces the same later-path-wins rule.
+  const selIdxByCode = columns.map(
+    ({ categories }) => new Int32Array(categories.length),
+  );
+  const colors = [];
+  for (let i = 0; i < paths.length; i += 1) {
+    const setNamePath = paths[i];
+    const colIndex = columns.findIndex(({ path }) => (
+      path.length === setNamePath.length - 1
+      && path.every((part, k) => part === setNamePath[k])
+    ));
+    const category = setNamePath[setNamePath.length - 1];
+    const catIndex = colIndex === -1
+      ? -1
+      : columns[colIndex].categories.indexOf(category);
+    if (catIndex === -1) {
+      // Not resolvable from codes; the caller falls back to the tree route.
+      return null;
+    }
+    selIdxByCode[colIndex][catIndex] = i + 1;
+    colors.push(
+      cellSetColor?.find(d => isEqual(d.path, setNamePath))?.color
+      || getDefaultColor(theme),
+    );
+  }
+  // eslint-disable-next-line no-nested-ternary
+  const IndicesArrayType = paths.length + 1 <= 256
+    ? Uint8Array
+    : (paths.length + 1 <= 65536 ? Uint16Array : Uint32Array);
+  const colorIndices = new IndicesArrayType(numObs);
+  for (let j = 0; j < columns.length; j += 1) {
+    const { codes } = columns[j];
+    const table = selIdxByCode[j];
+    for (let i = 0; i < numObs; i += 1) {
+      const code = codes[i];
+      if (code >= 0) {
+        const v = table[code];
+        if (v > colorIndices[i]) {
+          colorIndices[i] = v;
+        }
+      }
+    }
+  }
+  return { colorIndices, colorProbs: null, colors };
+}
+
 export function treeToColorIndicesArray(
   currTree, selectedNamePaths, cellSetColor, obsIndex, theme,
 ) {

--- a/packages/utils/sets-utils/src/cell-set-utils.js
+++ b/packages/utils/sets-utils/src/cell-set-utils.js
@@ -535,9 +535,10 @@ export function getObsIndexMap(obsIndex) {
  * Build the positional color encoding directly from raw categorical codes,
  * skipping the tree walk that treeToColorIndicesArray performs. Applicable when
  * every selected path resolves to a (hierarchy, category) pair in the provided
- * columns; selections that do not resolve — user-defined selections from
- * additionalObsSets, paths deeper than two levels, or the undefined-named set
- * for missing values — return null so the caller can fall back to the tree route.
+ * columns, where the category MISSING_VALUE_PLACEHOLDER resolves to the
+ * observations with a negative (missing) code. Selections that do not resolve —
+ * user-defined selections from additionalObsSets, or paths deeper than two
+ * levels — return null so the caller can fall back to the tree route.
  *
  * The output is identical to treeToColorIndicesArray for the tree built from the
  * same columns: index 0 means "in no selected set", and where an observation is
@@ -566,6 +567,9 @@ export function colorIndicesFromCodes({
   const selIdxByCode = columns.map(
     ({ categories }) => new Int32Array(categories.length),
   );
+  // Per column, the (selected path index + 1) for observations with a negative
+  // (missing) code, when the placeholder-named set is selected.
+  const selIdxMissing = new Int32Array(columns.length);
   const colors = [];
   for (let i = 0; i < paths.length; i += 1) {
     const setNamePath = paths[i];
@@ -573,15 +577,24 @@ export function colorIndicesFromCodes({
       path.length === setNamePath.length - 1
       && path.every((part, k) => part === setNamePath[k])
     ));
-    const category = setNamePath[setNamePath.length - 1];
-    const catIndex = colIndex === -1
-      ? -1
-      : columns[colIndex].categories.indexOf(category);
-    if (catIndex === -1) {
+    if (colIndex === -1) {
       // Not resolvable from codes; the caller falls back to the tree route.
       return null;
     }
-    selIdxByCode[colIndex][catIndex] = i + 1;
+    const category = setNamePath[setNamePath.length - 1];
+    const catIndex = columns[colIndex].categories.indexOf(category);
+    if (category === MISSING_VALUE_PLACEHOLDER) {
+      // The set of observations whose code is negative. Should a real category
+      // share the placeholder name, the tree merges both into one set, so both
+      // are colored here as well.
+      selIdxMissing[colIndex] = i + 1;
+    } else if (catIndex === -1) {
+      // Not resolvable from codes; the caller falls back to the tree route.
+      return null;
+    }
+    if (catIndex !== -1) {
+      selIdxByCode[colIndex][catIndex] = i + 1;
+    }
     colors.push(
       cellSetColor?.find(d => isEqual(d.path, setNamePath))?.color
       || getDefaultColor(theme),
@@ -595,13 +608,12 @@ export function colorIndicesFromCodes({
   for (let j = 0; j < columns.length; j += 1) {
     const { codes } = columns[j];
     const table = selIdxByCode[j];
+    const missingSel = selIdxMissing[j];
     for (let i = 0; i < numObs; i += 1) {
       const code = codes[i];
-      if (code >= 0) {
-        const v = table[code];
-        if (v > colorIndices[i]) {
-          colorIndices[i] = v;
-        }
+      const v = code >= 0 ? table[code] : missingSel;
+      if (v > colorIndices[i]) {
+        colorIndices[i] = v;
       }
     }
   }

--- a/packages/utils/sets-utils/src/cell-set-utils.test.js
+++ b/packages/utils/sets-utils/src/cell-set-utils.test.js
@@ -523,14 +523,26 @@ describe('Hierarchical sets cell-set-utils', () => {
         cellSetColor: setColor,
         theme: 'light',
       })).toEqual(null);
-      // The undefined-named set that holds missing codes.
-      expect(colorIndicesFromCodes({
+    });
+
+    it('resolves the placeholder-named set to observations with missing codes', () => {
+      // cell_3 has a missing Cell Type code; cell_4 has a missing Leiden code.
+      const missing = colorIndicesFromCodes({
         columns,
         obsIndex,
-        selectedNamePaths: [['Cell Type', undefined]],
+        selectedNamePaths: [['Cell Type', MISSING_VALUE_PLACEHOLDER]],
         cellSetColor: setColor,
         theme: 'light',
-      })).toEqual(null);
+      });
+      expect(Array.from(missing.colorIndices)).toEqual([0, 0, 1, 0, 0]);
+      expectSameAsTreeRoute([['Cell Type', MISSING_VALUE_PLACEHOLDER]]);
+      expectSameAsTreeRoute([['Leiden', MISSING_VALUE_PLACEHOLDER], ['Cell Type', 'T cell']]);
+      expectSameAsTreeRoute([
+        ['Cell Type', MISSING_VALUE_PLACEHOLDER], ['Leiden', MISSING_VALUE_PLACEHOLDER],
+      ]);
+    });
+
+    it('returns null for a wrong-depth path', () => {
       // A path with the wrong depth.
       expect(colorIndicesFromCodes({
         columns,
@@ -563,12 +575,20 @@ describe('Hierarchical sets cell-set-utils', () => {
 
 describe('Missing set names', () => {
   // A negative categorical code is a missing value. codesToCellSetsTree (like
-  // dataToCellSetsTree) places those observations in a set whose name is undefined.
+  // dataToCellSetsTree) places those observations in a set named by the placeholder.
   const obsIndex = ['c1', 'c2', 'c3', 'c4'];
   const columns = [{ codes: Int8Array.from([0, -1, 1, -1]), categories: ['A', 'B'] }];
   const missingTree = codesToCellSetsTree({ obsIndex, columns }, [{ name: 'Label' }]);
-  const missingPath = ['Label', undefined];
-  const missingNode = missingTree.tree[0].children.find(c => c.name === undefined);
+  const missingPath = ['Label', MISSING_VALUE_PLACEHOLDER];
+  const missingNode = missingTree.tree[0].children.find(c => c.name === MISSING_VALUE_PLACEHOLDER);
+
+  it('gives the missing set a real name that survives serialization', () => {
+    expect(missingNode).toBeDefined();
+    // A selection path into the set round-trips through JSON (as a view config
+    // does) and still resolves to the same node.
+    const roundTripped = JSON.parse(JSON.stringify(missingPath));
+    expect(treeFindNodeByNamePath(missingTree, roundTripped)).toBe(missingNode);
+  });
 
   it('titles the missing set with the shared placeholder in the sets manager', () => {
     const renderProps = nodeToRenderProps(missingNode, missingPath, []);

--- a/packages/utils/sets-utils/src/cell-set-utils.test.js
+++ b/packages/utils/sets-utils/src/cell-set-utils.test.js
@@ -1,6 +1,7 @@
 /* eslint-disable no-underscore-dangle */
 import { describe, it, expect } from 'vitest';
 import { cloneDeep } from 'lodash-es';
+import { MISSING_VALUE_PLACEHOLDER } from '@vitessce/utils';
 
 import {
   nodeToRenderProps,
@@ -557,5 +558,38 @@ describe('Hierarchical sets cell-set-utils', () => {
       expect(membership.size).toEqual(7);
       expect(treeToMembershipMap(null).size).toEqual(0);
     });
+  });
+});
+
+describe('Missing set names', () => {
+  // A negative categorical code is a missing value. codesToCellSetsTree (like
+  // dataToCellSetsTree) places those observations in a set whose name is undefined.
+  const obsIndex = ['c1', 'c2', 'c3', 'c4'];
+  const columns = [{ codes: Int8Array.from([0, -1, 1, -1]), categories: ['A', 'B'] }];
+  const missingTree = codesToCellSetsTree({ obsIndex, columns }, [{ name: 'Label' }]);
+  const missingPath = ['Label', undefined];
+  const missingNode = missingTree.tree[0].children.find(c => c.name === undefined);
+
+  it('titles the missing set with the shared placeholder in the sets manager', () => {
+    const renderProps = nodeToRenderProps(missingNode, missingPath, []);
+    expect(renderProps.title).toEqual(MISSING_VALUE_PLACEHOLDER);
+    expect(renderProps.size).toEqual(2);
+    // Named sets are untouched.
+    const namedNode = missingTree.tree[0].children.find(c => c.name === 'A');
+    expect(nodeToRenderProps(namedNode, ['Label', 'A'], []).title).toEqual('A');
+  });
+
+  it('labels the missing set with the same placeholder in plot data', () => {
+    const sizes = treeToSetSizesBySetNames(
+      missingTree, [['Label', 'A'], missingPath], [missingPath], [], 'dark',
+    );
+    expect(sizes.map(s => s.name)).toEqual(['A', MISSING_VALUE_PLACEHOLDER]);
+    expect(sizes[1].size).toEqual(2);
+    // The identity of the set is still carried by its path, not the display name.
+    expect(sizes[1].setNamePath).toEqual(missingPath);
+
+    const objects = treeToObjectsBySetNames(missingTree, [missingPath], [], 'dark');
+    expect(objects.map(o => o.obsId)).toEqual(['c2', 'c4']);
+    expect(objects.every(o => o.name === MISSING_VALUE_PLACEHOLDER)).toEqual(true);
   });
 });

--- a/packages/utils/sets-utils/src/cell-set-utils.test.js
+++ b/packages/utils/sets-utils/src/cell-set-utils.test.js
@@ -20,9 +20,11 @@ import {
   treeToCellSetColorIndicesBySetNames,
   treeToObjectsBySetNames,
   treeToColorIndicesArray,
+  colorIndicesFromCodes,
   getObsIndexMap,
   treeToMembershipMap,
 } from './cell-set-utils.js';
+import { codesToCellSetsTree } from './CellSetsZarrLoader.js';
 
 import {
   levelTwoNodeLeaf,
@@ -447,6 +449,95 @@ describe('Hierarchical sets cell-set-utils', () => {
         tree, [PERICYTES], setColor, ['cell_2'], 'light',
       );
       expect(Array.from(partial.colorIndices)).toEqual([1]);
+    });
+  });
+
+  describe('Color indices from raw codes', () => {
+    const obsIndex = ['cell_1', 'cell_2', 'cell_3', 'cell_4', 'cell_5'];
+    const columns = [
+      {
+        name: 'Cell Type',
+        path: ['Cell Type'],
+        codes: Int8Array.from([0, 1, -1, 0, 1]),
+        categories: ['T cell', 'B cell'],
+      },
+      {
+        name: 'Leiden',
+        path: ['Leiden'],
+        codes: Int8Array.from([1, 1, 0, -1, 0]),
+        categories: ['0', '1'],
+      },
+    ];
+    const options = [{ name: 'Cell Type' }, { name: 'Leiden' }];
+    const codesTree = codesToCellSetsTree({ obsIndex, columns }, options);
+    const setColor = [
+      { path: ['Cell Type', 'T cell'], color: [255, 0, 0] },
+      { path: ['Leiden', '0'], color: [0, 255, 0] },
+    ];
+
+    // The two routes must be interchangeable, so compare against the tree route
+    // on the tree built from the same columns.
+    function expectSameAsTreeRoute(selection) {
+      const expected = treeToColorIndicesArray(
+        codesTree, selection, setColor, obsIndex, 'light',
+      );
+      const actual = colorIndicesFromCodes({
+        columns, obsIndex, selectedNamePaths: selection, cellSetColor: setColor, theme: 'light',
+      });
+      expect(actual).not.toEqual(null);
+      expect(Array.from(actual.colorIndices)).toEqual(Array.from(expected.colorIndices));
+      expect(actual.colors).toEqual(expected.colors);
+      expect(actual.colorProbs).toEqual(expected.colorProbs);
+    }
+
+    it('matches the tree route for a single-hierarchy selection', () => {
+      expectSameAsTreeRoute([['Cell Type', 'T cell'], ['Cell Type', 'B cell']]);
+    });
+
+    it('matches the tree route across hierarchies (later path wins)', () => {
+      expectSameAsTreeRoute([['Cell Type', 'T cell'], ['Leiden', '1']]);
+      expectSameAsTreeRoute([['Leiden', '1'], ['Cell Type', 'T cell']]);
+    });
+
+    it('matches the tree route for missing colors and empty selections', () => {
+      // 'Leiden' > '1' has no entry in setColor, so it takes the theme default.
+      expectSameAsTreeRoute([['Leiden', '1']]);
+      expectSameAsTreeRoute([]);
+    });
+
+    it('returns null for selections it cannot resolve', () => {
+      // A user-defined selection from additionalObsSets.
+      expect(colorIndicesFromCodes({
+        columns,
+        obsIndex,
+        selectedNamePaths: [['My Selections', 'Selection 1']],
+        cellSetColor: setColor,
+        theme: 'light',
+      })).toEqual(null);
+      // A category that is not in the column.
+      expect(colorIndicesFromCodes({
+        columns,
+        obsIndex,
+        selectedNamePaths: [['Cell Type', 'NK cell']],
+        cellSetColor: setColor,
+        theme: 'light',
+      })).toEqual(null);
+      // The undefined-named set that holds missing codes.
+      expect(colorIndicesFromCodes({
+        columns,
+        obsIndex,
+        selectedNamePaths: [['Cell Type', undefined]],
+        cellSetColor: setColor,
+        theme: 'light',
+      })).toEqual(null);
+      // A path with the wrong depth.
+      expect(colorIndicesFromCodes({
+        columns,
+        obsIndex,
+        selectedNamePaths: [['Cell Type', 'T cell', 'extra']],
+        cellSetColor: setColor,
+        theme: 'light',
+      })).toEqual(null);
     });
   });
 

--- a/packages/utils/sets-utils/src/index.js
+++ b/packages/utils/sets-utils/src/index.js
@@ -3,6 +3,7 @@ export {
   treeToCellColorsBySetNames,
   treeToCellSetColorIndicesBySetNames,
   treeToColorIndicesArray,
+  colorIndicesFromCodes,
   getObsIndexMap,
   treeToSetSizesBySetNames,
   treeToObjectsBySetNames,
@@ -32,6 +33,7 @@ export {
 } from './cell-set-utils.js';
 export {
   lazyTreeToMembershipMap,
+  membershipFromCodes,
 } from './membership.js';
 export {
   findLongestCommonPath,
@@ -68,6 +70,7 @@ export {
 } from './constants.js';
 export {
   dataToCellSetsTree,
+  codesToCellSetsTree,
 } from './CellSetsZarrLoader.js';
 export {
   getCellColors,

--- a/packages/utils/sets-utils/src/membership.js
+++ b/packages/utils/sets-utils/src/membership.js
@@ -1,4 +1,5 @@
 import { ObsSetsWorker, packStrings } from '@vitessce/workers';
+import { MISSING_VALUE_PLACEHOLDER } from '@vitessce/utils';
 import { treeToLeafSets, treeToMembershipMap, getObsIndexMap } from './cell-set-utils.js';
 
 // Built membership encodings, keyed weakly by the set tree they came from, so that
@@ -177,7 +178,7 @@ export function lazyTreeToMembershipMap(currTree, obsIndex = undefined) {
  * all: a lookup is a memoized obsIndexMap position plus one typed-array read per
  * hierarchy. Matches the answers a tree-based membership map would give for the
  * tree that codesToCellSetsTree builds from the same columns, including the
- * undefined-named set that holds observations with a negative (missing) code.
+ * placeholder-named set that holds observations with a negative (missing) code.
  * @param {string[]} obsIndex The observation index shared by all columns.
  * @param {{ name: string, codes: ArrayLike<number>, categories: string[] }[]} columns
  * Raw codes and category names per hierarchy, with the hierarchy name.
@@ -198,9 +199,9 @@ export function membershipFromCodes(obsIndex, columns) {
     for (let j = 0; j < columns.length; j += 1) {
       const { name, codes, categories } = columns[j];
       const code = codes[obsI];
-      // categories[negativeCode] is undefined, mirroring the undefined-named
-      // set in the tree; the path is still reported.
-      paths[j] = [name, code >= 0 ? categories[code] : undefined];
+      // A negative code is a missing value, which the tree places in the set
+      // named by the shared placeholder.
+      paths[j] = [name, code >= 0 ? categories[code] : MISSING_VALUE_PLACEHOLDER];
     }
     return paths;
   }

--- a/packages/utils/sets-utils/src/membership.js
+++ b/packages/utils/sets-utils/src/membership.js
@@ -170,3 +170,47 @@ export function lazyTreeToMembershipMap(currTree, obsIndex = undefined) {
     },
   };
 }
+
+/**
+ * Get an observation-ID-to-set-paths lookup backed directly by raw categorical
+ * codes, for single-level hierarchies. No per-observation structure is built at
+ * all: a lookup is a memoized obsIndexMap position plus one typed-array read per
+ * hierarchy. Matches the answers a tree-based membership map would give for the
+ * tree that codesToCellSetsTree builds from the same columns, including the
+ * undefined-named set that holds observations with a negative (missing) code.
+ * @param {string[]} obsIndex The observation index shared by all columns.
+ * @param {{ name: string, codes: ArrayLike<number>, categories: string[] }[]} columns
+ * Raw codes and category names per hierarchy, with the hierarchy name.
+ * @returns {{ get: Function, has: Function, size: number }} A Map-like lookup
+ * exposing the subset of the Map interface that consumers use.
+ */
+export function membershipFromCodes(obsIndex, columns) {
+  // The only per-observation cost left is the obsId-to-position map, which is
+  // shared via getObsIndexMap. Warm it during idle time so the first tooltip
+  // hover does not pay for building it.
+  whenIdle(() => getObsIndexMap(obsIndex));
+  function get(obsId) {
+    const obsI = getObsIndexMap(obsIndex).get(obsId);
+    if (obsI === undefined) {
+      return undefined;
+    }
+    const paths = new Array(columns.length);
+    for (let j = 0; j < columns.length; j += 1) {
+      const { name, codes, categories } = columns[j];
+      const code = codes[obsI];
+      // categories[negativeCode] is undefined, mirroring the undefined-named
+      // set in the tree; the path is still reported.
+      paths[j] = [name, code >= 0 ? categories[code] : undefined];
+    }
+    return paths;
+  }
+  return {
+    get,
+    has: obsId => get(obsId) !== undefined,
+    get size() {
+      // Every observation belongs to one set per hierarchy (possibly the
+      // undefined-named one), so membership covers the whole index.
+      return columns.length > 0 ? obsIndex.length : 0;
+    },
+  };
+}

--- a/packages/utils/sets-utils/src/membership.test.js
+++ b/packages/utils/sets-utils/src/membership.test.js
@@ -2,7 +2,8 @@ import { describe, it, expect } from 'vitest';
 import { cloneDeep } from 'lodash-es';
 import { buildMembershipCsr } from '@vitessce/workers';
 import { treeToLeafSets, treeToMembershipMap } from './cell-set-utils.js';
-import { lazyTreeToMembershipMap } from './membership.js';
+import { lazyTreeToMembershipMap, membershipFromCodes } from './membership.js';
+import { codesToCellSetsTree } from './CellSetsZarrLoader.js';
 import { tree } from './cell-set-utils.test.fixtures.js';
 
 const PERICYTES = ['Cell Type Annotations', 'Vasculature', 'Pericytes'];
@@ -102,5 +103,33 @@ describe('obs set membership store', () => {
     // Without an obsIndex there is nothing to align to, so it stays on the
     // main-thread path.
     expect(lazyTreeToMembershipMap(tree).get('cell_1')).toEqual([PERICYTES]);
+  });
+});
+
+describe('membershipFromCodes', () => {
+  const obsIndex = ['cell_1', 'cell_2', 'cell_3', 'cell_4'];
+  const columns = [
+    { name: 'Cell Type', codes: Int8Array.from([0, 1, -1, 0]), categories: ['T cell', 'B cell'] },
+    { name: 'Leiden', codes: Int8Array.from([1, 1, 0, -1]), categories: ['0', '1'] },
+  ];
+
+  it('matches the tree-based membership map, including missing codes', () => {
+    const options = [{ name: 'Cell Type' }, { name: 'Leiden' }];
+    const codesTree = codesToCellSetsTree({ obsIndex, columns }, options);
+    const expected = treeToMembershipMap(codesTree);
+    const membership = membershipFromCodes(obsIndex, columns);
+    obsIndex.forEach((obsId) => {
+      expect(membership.get(obsId)).toEqual(expected.get(obsId));
+      expect(membership.has(obsId)).toEqual(true);
+    });
+    expect(membership.size).toEqual(expected.size);
+    // A missing code reports the undefined-named set, as the tree does.
+    expect(membership.get('cell_3')).toEqual([['Cell Type', undefined], ['Leiden', '0']]);
+    expect(membership.get('not_a_cell')).toEqual(undefined);
+    expect(membership.has('not_a_cell')).toEqual(false);
+  });
+
+  it('reports zero size with no columns', () => {
+    expect(membershipFromCodes(obsIndex, []).size).toEqual(0);
   });
 });

--- a/packages/utils/sets-utils/src/membership.test.js
+++ b/packages/utils/sets-utils/src/membership.test.js
@@ -1,4 +1,5 @@
 import { describe, it, expect } from 'vitest';
+import { MISSING_VALUE_PLACEHOLDER } from '@vitessce/utils';
 import { cloneDeep } from 'lodash-es';
 import { buildMembershipCsr } from '@vitessce/workers';
 import { treeToLeafSets, treeToMembershipMap } from './cell-set-utils.js';
@@ -123,8 +124,8 @@ describe('membershipFromCodes', () => {
       expect(membership.has(obsId)).toEqual(true);
     });
     expect(membership.size).toEqual(expected.size);
-    // A missing code reports the undefined-named set, as the tree does.
-    expect(membership.get('cell_3')).toEqual([['Cell Type', undefined], ['Leiden', '0']]);
+    // A missing code reports the placeholder-named set, as the tree does.
+    expect(membership.get('cell_3')).toEqual([['Cell Type', MISSING_VALUE_PLACEHOLDER], ['Leiden', '0']]);
     expect(membership.get('not_a_cell')).toEqual(undefined);
     expect(membership.has('not_a_cell')).toEqual(false);
   });

--- a/packages/utils/zarr-utils/src/index.ts
+++ b/packages/utils/zarr-utils/src/index.ts
@@ -4,7 +4,9 @@ export {
 export {
   zarrOpenRoot,
   transformEntriesForZipFileStore,
+  CachedStore,
 } from './normalize.js';
+export type { QueryClientLike } from './normalize.js';
 export { createStoreFromMapContents } from './base64-store.js';
 export { createGetRange } from './base-getrange.js';
 export {

--- a/packages/utils/zarr-utils/src/normalize.test.ts
+++ b/packages/utils/zarr-utils/src/normalize.test.ts
@@ -1,0 +1,137 @@
+import { describe, it, expect } from 'vitest';
+import type { AbsolutePath, RangeQuery } from 'zarrita';
+import { CachedStore, type QueryClientLike } from './normalize.js';
+
+// A store whose responses resolve only when released, for testing coalescing.
+function makeGatedStore(withGetRange = true) {
+  const calls: string[] = [];
+  let release: () => void = () => undefined;
+  const gate = new Promise<void>((resolve) => { release = resolve; });
+  const bytesFor = (label: string) => new TextEncoder().encode(label);
+  const store = {
+    async get(key: AbsolutePath) {
+      calls.push(`get:${key}`);
+      await gate;
+      if (key === '/missing') {
+        return undefined;
+      }
+      return bytesFor(`get:${key}`);
+    },
+    ...(withGetRange ? {
+      async getRange(key: AbsolutePath, range: RangeQuery) {
+        calls.push(`getRange:${key}:${JSON.stringify(range)}`);
+        await gate;
+        return bytesFor(`getRange:${key}:${JSON.stringify(range)}`);
+      },
+    } : {}),
+  };
+  return { store, calls, release: () => release() };
+}
+
+// A minimal fetchQuery implementation with permanent retention, for testing that
+// CachedStore drives a QueryClient correctly (dedup of both concurrent and
+// sequential reads).
+function makeQueryClientStub() {
+  const cache = new Map<string, Promise<unknown>>();
+  let fetchQueryCalls = 0;
+  const queryClient: QueryClientLike = {
+    fetchQuery({ queryKey, queryFn }) {
+      fetchQueryCalls += 1;
+      const key = JSON.stringify(queryKey);
+      let promise = cache.get(key);
+      if (!promise) {
+        promise = queryFn();
+        cache.set(key, promise);
+      }
+      return promise;
+    },
+  };
+  return { queryClient, cache, getFetchQueryCalls: () => fetchQueryCalls };
+}
+
+describe('CachedStore', () => {
+  it('coalesces concurrent gets for the same key (no queryClient)', async () => {
+    const { store, calls, release } = makeGatedStore();
+    const cached = new CachedStore(store, 'http://example.com/a.zarr');
+    const promises = [
+      cached.get('/X/0.0'),
+      cached.get('/X/0.0'),
+      cached.get('/X/0.1'),
+    ];
+    release();
+    const [a, b, c] = await Promise.all(promises);
+    expect(calls.filter(x => x === 'get:/X/0.0').length).toEqual(1);
+    expect(calls.filter(x => x === 'get:/X/0.1').length).toEqual(1);
+    expect(a).toBe(b);
+    expect(new TextDecoder().decode(c)).toEqual('get:/X/0.1');
+  });
+
+  it('does not retain results without a queryClient', async () => {
+    const { store, calls, release } = makeGatedStore();
+    const cached = new CachedStore(store, 'http://example.com/a.zarr');
+    release();
+    await cached.get('/X/0.0');
+    await cached.get('/X/0.0');
+    // Sequential reads each hit the store: the fallback only coalesces in-flight.
+    expect(calls.filter(x => x === 'get:/X/0.0').length).toEqual(2);
+  });
+
+  it('caches sequential gets through a queryClient', async () => {
+    const { store, calls, release } = makeGatedStore();
+    const { queryClient, getFetchQueryCalls } = makeQueryClientStub();
+    const cached = new CachedStore(store, 'http://example.com/a.zarr', queryClient);
+    release();
+    const first = await cached.get('/X/0.0');
+    const second = await cached.get('/X/0.0');
+    expect(calls.filter(x => x === 'get:/X/0.0').length).toEqual(1);
+    expect(getFetchQueryCalls()).toEqual(2);
+    expect(first).toBe(second);
+  });
+
+  it('round-trips undefined results through the queryClient', async () => {
+    const { store, release } = makeGatedStore();
+    const { queryClient } = makeQueryClientStub();
+    const cached = new CachedStore(store, 'http://example.com/a.zarr', queryClient);
+    release();
+    expect(await cached.get('/missing')).toEqual(undefined);
+    // The cached undefined answers again without becoming null.
+    expect(await cached.get('/missing')).toEqual(undefined);
+  });
+
+  it('keys getRange reads by range', async () => {
+    const { store, calls, release } = makeGatedStore();
+    const cached = new CachedStore(store, 'http://example.com/a.zarr');
+    const r1 = { offset: 0, length: 10 };
+    const r2 = { offset: 10, length: 10 };
+    const promises = [
+      cached.getRange?.('/f', r1),
+      cached.getRange?.('/f', r1),
+      cached.getRange?.('/f', r2),
+    ];
+    release();
+    await Promise.all(promises);
+    expect(calls.filter(x => x.startsWith('getRange:/f:')).length).toEqual(2);
+  });
+
+  it('omits getRange when the wrapped store lacks one', () => {
+    const { store } = makeGatedStore(false);
+    const cached = new CachedStore(store, 'http://example.com/a.zarr');
+    // Consumers feature-detect getRange, so the wrapper must not invent it.
+    expect(cached.getRange).toEqual(undefined);
+  });
+
+  it('separates caches by URL prefix', async () => {
+    const gatedA = makeGatedStore();
+    const gatedB = makeGatedStore();
+    const { queryClient } = makeQueryClientStub();
+    const cachedA = new CachedStore(gatedA.store, 'http://example.com/a.zarr', queryClient);
+    const cachedB = new CachedStore(gatedB.store, 'http://example.com/b.zarr', queryClient);
+    gatedA.release();
+    gatedB.release();
+    await cachedA.get('/X/0.0');
+    await cachedB.get('/X/0.0');
+    // Same key, different URLs: both stores are read.
+    expect(gatedA.calls.length).toEqual(1);
+    expect(gatedB.calls.length).toEqual(1);
+  });
+});

--- a/packages/utils/zarr-utils/src/normalize.ts
+++ b/packages/utils/zarr-utils/src/normalize.ts
@@ -5,10 +5,114 @@ import ZipFileStore from '@zarrita/storage/zip';
 import ReferenceStore from '@zarrita/storage/ref';
 import { getDebugMode } from '@vitessce/globals';
 
+// The subset of a TanStack Query QueryClient that the store cache uses. Typed
+// structurally so this package does not need a dependency on @tanstack/query-core;
+// the instance is created by vit-s and threaded through the DataSource constructor.
+export type QueryClientLike = {
+  fetchQuery: (options: {
+    queryKey: unknown[],
+    queryFn: () => Promise<unknown>,
+    staleTime?: number,
+    gcTime?: number,
+  }) => Promise<unknown>,
+};
+
 type ZarrOpenRootOptions = {
   requestInit?: RequestInit,
   refSpecUrl?: string,
+  queryClient?: QueryClientLike,
 };
+
+// How long a fetched chunk stays in the react-query cache once no fetch is using it.
+// Chunks are large binary blobs, so retention is kept short: the important effect is
+// that concurrent reads of the same chunk share one request (and one decode input);
+// re-reads within a brief window are a bonus, not the goal.
+const CHUNK_GC_TIME = 30_000;
+
+// react-query does not allow `undefined` as query data, but zarrita stores return
+// `undefined` for missing keys, so a sentinel stands in for it inside the cache.
+const UNDEFINED_SENTINEL = null;
+
+type CacheFetchFn = (
+  cacheKey: unknown[],
+  fn: () => Promise<Uint8Array | undefined>,
+) => Promise<Uint8Array | undefined>;
+
+/**
+ * Build the function through which all cached store reads flow.
+ * @param queryClient A QueryClient, when available.
+ * @returns With a queryClient: reads go through fetchQuery, which coalesces
+ * concurrent requests for the same key and retains results briefly — and, because
+ * the cache lives on the client rather than the store instance, is shared across
+ * store instances for the same URL. Without one: a local in-flight map that
+ * coalesces concurrent requests and retains nothing.
+ */
+function makeCacheFetch(queryClient?: QueryClientLike): CacheFetchFn {
+  if (queryClient) {
+    return async (cacheKey, fn) => {
+      const result = await queryClient.fetchQuery({
+        queryKey: cacheKey,
+        queryFn: async () => (await fn()) ?? UNDEFINED_SENTINEL,
+        staleTime: Infinity,
+        gcTime: CHUNK_GC_TIME,
+      });
+      return (result === UNDEFINED_SENTINEL ? undefined : result) as Uint8Array | undefined;
+    };
+  }
+  const inflight = new Map<string, Promise<Uint8Array | undefined>>();
+  return (cacheKey, fn) => {
+    const key = JSON.stringify(cacheKey);
+    let promise = inflight.get(key);
+    if (!promise) {
+      promise = fn().finally(() => {
+        inflight.delete(key);
+      });
+      inflight.set(key, promise);
+    }
+    return promise;
+  };
+}
+
+/**
+ * A read-through cache around a zarrita store. Concurrent reads of the same
+ * (key, range) share one underlying request; see makeCacheFetch for retention.
+ */
+export class CachedStore {
+  store: Readable;
+
+  cacheKeyPrefix: string;
+
+  cacheFetch: CacheFetchFn;
+
+  getRange?: (
+    key: AbsolutePath, range: RangeQuery, opts?: RequestInit,
+  ) => Promise<Uint8Array | undefined>;
+
+  constructor(store: Readable, cacheKeyPrefix: string, queryClient?: QueryClientLike) {
+    this.store = store;
+    this.cacheKeyPrefix = cacheKeyPrefix;
+    this.cacheFetch = makeCacheFetch(queryClient);
+    // getRange is part of zarrita's optional store interface and consumers
+    // feature-detect it, so only define it when the wrapped store has one.
+    if (typeof (store as { getRange?: unknown }).getRange === 'function') {
+      this.getRange = (key, range, opts) => this.cacheFetch(
+        ['zarrStore', this.cacheKeyPrefix, key, range],
+        () => (this.store as {
+          getRange: (
+            k: AbsolutePath, r: RangeQuery, o?: RequestInit,
+          ) => Promise<Uint8Array | undefined>,
+        }).getRange(key, range, opts),
+      );
+    }
+  }
+
+  get(key: AbsolutePath, opts?: RequestInit): Promise<Uint8Array | undefined> {
+    return this.cacheFetch(
+      ['zarrStore', this.cacheKeyPrefix, key],
+      async () => this.store.get(key, opts),
+    );
+  }
+}
 
 class RelaxedFetchStore extends FetchStore {
   // This allows returning `undefined` for 403 responses,
@@ -118,6 +222,8 @@ export function zarrOpenRoot(url: string, fileType: null | string, opts?: ZarrOp
     store = new RelaxedFetchStore(url, { overrides: opts?.requestInit });
   }
 
-  // Wrap remote stores in a cache
-  return zarrRoot(store);
+  // Wrap remote stores in a read-through cache, so that concurrent reads of the
+  // same chunk (e.g. multiple embedding dims within one chunk column-block) share
+  // one request instead of downloading it once per reader.
+  return zarrRoot(new CachedStore(store, url, opts?.queryClient));
 }

--- a/packages/view-types/scatterplot-embedding/src/EmbeddingScatterplotSubscriber.js
+++ b/packages/view-types/scatterplot-embedding/src/EmbeddingScatterplotSubscriber.js
@@ -29,7 +29,7 @@ import {
 } from '@vitessce/vit-s';
 import {
   setObsSelection, mergeObsSets, getCellSetPolygons, treeToColorIndicesArray,
-  getObsIndexMap, stratifyArrays,
+  colorIndicesFromCodes, getObsIndexMap, stratifyArrays,
 } from '@vitessce/sets-utils';
 import { pluralize as plur, commaNumber, aggregateFeatureArrays } from '@vitessce/utils';
 import {
@@ -187,7 +187,8 @@ export function EmbeddingScatterplotSubscriber(props) {
   );
   const cellsCount = obsEmbeddingIndex?.length || 0;
   const [
-    { obsSets: cellSets, obsSetsMembership }, obsSetsStatus, obsSetsUrls, obsSetsError,
+    { obsSets: cellSets, obsSetsMembership, obsSetsColumns },
+    obsSetsStatus, obsSetsUrls, obsSetsError,
   ] = useObsSetsData(
     loaders, dataset, false,
     { setObsSetSelection: setCellSetSelection, setObsSetColor: setCellSetColor },
@@ -281,9 +282,24 @@ export function EmbeddingScatterplotSubscriber(props) {
   // Positional rather than keyed by observation ID: at atlas scale an ID-keyed color
   // Map costs one string hash lookup per point per render, plus a per-observation
   // color array whenever the selected sets carry confidence scores.
-  const obsColorIndices = useMemo(() => treeToColorIndicesArray(
-    mergedCellSets, cellSetSelection, cellSetColor, obsEmbeddingIndex, theme,
-  ), [mergedCellSets, cellSetSelection, cellSetColor, obsEmbeddingIndex, theme]);
+  const obsColorIndices = useMemo(() => (
+    // When the loader provides raw categorical codes over this same observation
+    // axis (checked by reference), the encoding is one typed-array pass with no
+    // tree walk. colorIndicesFromCodes returns null for selections it cannot
+    // resolve (e.g. user-defined lasso selections), falling back to the tree.
+    (obsSetsColumns && obsSetsColumns.obsIndex === obsEmbeddingIndex
+      && colorIndicesFromCodes({
+        columns: obsSetsColumns.columns,
+        obsIndex: obsEmbeddingIndex,
+        selectedNamePaths: cellSetSelection,
+        cellSetColor,
+        theme,
+      }))
+    || treeToColorIndicesArray(
+      mergedCellSets, cellSetSelection, cellSetColor, obsEmbeddingIndex, theme,
+    )
+  ), [mergedCellSets, cellSetSelection, cellSetColor, obsEmbeddingIndex, theme,
+    obsSetsColumns]);
 
   // cellSetPolygonCache is an array of tuples like [(key0, val0), (key1, val1), ...],
   // where the keys are cellSetSelection arrays.

--- a/packages/view-types/scatterplot-gating/src/GatingSubscriber.js
+++ b/packages/view-types/scatterplot-gating/src/GatingSubscriber.js
@@ -25,6 +25,7 @@ import {
 } from '@vitessce/vit-s';
 import {
   getCellSetPolygons, mergeObsSets, setObsSelection, treeToColorIndicesArray,
+  colorIndicesFromCodes,
 } from '@vitessce/sets-utils';
 import {
   Scatterplot, ScatterplotTooltipSubscriber, ScatterplotOptions,
@@ -155,7 +156,9 @@ export function GatingSubscriber(props) {
   ), [gatingFeatureSelectionY]);
 
   // Get data from loaders using the data hooks.
-  const [{ obsSets: cellSets }, obsSetsStatus, obsSetsUrls, obsSetsError] = useObsSetsData(
+  const [
+    { obsSets: cellSets, obsSetsColumns }, obsSetsStatus, obsSetsUrls, obsSetsError,
+  ] = useObsSetsData(
     loaders, dataset, false,
     { setObsSetSelection: setCellSetSelection, setObsSetColor: setCellSetColor },
     { obsSetSelection: cellSetSelection, obsSetColor: cellSetColor },
@@ -271,9 +274,23 @@ export function GatingSubscriber(props) {
   // Positional rather than keyed by observation ID: at atlas scale an ID-keyed color
   // Map costs one string hash lookup per point per render, plus a per-observation
   // color array whenever the selected sets carry confidence scores.
-  const obsColorIndices = useMemo(() => treeToColorIndicesArray(
-    mergedCellSets, cellSetSelection, cellSetColor, obsIndex, theme,
-  ), [mergedCellSets, cellSetSelection, cellSetColor, obsIndex, theme]);
+  const obsColorIndices = useMemo(() => (
+    // When the loader provides raw categorical codes over this same observation
+    // axis (checked by reference), the encoding is one typed-array pass with no
+    // tree walk. colorIndicesFromCodes returns null for selections it cannot
+    // resolve (e.g. user-defined lasso selections), falling back to the tree.
+    (obsSetsColumns && obsSetsColumns.obsIndex === obsIndex
+      && colorIndicesFromCodes({
+        columns: obsSetsColumns.columns,
+        obsIndex,
+        selectedNamePaths: cellSetSelection,
+        cellSetColor,
+        theme,
+      }))
+    || treeToColorIndicesArray(
+      mergedCellSets, cellSetSelection, cellSetColor, obsIndex, theme,
+    )
+  ), [mergedCellSets, cellSetSelection, cellSetColor, obsIndex, theme, obsSetsColumns]);
 
   // cellSetPolygonCache is an array of tuples like [(key0, val0), (key1, val1), ...],
   // where the keys are cellSetSelection arrays.

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1621,9 +1621,18 @@ importers:
         specifier: workspace:*
         version: link:../vit-s
     devDependencies:
+      '@testing-library/jest-dom':
+        specifier: 'catalog:'
+        version: 6.6.3
+      '@testing-library/react':
+        specifier: 'catalog:'
+        version: 16.3.0(@testing-library/dom@10.4.0)(@types/react-dom@18.0.6)(@types/react@19.1.6)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
       react:
         specifier: 'catalog:'
         version: 19.2.6
+      react-dom:
+        specifier: 'catalog:'
+        version: 19.2.6(react@19.2.6)
       vite:
         specifier: 'catalog:'
         version: 7.1.4(jiti@1.21.7)(lightningcss@1.22.1)(sass@1.89.1)(terser@5.40.0)


### PR DESCRIPTION
Fixes #2564

#### Background

Same 2,073,246-cell HuBMAP dataset as the parent PR. With the coloring fixes in place, the remaining problems were in how the data got to the views:

- **Duplicate chunk downloads (#2564).** `zarrOpenRoot`'s "wrap remote stores in a cache" comment had no cache behind it, so concurrent reads of the same key each issued a fetch. For `X_pca` (`chunks: [129578, 4]`, `dims: [0, 1]`) the same 16 chunk keys were downloaded twice — 25% of the page's initial transfer was duplicate.
- **String materialization for categorical obs sets.** The obs-sets route decoded every categorical column into 2M JS strings, then built the set tree, a 2M-entry membership `Map`, and the color encoding from those strings, when the raw integer codes plus the ~100 category strings already carry the same information.
- **Missing categorical values rendered inconsistently.** 772,400 cells (37%) in this dataset have no `azimuth_label` (code `-1`). Those landed in a set literally named `undefined`, which the sets manager showed as `---` only because that is rc-tree's default title, tooltips showed as a blank cell, and a selection of it (`['Azimuth Label', undefined]`) could not survive `JSON.stringify` of a view config. A multi-level hierarchy with a missing value threw in `dataToCellSetsTree` (`undefined.localeCompare`).

#### Change List

**Zarr read cache (`@vitessce/zarr-utils`, `@vitessce/zarr`)**
- New `CachedStore` wraps every remote store (`FetchStore`, `ZipFileStore`, `ReferenceStore`) returned by `zarrOpenRoot`. Reads go through the app's react-query `QueryClient` (`fetchQuery`, `staleTime: Infinity`, 30 s GC), so concurrent reads of one key share a single download and recent reads are served from cache; without a client it still coalesces in-flight reads. Supports `getRange` when the wrapped store does, and round-trips `undefined` (missing key) safely.
- `ZarrDataSource` accepts the `queryClient` that `VitS` already threads through `createLoaders`. A structural `QueryClientLike` type (`@vitessce/types`) keeps data sources free of a TanStack dependency.
- `AnnDataSource.loadNumericForDims` issues one sliced read when the requested dims are contiguous (the #2564 alternative), instead of one read per dim.

**Raw categorical codes end-to-end (`@vitessce/zarr`, `@vitessce/sets-utils`, `@vitessce/types`)**
- `AnnDataSource._getColumnSpec` factors out column-encoding detection (AnnData 0.7 and 0.8+ layouts); the existing string route (`_loadColumn`) and the new `loadObsColumnCodes` (raw codes + category strings, memoized per path, int64 codes downcast) share it.
- `ObsSetsAnndataLoader` takes the codes route when every entry is a single, unscored categorical column on one obs axis, producing the tree via `codesToCellSetsTree`, memberships via `membershipFromCodes`, and exposing the raw `obsSetsColumns` on the `LoaderResult`. Anything else — scored columns, multi-level hierarchies, non-categorical columns, the SpatialData subclass — keeps the string route unchanged.
- `codesToCellSetsTree` is byte-identical to `dataToCellSetsTree` for the same data (same child ordering, observed categories only). `membershipFromCodes` answers tooltip lookups with one typed-array read per hierarchy and no per-observation structure. `colorIndicesFromCodes` builds the positional color encoding straight from codes; the embedding and gating subscribers use it when `obsSetsColumns.obsIndex` is the same reference as the embedding's index, and fall back to `treeToColorIndicesArray` otherwise (e.g. user-defined selections).

**Consistent missing-value handling (`@vitessce/utils`, `@vitessce/sets-utils`, `@vitessce/tooltip`)**
- New `MISSING_VALUE_PLACEHOLDER` (`'---'`, chosen to match what the sets manager already showed). Both tree builders now *name* the missing-value set with it, ordered after every real category, including the multi-level branch that previously threw. `membershipFromCodes` reports it, and `colorIndicesFromCodes` resolves it back to "code < 0", so selecting the unlabelled set stays on the fast path. The name is a real string, so trees and selection paths survive serialization.
- Render-layer fallbacks for any other source of undefined names: `nodeToRenderProps.title`, the plot-facing `name` fields in `cell-set-utils`, and `TooltipContent` (`value ?? MISSING_VALUE_PLACEHOLDER`), covering every tooltip producer at once.

**Tests**
- `normalize.test.ts` (coalescing, retention, `getRange` keying, undefined round-trip, per-URL isolation), `AnnDataSource.test.js`, `ObsSetsAnndataLoader.test.js` (codes route ≡ string route end-to-end: tree, memberships, coordination values), `CellSetsZarrLoader.test.js`, `membership.test.js`, `cell-set-utils.test.js`, `TooltipContent.test.jsx`.

#### Verification

- HAR of the 2M-cell config after this change: every chunk fetched exactly once — `X_pca` 16/16, `X_umap` 32/32, `obs/cell_id` 32/32, zero duplicates (previously the 16 `X_pca` chunks were fetched twice).
- Raw store contents confirmed independently with Node against the live zip: `azimuth_label` 113 categories, `Int8Array` codes, 772,400 × `-1`; `leiden` 59 categories, 0 missing; 2,073,246 distinct obs IDs. The `---` set's size in the UI matches that count.
- Unit tests: sets-utils 82/82, zarr 78/78, zarr-utils 14/14, tooltip 2/2; ESLint and `tsc --build` clean.

**Note for reviewers — evaluate performance in a production build** (`pnpm run build && pnpm -C sites/demo run build-demo && pnpm run preview-demo`). React 19.2 development builds set `ProfileMode` unconditionally and, on every commit, deep-diff component props for the Performance track (`logComponentRender` → `addObjectDiffToProperties`, which `for…in`-enumerates typed arrays with no breadth cap). With 2M-element arrays as `Scatterplot` props this alone blocks the main thread for >14 s per commit and allocates ~1.5 GB, and it dominates any dev-mode profile of this dataset. It is absent from `react-dom.production.js`.

#### Follow-ups (not in this PR)

Measured on the same dataset in a Firefox profile, per scatterplot render, all avoidable when nothing is selected or when the obs indices are the same reference:
- `stratifyArrays` ≈ 2.4 s — ~10 `InternMap` (`JSON.stringify`-keyed) lookups per cell even with no cell/sample set selection; wants a fast path and hoisted lookups.
- `treeToColorIndicesArray` ≈ 1.5 s — builds the 2M-entry `getObsIndexMap` eagerly even when the selection is empty.
- `useExpressionValueGetter` ≈ 0.9 s — builds a second, unshared 2M `Map` plus a 2M array even with no expression data.
- `createQuadTree` ≈ 1.15 s — built on every embedding change but consumed only by the lasso/rectangle `getSelectionLayer`; could be built lazily.
- `alignedEmbedding` ≈ 0.3 s — skippable when `obsEmbeddingIndex === matrixObsIndex`.

Also observed: in the browser, a handful of small metadata keys (`.zattrs`/`.zarray`) were still read twice a few seconds apart although `CachedStore` serves sequential re-reads from cache in isolation; against `.zarr.zip` that is two round-trips per key at ~5 s server latency each, so worth a look. And the zarr test run logs `Failed to parse URL from ''` because `vitest.setup.js` stubs `URL.createObjectURL` to `''`, which breaks inline-worker construction in `lazyTreeToMembershipMap`; the fallback catches it, so it is noise rather than a failure.

#### Checklist
 - [x] Have tested PR with one or more demo configurations — the 2M-cell HuBMAP config, production build
 - [x] Documentation added, updated, or not applicable — no user-facing config changes; loaders pick the codes route automatically
