### PR TITLE
NickAkhmetov/feat: enhance CSR matrix handling and memory management

### DIFF
--- a/.changeset/sparse-matrix-guard.md
+++ b/.changeset/sparse-matrix-guard.md
@@ -1,0 +1,10 @@
+---
+"@vitessce/zarr": patch
+"@vitessce/zarr-utils": patch
+"@vitessce/utils": patch
+"@vitessce/error": patch
+"@vitessce/vit-s": patch
+"docs": patch
+---
+
+Read individual features from CSR-encoded obsFeatureMatrix stores by scanning `indices`/`data` in chunks instead of densifying the whole matrix, coalescing concurrent selections into one scan and refusing scans beyond the browser's allocation budget with a descriptive `MatrixTooLargeError`; warn before full-matrix densification that exceeds the budget and report allocation failures descriptively; fix CSC selection on int64 `indptr` and the silent last-column result for unknown features on dense matrices; document that `csc_matrix` is the preferred sparse encoding.

--- a/packages/error/src/index.js
+++ b/packages/error/src/index.js
@@ -46,3 +46,10 @@ export class ZarrNodeNotFoundError extends DataLoaderError {
     this.name = 'ZarrNodeNotFoundError';
   }
 }
+
+export class MatrixTooLargeError extends DataLoaderError {
+  constructor(message) {
+    super(message);
+    this.name = 'MatrixTooLargeError';
+  }
+}

--- a/packages/file-types/zarr/src/anndata-loaders/ObsFeatureMatrixAnndataLoader.js
+++ b/packages/file-types/zarr/src/anndata-loaders/ObsFeatureMatrixAnndataLoader.js
@@ -1,13 +1,85 @@
 /* eslint-disable no-underscore-dangle */
 import { open as zarrOpen, get as zarrGet, slice } from 'zarrita';
-import { createZarrArrayAdapter } from '@vitessce/zarr-utils';
+import { createZarrArrayAdapter, UNCACHED_READ } from '@vitessce/zarr-utils';
 import { LoaderResult, AbstractTwoStepLoader } from '@vitessce/abstract';
-import { maybeDowncastInt64, concatenateColumnVectors } from './utils.js';
+import { MatrixTooLargeError } from '@vitessce/error';
+import { log } from '@vitessce/globals';
+import {
+  commaNumber,
+  formatBytes,
+  exceedsAllocationBudget,
+  getAllocationBudgetBytes,
+} from '@vitessce/utils';
+import {
+  maybeDowncastInt64,
+  concatenateColumnVectors,
+  bigInt64ToNumberArray,
+  getBytesPerElement,
+  extractCsrColumns,
+  createLimiter,
+} from './utils.js';
+
+const SPARSE_DOCS_URL = 'https://vitessce.io/docs/data-troubleshooting/#anndata-zarr-obsfeaturematrix-with-sparse-matrices';
+const TOO_LARGE_DOCS_URL = 'https://vitessce.io/docs/data-troubleshooting/#my-obsfeaturematrix-is-too-large-to-render-everything';
+
+// Above this estimated download, a CSR feature selection logs a warning (once per
+// loader), so that a permitted-but-slow scan is not silent.
+const CSR_SCAN_WARN_BYTES = 256 * (2 ** 20);
+// Chunk reads kept in flight while scanning a CSR matrix.
+const CSR_SCAN_PREFETCH = 4;
+// Concurrent slice reads when selecting many features from a CSC matrix.
+const CSC_READ_CONCURRENCY = 8;
+// A scan visits each chunk once, so its reads bypass the store-level cache rather
+// than pinning the whole array in it.
+const SCAN_READ_OPTS = { [UNCACHED_READ]: true };
 
 // Put array of data into an object,
 // to match the expected format of the
 // value returned from the load function.
 const toObject = data => ({ data });
+
+const describeShape = shape => `[${shape.join(', ')}]`;
+const describeBytes = bytes => (
+  Number.isFinite(bytes) ? formatBytes(bytes) : 'more memory than can be addressed'
+);
+
+function fullMatrixMessage({ path, shape, description, bytes }) {
+  return `Loading the full observation-by-feature matrix at "${path}" (shape ${describeShape(shape)}, ${description}) needs about ${describeBytes(bytes)} of memory, more than this browser's ~${formatBytes(getAllocationBudgetBytes())} budget. Load a subset of features with the "initialFeatureFilterPath" option (or a smaller subset, if one is already set), or point "path" at a smaller matrix, for example in obsm, together with "featureFilterPath". See ${TOO_LARGE_DOCS_URL}`;
+}
+
+function csrScanMessage({ path, shape, nnz, bytes }) {
+  return `Selecting features from the csr_matrix at "${path}" (shape ${describeShape(shape)}, ${commaNumber(nnz)} stored values) requires scanning about ${describeBytes(bytes)} of "indices" and "data" per selection, more than this browser's ~${formatBytes(getAllocationBudgetBytes())} budget. Store the matrix as csc_matrix (adata.X = scipy.sparse.csc_matrix(adata.X)) so that individual features can be read without scanning the whole matrix. See ${SPARSE_DOCS_URL}`;
+}
+
+/**
+ * Whether an error is the RangeError thrown for a typed array that is too large
+ * or whose buffer could not be allocated. Checked by name as well as by class,
+ * since the error may originate in another realm.
+ * @param {*} e A caught error.
+ * @returns {boolean} True for an allocation failure.
+ */
+function isAllocationFailure(e) {
+  return e instanceof RangeError || e?.name === 'RangeError';
+}
+
+/**
+ * Run an allocation, converting an allocation failure into a
+ * MatrixTooLargeError that explains which matrix was being loaded and what to
+ * do about it.
+ * @param {Function} allocate A function performing the allocation.
+ * @param {string} message The descriptive message to use on failure.
+ * @returns {*} The allocation result.
+ */
+function allocateOrThrow(allocate, message) {
+  try {
+    return allocate();
+  } catch (e) {
+    if (isAllocationFailure(e)) {
+      throw new MatrixTooLargeError(`${message} (${e.message})`);
+    }
+    throw e;
+  }
+}
 
 /**
  * Loader for converting zarr into the a cell x gene matrix for use in Genes/Heatmap components.
@@ -18,28 +90,54 @@ export default class ObsFeatureMatrixAnndataLoader extends AbstractTwoStepLoader
   }
 
   /**
+   * Memoize the promise returned by `factory` on this loader under `key`. A
+   * rejected promise is dropped again, so that a later call (for example a
+   * react-query retry) re-runs the work instead of re-awaiting a dead promise.
+   * @param {string} key The property name to store the promise under.
+   * @param {() => Promise<any>} factory Creates the promise on first use.
+   * @returns {Promise<any>} The memoized promise.
+   */
+  _memoized(key, factory) {
+    if (!this[key]) {
+      this[key] = Promise.resolve().then(factory).catch((err) => {
+        delete this[key];
+        throw err;
+      });
+    }
+    return this[key];
+  }
+
+  /**
+   * Log a warning at most once per loader for a given topic.
+   * @param {string} topic A key identifying the warning.
+   * @param {string} message The warning message.
+   */
+  _warnOnce(topic, message) {
+    if (!this._warned) {
+      this._warned = new Set();
+    }
+    if (!this._warned.has(topic)) {
+      this._warned.add(topic);
+      log.warn(message);
+    }
+  }
+
+  /**
    * Class method for loading the genes list from AnnData.var,
    * filtered if a there is a `geneFilterZarr` present in the view config.
    * @returns {Promise} A promise for the zarr array contianing the gene names.
    */
-  async loadFilteredGeneNames() {
-    if (this.filteredGeneNames) {
-      return this.filteredGeneNames;
-    }
-    const { path, featureFilterPath: geneFilterZarr, geneAlias } = this.getOptions();
-    const getFilterFn = async () => {
-      if (!geneFilterZarr) return data => data;
-      const geneFilter = await this.dataSource.getFlatArrDecompressed(geneFilterZarr);
-      return data => data.filter((_, j) => geneFilter[j]);
-    };
-    const geneNamesPromise = geneAlias
-      ? this.dataSource.loadVarAlias(geneAlias, path)
-      : this.dataSource.loadVarIndex(path);
-    this.filteredGeneNames = Promise.all([
-      geneNamesPromise,
-      getFilterFn(),
-    ]).then(([data, filter]) => filter(data));
-    return this.filteredGeneNames;
+  loadFilteredGeneNames() {
+    return this._memoized('filteredGeneNames', async () => {
+      const { path, featureFilterPath: geneFilterZarr, geneAlias } = this.getOptions();
+      const [geneNames, geneFilter] = await Promise.all([
+        geneAlias
+          ? this.dataSource.loadVarAlias(geneAlias, path)
+          : this.dataSource.loadVarIndex(path),
+        geneFilterZarr ? this.dataSource.getFlatArrDecompressed(geneFilterZarr) : null,
+      ]);
+      return geneFilter ? geneNames.filter((_, j) => geneFilter[j]) : geneNames;
+    });
   }
 
   /**
@@ -57,7 +155,7 @@ export default class ObsFeatureMatrixAnndataLoader extends AbstractTwoStepLoader
   /**
    * Class method for getting the integer indices of a selection of genes within a list.
    * @param {Array} selection A list of gene names.
-   * @returns {Array} A list of integer indices.
+   * @returns {Array} A list of integer indices (-1 for genes that are not present).
    */
   async _getGeneIndices(selection) {
     const geneNames = await this.loadFilteredGeneNames();
@@ -75,60 +173,106 @@ export default class ObsFeatureMatrixAnndataLoader extends AbstractTwoStepLoader
   }
 
   /**
-   * Class method for getting the number of genes i.e entries in `var`,
-   * potentially filtered by `genesFilter`.
-   * @returns {Number} The number of genes.
+   * Load the attributes of the matrix group or array (encoding type, and the
+   * shape for sparse encodings).
+   * @returns {Promise<object>} The attributes.
    */
-  async _getNumGenes() {
-    const genes = await this.loadFilteredGeneNames();
-    return genes.length;
+  _loadMatrixZattrs() {
+    return this._memoized('matrixZattrs', () => {
+      const { path: matrix } = this.getOptions();
+      return this.dataSource.getJson(`${matrix}/.zattrs`);
+    });
   }
 
   /**
    * Class method for opening the sparse matrix arrays in zarr.
-   * @returns {Array} A list of promises pointing to the indptr, indices, and data of the matrix.
+   * @returns {Promise<Array>} The opened indptr, indices, and data arrays.
    */
-  async _openSparseArrays() {
-    const { path: matrix } = this.getOptions();
-    const { storeRoot } = this.dataSource;
-    if (this.sparseArrays) {
-      return this.sparseArrays;
-    }
-    this.sparseArrays = Promise.all(
-      ['indptr', 'indices', 'data'].map(name => zarrOpen(storeRoot.resolve(`${matrix}/${name}`), { kind: 'array' })),
-    );
-    return this.sparseArrays;
+  _openSparseArrays() {
+    return this._memoized('sparseArrays', () => {
+      const { path: matrix } = this.getOptions();
+      const { storeRoot } = this.dataSource;
+      return Promise.all(
+        ['indptr', 'indices', 'data'].map(name => zarrOpen(
+          storeRoot.resolve(`${matrix}/${name}`), { kind: 'array' },
+        )),
+      );
+    });
+  }
+
+  /**
+   * Open the dense matrix array in zarr.
+   * @returns {Promise<object>} The opened zarr array.
+   */
+  _openDenseArray() {
+    return this._memoized('denseArray', () => {
+      const { path: matrix } = this.getOptions();
+      const { storeRoot } = this.dataSource;
+      return zarrOpen(storeRoot.resolve(matrix), { kind: 'array' });
+    });
+  }
+
+  /**
+   * Load the sparse `indptr` array once, as plain numbers. Its values are
+   * bounded by nnz and can exceed 2^31, so int64 is converted without truncation.
+   * @returns {Promise<ArrayLike<number>>} The row (CSR) or column (CSC) pointers.
+   */
+  _loadIndptr() {
+    return this._memoized('indptr', async () => {
+      const [indptrArr] = await this._openSparseArrays();
+      const { data } = await zarrGet(indptrArr);
+      return bigInt64ToNumberArray(data);
+    });
+  }
+
+  /**
+   * The column to report for a feature that is not in the matrix: zeros, with
+   * a warning. This matches what the CSC route always did, and keeps a feature
+   * selection shared across datasets from failing in the ones that lack a gene.
+   * @param {string} name The feature name.
+   * @param {number} numRows The number of observations.
+   * @returns {Float32Array} An all-zero column.
+   */
+  _missingFeatureColumn(name, numRows) {
+    const { path } = this.getOptions();
+    log.warn(`Feature "${name}" was not found in the observation-by-feature matrix at "${path}"; its values are reported as zeros.`);
+    return new Float32Array(numRows);
   }
 
   /**
    * Class method for loading a gene selection from a CSC matrix.
    * @param {Array} selection A list of gene names whose data should be fetched.
-   * @returns {Promise} A Promise.all array of promises containing Uint8Arrays, one per selection.
+   * @returns {Promise} A Promise.all array of promises containing Float32Arrays, one per selection.
    */
   async _loadCSCGeneSelection(selection) {
     const indices = await this._getGeneIndices(selection);
-    const [indptrArr, indexArr, cellXGeneArr] = await this._openSparseArrays();
-    const numCells = await this._getNumCells();
-    const { data: cols } = await createZarrArrayAdapter(indptrArr).getRaw(null);
-    // If there is not change in the column indexer, then the data is all zeros
+    const [, indexArr, dataArr] = await this._openSparseArrays();
+    const [indptr, { shape }] = await Promise.all([
+      this._loadIndptr(),
+      this._loadMatrixZattrs(),
+    ]);
+    const numRows = shape[0];
+    const limit = createLimiter(CSC_READ_CONCURRENCY);
     return Promise.all(
-      indices.map(async (index) => {
-        const startRowIndex = cols[index];
-        const endRowIndex = cols[index + 1];
-        const isColumnAllZeros = startRowIndex === endRowIndex;
-        const geneData = new Float32Array(numCells).fill(0);
-        if (isColumnAllZeros) {
+      indices.map(async (index, i) => {
+        if (index < 0) {
+          return this._missingFeatureColumn(selection[i], numRows);
+        }
+        const start = indptr[index];
+        const end = indptr[index + 1];
+        const geneData = new Float32Array(numRows);
+        // If there is no change in the column pointer, then the column is all zeros.
+        if (start === end) {
           return geneData;
         }
-        const { data: rowIndices } = await zarrGet(indexArr, [
-          slice(startRowIndex, endRowIndex),
+        const [{ data: rowIndices }, { data: values }] = await Promise.all([
+          limit(() => zarrGet(indexArr, [slice(start, end)])),
+          limit(() => zarrGet(dataArr, [slice(start, end)])),
         ]);
-        let { data: cellXGeneData } = await zarrGet(cellXGeneArr, [
-          slice(startRowIndex, endRowIndex),
-        ]);
-        cellXGeneData = maybeDowncastInt64(cellXGeneData);
-        for (let rowIndex = 0; rowIndex < rowIndices.length; rowIndex += 1) {
-          geneData[rowIndices[rowIndex]] = cellXGeneData[rowIndex];
+        const rows = bigInt64ToNumberArray(rowIndices);
+        const vals = bigInt64ToNumberArray(values);
+        for (let r = 0; r < rows.length; r += 1) {
+          geneData[rows[r]] = vals[r];
         }
         return geneData;
       }),
@@ -137,152 +281,269 @@ export default class ObsFeatureMatrixAnndataLoader extends AbstractTwoStepLoader
 
   /**
    * Class method for loading a gene selection from a CSR matrix.
+   *
+   * CSR has no per-column slice, so the requested columns are gathered by one
+   * chunk-wise scan of `indices`/`data` (see extractCsrColumns); the matrix is
+   * never densified. Concurrent selections on this loader share a single scan.
    * @param {Array} selection A list of gene names whose data should be fetched.
-   * @returns {Promise} A Promise.all array of promises containing Uint8Arrays, one per selection.
+   * @returns {Promise} A Promise.all array of promises containing Float32Arrays, one per selection.
    */
   async _loadCSRGeneSelection(selection) {
     const indices = await this._getGeneIndices(selection);
-    const numGenes = await this._getNumGenes();
-    const numCells = await this._getNumCells();
-    const cellXGene = await this._loadCSRSparseCellXGene();
-    return indices.map((index) => {
-      const geneData = new Float32Array(numCells).fill(0);
-      for (let i = 0; i < numCells; i += 1) {
-        geneData[i] = cellXGene[i * numGenes + index];
+    const [, indexArr, dataArr] = await this._openSparseArrays();
+    const { shape } = await this._loadMatrixZattrs();
+    const { path } = this.getOptions();
+    const nnz = indexArr.shape[0];
+    const bytesPerEntry = getBytesPerElement(indexArr.dtype) + getBytesPerElement(dataArr.dtype);
+    // Every selection reads all of `indices` and most of `data`; refuse when that
+    // is beyond what a browser can reasonably move, before reading any chunk.
+    const scanBytes = nnz * bytesPerEntry;
+    if (exceedsAllocationBudget(scanBytes)) {
+      throw new MatrixTooLargeError(csrScanMessage({
+        path, shape, nnz, bytes: scanBytes,
+      }));
+    }
+    const numRows = shape[0];
+    const numRequested = new Set(indices.filter(index => index >= 0)).size;
+    // Memory held during the scan: chunks in flight, the pointers, and the outputs.
+    const workingSetBytes = CSR_SCAN_PREFETCH * indexArr.chunks[0] * bytesPerEntry
+      + (numRows + 1) * 8
+      + numRows * 4 * numRequested;
+    if (exceedsAllocationBudget(workingSetBytes)) {
+      throw new MatrixTooLargeError(csrScanMessage({
+        path, shape, nnz, bytes: workingSetBytes,
+      }));
+    }
+    if (scanBytes > CSR_SCAN_WARN_BYTES) {
+      this._warnOnce('csrScan', `Selecting features from the csr_matrix at "${path}" scans about ${formatBytes(scanBytes)} of "indices" and "data" per selection. Store the matrix as csc_matrix so that individual features can be read directly. See ${SPARSE_DOCS_URL}`);
+    }
+    return Promise.all(
+      indices.map((index, i) => (
+        index < 0
+          ? this._missingFeatureColumn(selection[i], numRows)
+          : this._requestCsrColumn(index)
+      )),
+    );
+  }
+
+  /**
+   * Request one CSR column. Requests are collected and served by a single scan
+   * per batch, so that the one-query-per-feature pattern of the data hooks does
+   * not scan the matrix once per feature.
+   * @param {number} col The column index.
+   * @returns {Promise<Float32Array>} The column.
+   */
+  _requestCsrColumn(col) {
+    if (!this._csrInflight) {
+      this._csrInflight = new Map();
+      this._csrPending = new Set();
+    }
+    let entry = this._csrInflight.get(col);
+    if (!entry) {
+      entry = {};
+      entry.promise = new Promise((resolve, reject) => {
+        entry.resolve = resolve;
+        entry.reject = reject;
+      });
+      this._csrInflight.set(col, entry);
+      this._csrPending.add(col);
+      this._scheduleCsrFlush();
+    }
+    return entry.promise;
+  }
+
+  _scheduleCsrFlush() {
+    if (this._csrFlushScheduled || this._csrScanning) {
+      return;
+    }
+    this._csrFlushScheduled = true;
+    // A macrotask, so that every caller in the same burst has enqueued its columns
+    // regardless of how many awaits it went through to get here.
+    setTimeout(() => {
+      this._csrFlushScheduled = false;
+      this._flushCsrScan();
+    }, 0);
+  }
+
+  async _flushCsrScan() {
+    if (this._csrScanning || this._csrPending.size === 0) {
+      return;
+    }
+    const cols = Array.from(this._csrPending);
+    this._csrPending.clear();
+    this._csrScanning = true;
+    try {
+      const columns = await this._scanCsrColumns(cols);
+      cols.forEach((col, i) => this._csrInflight.get(col).resolve(columns[i]));
+    } catch (err) {
+      cols.forEach(col => this._csrInflight.get(col).reject(err));
+    } finally {
+      cols.forEach(col => this._csrInflight.delete(col));
+      this._csrScanning = false;
+      if (this._csrPending.size > 0) {
+        // Columns requested while this scan ran form the next one.
+        this._scheduleCsrFlush();
       }
-      return geneData;
+    }
+  }
+
+  /**
+   * Scan the CSR `indices`/`data` arrays once for the given columns.
+   * @param {number[]} cols Unique column indices.
+   * @returns {Promise<Float32Array[]>} One column per entry of cols.
+   */
+  async _scanCsrColumns(cols) {
+    const [, indexArr, dataArr] = await this._openSparseArrays();
+    const [indptr, { shape }] = await Promise.all([
+      this._loadIndptr(),
+      this._loadMatrixZattrs(),
+    ]);
+    const nnz = indexArr.shape[0];
+    const chunkSize = indexArr.chunks[0];
+    const getIndicesChunk = c => indexArr.getChunk([c], SCAN_READ_OPTS).then(chunk => chunk.data);
+    // AnnData writes `data` with the same chunks as `indices`; if a store does not,
+    // read the matching element range instead of a chunk.
+    const getDataChunk = dataArr.chunks[0] === chunkSize
+      ? c => dataArr.getChunk([c], SCAN_READ_OPTS).then(chunk => chunk.data)
+      : c => zarrGet(
+        dataArr,
+        [slice(c * chunkSize, Math.min(nnz, (c + 1) * chunkSize))],
+        { opts: SCAN_READ_OPTS },
+      ).then(chunk => chunk.data);
+    return extractCsrColumns({
+      indptr,
+      numRows: shape[0],
+      numCols: shape[1],
+      colIndices: cols,
+      nnz,
+      chunkSize,
+      getIndicesChunk,
+      getDataChunk,
+      prefetch: CSR_SCAN_PREFETCH,
     });
   }
 
   /**
-   * Class method for loading row oriented (CSR) sparse data from zarr.
-   *
-   * @returns {Object} A { data: Float32Array } contianing the CellXGene matrix.
+   * Class method for loading a full sparse (CSR or CSC) matrix from zarr into a
+   * dense row-major Float32Array.
+   * @param {string} encodingType Either 'csr_matrix' or 'csc_matrix'.
+   * @returns {Promise<Float32Array>} The dense matrix.
    */
-  async _loadCSRSparseCellXGene() {
-    if (this._sparseMatrix) {
-      return this._sparseMatrix;
-    }
-    this._sparseMatrix = this._openSparseArrays().then(async (sparseArrays) => {
-      const { path: matrix } = this.getOptions();
-      const { shape } = await this.dataSource.getJson(`${matrix}/.zattrs`);
-      // eslint-disable-next-line prefer-const
-      let [rows, cols, cellXGene] = await Promise.all(
-        sparseArrays.map(async (arr) => {
-          const { data } = await createZarrArrayAdapter(arr).getRaw(null);
-          return data;
-        }),
-      );
-      cellXGene = maybeDowncastInt64(cellXGene);
-      const cellXGeneMatrix = new Float32Array(shape[0] * shape[1]).fill(0);
-      let row = 0;
-      rows.forEach((_, index) => {
-        const rowStart = rows[index];
-        const rowEnd = rows[index + 1];
-        for (let i = rowStart; i < rowEnd; i += 1) {
-          const val = cellXGene[i];
-          const col = cols[i];
-          cellXGeneMatrix[row * shape[1] + col] = val;
-        }
-        row += 1;
+  _loadSparseCellXGene(encodingType) {
+    return this._memoized('sparseMatrix', async () => {
+      const { path } = this.getOptions();
+      const [[indptrArr, indexArr, dataArr], { shape }] = await Promise.all([
+        this._openSparseArrays(),
+        this._loadMatrixZattrs(),
+      ]);
+      const nnz = indexArr.shape[0];
+      const bytes = 4 * shape[0] * shape[1]
+        + nnz * (getBytesPerElement(indexArr.dtype) + getBytesPerElement(dataArr.dtype))
+        + indptrArr.shape[0] * getBytesPerElement(indptrArr.dtype);
+      const message = fullMatrixMessage({
+        path, shape, description: encodingType, bytes,
       });
-      return cellXGeneMatrix;
+      if (exceedsAllocationBudget(bytes)) {
+        // Attempt anyway: the budget is a heuristic, and a failed allocation is
+        // reported descriptively below.
+        this._warnOnce('fullMatrix', message);
+      }
+      const numCols = shape[1];
+      // Allocate before downloading, so that a matrix too large to hold fails
+      // right away instead of after fetching every stored value.
+      const matrix = allocateOrThrow(() => new Float32Array(shape[0] * numCols), message);
+      const [indptr, indices, values] = await Promise.all([
+        this._loadIndptr(),
+        zarrGet(indexArr).then(({ data }) => bigInt64ToNumberArray(data)),
+        zarrGet(dataArr).then(({ data }) => bigInt64ToNumberArray(data)),
+      ]);
+      const numPointers = indptr.length - 1;
+      if (encodingType === 'csr_matrix') {
+        const numRows = Math.min(shape[0], numPointers);
+        for (let row = 0; row < numRows; row += 1) {
+          for (let k = indptr[row]; k < indptr[row + 1]; k += 1) {
+            matrix[row * numCols + indices[k]] = values[k];
+          }
+        }
+      } else {
+        const numStoredCols = Math.min(numCols, numPointers);
+        for (let col = 0; col < numStoredCols; col += 1) {
+          for (let k = indptr[col]; k < indptr[col + 1]; k += 1) {
+            matrix[indices[k] * numCols + col] = values[k];
+          }
+        }
+      }
+      return matrix;
     });
-    return this._sparseMatrix;
   }
 
   /**
-   * Class method for loading column oriented (CSC) sparse data from zarr.
-   * @returns {Object} A { data: Float32Array } contianing the CellXGene matrix.
+   * Class method for loading a full dense matrix from zarr.
+   * @returns {Promise<TypedArray>} The matrix, in the array's own dtype
+   * (int64 downcast to int32).
    */
-  async _loadCSCSparseCellXGene() {
-    if (this._sparseMatrix) {
-      return this._sparseMatrix;
-    }
-    this._sparseMatrix = this._openSparseArrays().then(async (sparseArrays) => {
-      const { path: matrix } = this.getOptions();
-      const { shape } = await this.dataSource.getJson(`${matrix}/.zattrs`);
-      // eslint-disable-next-line prefer-const
-      let [cols, rows, cellXGene] = await Promise.all(
-        sparseArrays.map(async (arr) => {
-          const { data } = await createZarrArrayAdapter(arr).getRaw(null);
-          return data;
-        }),
-      );
-      cellXGene = maybeDowncastInt64(cellXGene);
-      const cellXGeneMatrix = new Float32Array(shape[0] * shape[1]).fill(0);
-      let col = 0;
-      cols.forEach((_, index) => {
-        const colStart = cols[index];
-        const colEnd = cols[index + 1];
-        for (let i = colStart; i < colEnd; i += 1) {
-          const val = cellXGene[i];
-          const row = rows[i];
-          cellXGeneMatrix[row * shape[1] + col] = val;
-        }
-        col += 1;
+  _loadDenseCellXGene() {
+    return this._memoized('denseMatrix', async () => {
+      const { path } = this.getOptions();
+      const z = await this._openDenseArray();
+      const bytes = getBytesPerElement(z.dtype) * z.shape[0] * z.shape[1];
+      const message = fullMatrixMessage({
+        path, shape: z.shape, description: `dense ${z.dtype}`, bytes,
       });
-      return cellXGeneMatrix;
+      if (exceedsAllocationBudget(bytes)) {
+        this._warnOnce('fullMatrix', message);
+      }
+      let data;
+      try {
+        // zarrita allocates the whole selection up front.
+        ({ data } = await createZarrArrayAdapter(z).getRaw(null));
+      } catch (e) {
+        if (isAllocationFailure(e)) {
+          throw new MatrixTooLargeError(`${message} (${e.message})`);
+        }
+        throw e;
+      }
+      return maybeDowncastInt64(data);
     });
-    return this._sparseMatrix;
   }
 
   /**
    * Class method for loading the cell x gene matrix.
    * @returns {Promise} A promise for the zarr array contianing the cell x gene data.
    */
-  async loadCellXGene() {
-    const { storeRoot } = this.dataSource;
-    if (this.cellXGene) {
-      return this.cellXGene;
-    }
-    const {
-      path: matrix,
-      initialFeatureFilterPath: matrixGeneFilter,
-    } = this.getOptions();
-    if (!this._matrixZattrs) {
-      this._matrixZattrs = await this.dataSource.getJson(`${matrix}/.zattrs`);
-    }
-    const encodingType = this._matrixZattrs['encoding-type'];
-    if (!matrixGeneFilter) {
-      if (encodingType === 'csr_matrix') {
-        this.cellXGene = this._loadCSRSparseCellXGene().then(data => toObject(data));
-      } else if (encodingType === 'csc_matrix') {
-        this.cellXGene = this._loadCSCSparseCellXGene().then(data => toObject(data));
-      } else {
-        if (!this.arr) {
-          this.arr = zarrOpen(storeRoot.resolve(matrix), { kind: 'array' });
-        }
-        this.cellXGene = this.arr
-          .then(z => createZarrArrayAdapter(z).getRaw(null))
-          .then(({ data }) => toObject(maybeDowncastInt64(data)));
-      }
-    } else if (encodingType === 'csr_matrix') {
-      this.cellXGene = this._loadCSRSparseCellXGene().then(
-        async (cellXGene) => {
-          const filteredGenes = await this._getFilteredGenes(matrixGeneFilter);
-          const numGenesFiltered = filteredGenes.length;
-          const geneNames = await this.loadFilteredGeneNames();
-          const numGenes = geneNames.length;
-          const numCells = await this._getNumCells();
-          const cellXGeneMatrixFiltered = new Float32Array(
-            numCells * numGenesFiltered,
-          ).fill(0);
-          for (let i = 0; i < numGenesFiltered; i += 1) {
-            const index = geneNames.indexOf(filteredGenes[i]);
-            for (let j = 0; j < numCells; j += 1) {
-              cellXGeneMatrixFiltered[j * numGenesFiltered + i] = cellXGene[j * numGenes + index];
-            }
-          }
-          return toObject(cellXGeneMatrixFiltered);
-        },
-      );
-    } else {
+  loadCellXGene() {
+    return this._memoized('cellXGene', () => this._loadCellXGeneUncached());
+  }
+
+  async _loadCellXGeneUncached() {
+    const { path, initialFeatureFilterPath: matrixGeneFilter } = this.getOptions();
+    const { 'encoding-type': encodingType } = await this._loadMatrixZattrs();
+    if (matrixGeneFilter) {
+      // Only the filtered features are needed, so read them as columns whatever
+      // the encoding; this never densifies the full matrix.
       const genes = await this._getFilteredGenes(matrixGeneFilter);
-      this.cellXGene = this.loadGeneSelection({ selection: genes })
-        .then(({ data }) => (toObject(concatenateColumnVectors(data))));
+      if (genes.length === 0) {
+        return toObject(new Float32Array(0));
+      }
+      const numRows = await this._getNumCells();
+      // The per-feature columns plus their interleaved copy.
+      const bytes = 2 * 4 * numRows * genes.length;
+      const message = fullMatrixMessage({
+        path,
+        shape: [numRows, genes.length],
+        description: `${encodingType || 'dense'}, ${genes.length} filtered features`,
+        bytes,
+      });
+      if (exceedsAllocationBudget(bytes)) {
+        this._warnOnce('fullMatrix', message);
+      }
+      const { data } = await this.loadGeneSelection({ selection: genes });
+      return toObject(allocateOrThrow(() => concatenateColumnVectors(data), message));
     }
-    return this.cellXGene;
+    if (encodingType === 'csr_matrix' || encodingType === 'csc_matrix') {
+      return toObject(await this._loadSparseCellXGene(encodingType));
+    }
+    return toObject(await this._loadDenseCellXGene());
   }
 
   /**
@@ -292,27 +553,26 @@ export default class ObsFeatureMatrixAnndataLoader extends AbstractTwoStepLoader
    * @returns {Object} { data } containing an array of gene expression data.
    */
   async loadGeneSelection({ selection }) {
-    const { path: matrix } = this.getOptions();
-    const { storeRoot } = this.dataSource;
-    if (!this._matrixZattrs) {
-      this._matrixZattrs = await this.dataSource.getJson(`${matrix}/.zattrs`);
-    }
-    const encodingType = this._matrixZattrs['encoding-type'];
+    const { 'encoding-type': encodingType } = await this._loadMatrixZattrs();
     let genes;
     if (encodingType === 'csc_matrix') {
       genes = await this._loadCSCGeneSelection(selection);
     } else if (encodingType === 'csr_matrix') {
       genes = await this._loadCSRGeneSelection(selection);
     } else {
-      if (!this.arr) {
-        this.arr = zarrOpen(storeRoot.resolve(matrix), { kind: 'array' });
-      }
-      const indices = await this._getGeneIndices(selection);
+      const [z, indices] = await Promise.all([
+        this._openDenseArray(),
+        this._getGeneIndices(selection),
+      ]);
       // We can index directly into a normal dense array zarr store via `get`.
       genes = await Promise.all(
-        indices.map(index => this.arr
-          .then(z => zarrGet(z, [null, index]))
-          .then(({ data }) => maybeDowncastInt64(data))),
+        indices.map(async (index, i) => {
+          if (index < 0) {
+            return this._missingFeatureColumn(selection[i], z.shape[0]);
+          }
+          const { data } = await zarrGet(z, [null, index]);
+          return maybeDowncastInt64(data);
+        }),
       );
     }
     return { data: genes, url: null };

--- a/packages/file-types/zarr/src/anndata-loaders/ObsFeatureMatrixAnndataLoader.test.js
+++ b/packages/file-types/zarr/src/anndata-loaders/ObsFeatureMatrixAnndataLoader.test.js
@@ -1,6 +1,11 @@
 /* eslint-disable func-names, camelcase */
-import { describe, it, expect } from 'vitest';
+import {
+  describe, it, expect, vi, afterEach,
+} from 'vitest';
+import { root as zarrRoot, create as zarrCreate } from 'zarrita';
 import { createStoreFromMapContents } from '@vitessce/zarr-utils';
+import { log } from '@vitessce/globals';
+import { MatrixTooLargeError } from '@vitessce/error';
 import ObsFeatureMatrixAnndataLoader from './ObsFeatureMatrixAnndataLoader.js';
 import AnnDataSource from '../AnnDataSource.js';
 import MuDataSource from '../MuDataSource.js';
@@ -27,6 +32,7 @@ import mudata_0_2_CsrFixture from '../json-fixtures/mudata-0.2/mudata-csr.json';
 import mudata_0_2_DenseFixture from '../json-fixtures/mudata-0.2/mudata-dense.json';
 
 const toArray = typedArr => Array.from(typedArr).map(Number);
+const toBigInt = value => BigInt(value); // eslint-disable-line no-undef
 
 function createAnndataLoader(url, mapContents, path = 'X') {
   const store = createStoreFromMapContents(mapContents);
@@ -224,6 +230,318 @@ describe('loaders/ObsFeatureMatrixAnndataLoader', () => {
       const cscMatrix = await loaderCsc.loadCellXGene();
       expect(cscMatrix).toEqual(denseMatrix);
       expect(csrMatrix).toEqual(denseMatrix);
+    });
+  });
+
+  describe('size handling and the CSR column scan', () => {
+    const CSR_URL = '@fixtures/zarr/anndata-0.11/anndata-csr.adata.zarr';
+    const CSC_URL = '@fixtures/zarr/anndata-0.11/anndata-csc.zarr';
+    const DENSE_URL = '@fixtures/zarr/anndata-0.11/anndata-dense.zarr';
+
+    // The fixtures store X[i, j] = j for 3 cells and 15 genes.
+    const NUM_CELLS = 3;
+    const NUM_GENES = 15;
+    const PATTERN = Array.from(
+      { length: NUM_CELLS },
+      () => Array.from({ length: NUM_GENES }, (_, j) => j),
+    );
+
+    const decodeJson = (fixture, key) => JSON.parse(atob(new Map(fixture).get(key)));
+
+    // Replace one metadata document of a fixture, e.g. to fake a shape.
+    function withOverride(fixture, key, value) {
+      return [...fixture.filter(([k]) => k !== key), [key, btoa(JSON.stringify(value))]];
+    }
+
+    function createLoaderFromStore(store, options = { path: 'X' }) {
+      const config = {
+        url: '@fixtures/zarr/custom.zarr',
+        fileType: 'obsFeatureMatrix.anndata.zarr',
+        options,
+      };
+      const source = new AnnDataSource({ ...config, store });
+      return new ObsFeatureMatrixAnndataLoader(source, config);
+    }
+
+    // A fixture store that records every key read, optionally holding reads of
+    // matching keys until released.
+    function createCountingStore(mapContents, gatePattern = null) {
+      const inner = createStoreFromMapContents(mapContents);
+      const reads = [];
+      let release = () => {};
+      const gate = new Promise((resolve) => { release = resolve; });
+      const store = {
+        async get(key) {
+          reads.push(key);
+          if (gatePattern && gatePattern.test(key)) {
+            await gate;
+          }
+          return inner.get(key);
+        },
+      };
+      return { store, reads, release: () => release() };
+    }
+
+    // Build a sparse X (zarr v3, written with zarrita) over the obs/var of a
+    // fixture, with a chosen chunk size and pointer dtype, so that multi-chunk
+    // and int64 code paths can be tested without new fixture files. Optionally
+    // adds a uint8 var column usable as a feature filter.
+    async function createSparseOverlayStore(baseFixture, {
+      encoding, matrix, chunkSize, indexDtype = 'int32', dataDtype = 'float32', varFilter = null,
+    }) {
+      const numRows = matrix.length;
+      const numCols = matrix[0].length;
+      const indptr = [0];
+      const indices = [];
+      const data = [];
+      if (encoding === 'csr_matrix') {
+        matrix.forEach((rowValues) => {
+          rowValues.forEach((value, col) => {
+            if (value !== 0) {
+              indices.push(col);
+              data.push(value);
+            }
+          });
+          indptr.push(indices.length);
+        });
+      } else {
+        for (let col = 0; col < numCols; col += 1) {
+          for (let row = 0; row < numRows; row += 1) {
+            if (matrix[row][col] !== 0) {
+              indices.push(row);
+              data.push(matrix[row][col]);
+            }
+          }
+          indptr.push(indices.length);
+        }
+      }
+      const overlay = new Map();
+      const root = zarrRoot(overlay);
+      await zarrCreate(root.resolve('X'), {
+        attributes: { 'encoding-type': encoding, 'encoding-version': '0.1.0', shape: [numRows, numCols] },
+      });
+      const TYPED = {
+        int32: Int32Array,
+        int64: BigInt64Array, // eslint-disable-line no-undef
+        float32: Float32Array,
+        float64: Float64Array,
+        uint8: Uint8Array,
+      };
+      const writeArray = async (path, values, dataType, chunk) => {
+        await zarrCreate(root.resolve(path), {
+          shape: [values.length],
+          chunk_shape: [chunk],
+          data_type: dataType,
+          codecs: [{ name: 'bytes', configuration: { endian: 'little' } }],
+          fill_value: 0,
+        });
+        // Write the chunk bytes directly (the bytes codec is little-endian raw
+        // bytes), padding the trailing chunk the way a zarr writer would.
+        const Ctor = TYPED[dataType];
+        for (let c = 0; c * chunk < values.length; c += 1) {
+          const typed = new Ctor(chunk);
+          values.slice(c * chunk, (c + 1) * chunk).forEach((value, i) => {
+            typed[i] = dataType === 'int64' ? toBigInt(value) : value;
+          });
+          overlay.set(`/${path}/c/${c}`, new Uint8Array(typed.buffer));
+        }
+      };
+      await writeArray('X/indptr', indptr, indexDtype, indptr.length);
+      await writeArray('X/indices', indices, indexDtype, chunkSize);
+      await writeArray('X/data', data, dataDtype, chunkSize);
+      if (varFilter) {
+        await writeArray('var/highly_variable', varFilter.map(v => (v ? 1 : 0)), 'uint8', varFilter.length);
+      }
+      const base = createStoreFromMapContents(baseFixture);
+      return {
+        async get(key) {
+          return overlay.has(key) ? overlay.get(key) : base.get(key);
+        },
+      };
+    }
+
+    afterEach(() => {
+      vi.restoreAllMocks();
+      delete window.performance.memory;
+    });
+
+    it('selects all-zero, repeated, and unknown features consistently across encodings', async () => {
+      const warn = vi.spyOn(log, 'warn').mockImplementation(() => {});
+      const selection = { selection: ['gene_0', 'gene_14', 'gene_5', 'gene_5', 'not_a_gene'] };
+      const [csr, csc, dense] = await Promise.all([
+        createAnndataLoader(CSR_URL, anndata_0_11_CsrFixture).loadGeneSelection(selection),
+        createAnndataLoader(CSC_URL, anndata_0_11_CscFixture).loadGeneSelection(selection),
+        createAnndataLoader(DENSE_URL, anndata_0_11_DenseFixture).loadGeneSelection(selection),
+      ]);
+      expect(csr.data.map(toArray)).toEqual(dense.data.map(toArray));
+      expect(csc.data.map(toArray)).toEqual(dense.data.map(toArray));
+      // gene_0 is all zeros in the fixtures; an unknown feature reports zeros too.
+      expect(toArray(dense.data[0])).toEqual([0, 0, 0]);
+      expect(toArray(dense.data[1])).toEqual([14, 14, 14]);
+      expect(toArray(dense.data[4])).toEqual([0, 0, 0]);
+      // One warning per loader for the unknown feature.
+      expect(warn).toHaveBeenCalledTimes(3);
+      expect(warn.mock.calls[0][0]).toContain('not_a_gene');
+    });
+
+    it('coalesces concurrent CSR selections into a single scan', async () => {
+      const { store, reads } = createCountingStore(anndata_0_11_CsrFixture);
+      const loader = createLoaderFromStore(store);
+      const [a, b] = await Promise.all([
+        loader.loadGeneSelection({ selection: ['gene_1'] }),
+        loader.loadGeneSelection({ selection: ['gene_5', 'gene_1'] }),
+      ]);
+      expect(toArray(a.data[0])).toEqual([1, 1, 1]);
+      expect(b.data.map(toArray)).toEqual([[5, 5, 5], [1, 1, 1]]);
+      expect(reads.filter(key => key === '/X/indices/0').length).toEqual(1);
+      expect(reads.filter(key => key === '/X/data/0').length).toEqual(1);
+    });
+
+    it('serves columns requested during a scan with one further scan', async () => {
+      const { store, reads, release } = createCountingStore(
+        anndata_0_11_CsrFixture, /\/X\/indices\/0$/,
+      );
+      const loader = createLoaderFromStore(store);
+      const first = loader.loadGeneSelection({ selection: ['gene_1'] });
+      // Wait until the first scan is blocked on its chunk read, then ask for more.
+      await vi.waitFor(() => expect(reads).toContain('/X/indices/0'));
+      const second = loader.loadGeneSelection({ selection: ['gene_2'] });
+      const third = loader.loadGeneSelection({ selection: ['gene_3'] });
+      await new Promise((resolve) => { setTimeout(resolve, 10); });
+      release();
+      const [a, b, c] = await Promise.all([first, second, third]);
+      expect(toArray(a.data[0])).toEqual([1, 1, 1]);
+      expect(toArray(b.data[0])).toEqual([2, 2, 2]);
+      expect(toArray(c.data[0])).toEqual([3, 3, 3]);
+      // The two later requests shared the second scan.
+      expect(reads.filter(key => key === '/X/indices/0').length).toEqual(2);
+    });
+
+    it('refuses a CSR selection whose scan exceeds the budget, before reading any chunk', async () => {
+      const zarray = decodeJson(anndata_0_11_CsrFixture, '/X/indices/.zarray');
+      const fixture = withOverride(
+        anndata_0_11_CsrFixture, '/X/indices/.zarray', { ...zarray, shape: [3e9] },
+      );
+      const { store, reads } = createCountingStore(fixture);
+      const loader = createLoaderFromStore(store);
+      const error = await loader.loadGeneSelection({ selection: ['gene_1'] }).catch(e => e);
+      expect(error).toBeInstanceOf(MatrixTooLargeError);
+      expect(error.name).toEqual('MatrixTooLargeError');
+      expect(error.message).toContain('"X"');
+      expect(error.message).toContain('3,000,000,000');
+      expect(error.message).toContain('csc_matrix');
+      expect(reads.filter(key => /\/X\/(indices|data)\/\d+$/.test(key))).toEqual([]);
+    });
+
+    it('applies the reported heap limit to the scan budget without caching the refusal', async () => {
+      Object.defineProperty(window.performance, 'memory', {
+        value: { jsHeapSizeLimit: 64 }, configurable: true,
+      });
+      const loader = createAnndataLoader(CSR_URL, anndata_0_11_CsrFixture);
+      await expect(loader.loadGeneSelection({ selection: ['gene_1'] }))
+        .rejects.toThrow(MatrixTooLargeError);
+      delete window.performance.memory;
+      // The same loader answers once the budget allows; nothing stuck in flight.
+      const { data } = await loader.loadGeneSelection({ selection: ['gene_1'] });
+      expect(toArray(data[0])).toEqual([1, 1, 1]);
+    });
+
+    it('warns, but still loads, a full matrix whose estimate exceeds the budget', async () => {
+      const warn = vi.spyOn(log, 'warn').mockImplementation(() => {});
+      Object.defineProperty(window.performance, 'memory', {
+        value: { jsHeapSizeLimit: 64 }, configurable: true,
+      });
+      const [csr, csc, dense] = await Promise.all([
+        createAnndataLoader(CSR_URL, anndata_0_11_CsrFixture).loadCellXGene(),
+        createAnndataLoader(CSC_URL, anndata_0_11_CscFixture).loadCellXGene(),
+        createAnndataLoader(DENSE_URL, anndata_0_11_DenseFixture).loadCellXGene(),
+      ]);
+      expect(csr).toEqual(dense);
+      expect(csc).toEqual(dense);
+      expect(warn).toHaveBeenCalledTimes(3);
+      warn.mock.calls.forEach(([message]) => {
+        expect(message).toContain('"X"');
+        expect(message).toContain('[3, 15]');
+        expect(message).toContain('initialFeatureFilterPath');
+      });
+    });
+
+    it('reports a failed full-matrix allocation as a MatrixTooLargeError', async () => {
+      vi.spyOn(log, 'warn').mockImplementation(() => {});
+      const fixture = withOverride(anndata_0_11_CsrFixture, '/X/.zattrs', {
+        'encoding-type': 'csr_matrix', 'encoding-version': '0.1.0', shape: [2 ** 20, 2 ** 20],
+      });
+      const { store, reads } = createCountingStore(fixture);
+      const loader = createLoaderFromStore(store);
+      const error = await loader.loadCellXGene().catch(e => e);
+      expect(error).toBeInstanceOf(MatrixTooLargeError);
+      expect(error.message).toContain('[1048576, 1048576]');
+      expect(error.message).toContain('"X"');
+      expect(error.message).toContain('initialFeatureFilterPath');
+      // The allocation is attempted before any stored values are downloaded.
+      expect(reads.filter(key => /\/X\/(indices|data)\/\d+$/.test(key))).toEqual([]);
+    });
+
+    it('does not cache a failed full-matrix load', async () => {
+      const inner = createStoreFromMapContents(anndata_0_11_CsrFixture);
+      let failed = false;
+      const store = {
+        async get(key) {
+          if (!failed && key === '/X/data/0') {
+            failed = true;
+            throw new Error('transient');
+          }
+          return inner.get(key);
+        },
+      };
+      const loader = createLoaderFromStore(store);
+      await expect(loader.loadCellXGene()).rejects.toThrow('transient');
+      const dense = await createAnndataLoader(DENSE_URL, anndata_0_11_DenseFixture).loadCellXGene();
+      expect(await loader.loadCellXGene()).toEqual(dense);
+    });
+
+    [
+      { encoding: 'csr_matrix', chunkSize: 4 },
+      { encoding: 'csr_matrix', chunkSize: 5, indexDtype: 'int64', dataDtype: 'float64' },
+      { encoding: 'csr_matrix', chunkSize: 1 },
+      { encoding: 'csc_matrix', chunkSize: 4, indexDtype: 'int64' },
+    ].forEach((variant) => {
+      const label = `${variant.encoding} with ${variant.indexDtype || 'int32'} pointers in chunks of ${variant.chunkSize}`;
+      it(`matches the dense matrix for ${label}`, async () => {
+        const store = await createSparseOverlayStore(anndata_0_12_DenseFixture, {
+          ...variant, matrix: PATTERN,
+        });
+        const loader = createLoaderFromStore(store);
+        const dense = createAnndataLoader(
+          '@fixtures/zarr/anndata-0.12/anndata-dense.zarr', anndata_0_12_DenseFixture,
+        );
+        const selection = { selection: ['gene_0', 'gene_1', 'gene_14', 'gene_7'] };
+        const [sparseSelection, denseSelection] = await Promise.all([
+          loader.loadGeneSelection(selection),
+          dense.loadGeneSelection(selection),
+        ]);
+        expect(sparseSelection.data.map(toArray)).toEqual(denseSelection.data.map(toArray));
+        const [sparseMatrix, denseMatrix] = await Promise.all([
+          loader.loadCellXGene(),
+          dense.loadCellXGene(),
+        ]);
+        expect(toArray(sparseMatrix.data)).toEqual(toArray(denseMatrix.data));
+      });
+    });
+
+    it('loads an initialFeatureFilterPath subset of a CSR matrix without densifying it', async () => {
+      const varFilter = Array.from({ length: NUM_GENES }, (_, j) => j % 2 === 0);
+      const store = await createSparseOverlayStore(anndata_0_12_DenseFixture, {
+        encoding: 'csr_matrix', chunkSize: 4, matrix: PATTERN, varFilter,
+      });
+      const options = { path: 'X', initialFeatureFilterPath: 'var/highly_variable' };
+      const loader = createLoaderFromStore(store, options);
+      const result = await loader.load();
+      const expectedGenes = varFilter.flatMap((keep, j) => (keep ? [`gene_${j}`] : []));
+      expect(result.data.featureIndex).toEqual(expectedGenes);
+      // Row-major over the kept columns only.
+      const expected = PATTERN.flatMap(rowValues => rowValues.filter((_, j) => varFilter[j]));
+      expect(toArray(result.data.obsFeatureMatrix.data)).toEqual(expected);
     });
   });
 });

--- a/packages/file-types/zarr/src/anndata-loaders/utils.js
+++ b/packages/file-types/zarr/src/anndata-loaders/utils.js
@@ -53,3 +53,160 @@ export const concatenateColumnVectors = (arr) => {
   }
   return new TypedArray(view.buffer);
 };
+
+/**
+ * Convert a 64-bit integer array to a Float64Array of plain numbers, exact
+ * below 2^53. Unlike maybeDowncastInt64 this keeps the high bits, so it is safe
+ * for values that can exceed 2^31, such as sparse `indptr` entries (bounded by
+ * nnz). Other arrays pass through unchanged.
+ * @param {ArrayLike<number|bigint>} data A typed array.
+ * @returns {ArrayLike<number>} A number-valued array.
+ */
+export function bigInt64ToNumberArray(data) {
+  // eslint-disable-next-line no-undef
+  if (data instanceof BigInt64Array || data instanceof BigUint64Array) {
+    const out = new Float64Array(data.length);
+    for (let i = 0; i < data.length; i += 1) {
+      out[i] = Number(data[i]);
+    }
+    return out;
+  }
+  return data;
+}
+
+const BYTES_PER_ELEMENT = {
+  bool: 1,
+  int8: 1,
+  uint8: 1,
+  int16: 2,
+  uint16: 2,
+  int32: 4,
+  uint32: 4,
+  float32: 4,
+  int64: 8,
+  uint64: 8,
+  float64: 8,
+};
+
+/**
+ * Bytes per element for a zarrita data type name.
+ * @param {string} dtype A dtype such as 'int32' or 'float32'.
+ * @returns {number} Bytes per element; 8 (conservative) when unknown.
+ */
+export function getBytesPerElement(dtype) {
+  return BYTES_PER_ELEMENT[dtype] ?? 8;
+}
+
+/**
+ * Create a function that runs async tasks with bounded concurrency.
+ * @param {number} concurrency Maximum number of tasks in flight.
+ * @returns {<T>(task: () => Promise<T>) => Promise<T>} A scheduler.
+ */
+export function createLimiter(concurrency) {
+  let active = 0;
+  const queue = [];
+  const next = () => {
+    if (active >= concurrency || queue.length === 0) {
+      return;
+    }
+    active += 1;
+    const { task, resolve, reject } = queue.shift();
+    task().then(resolve, reject).finally(() => {
+      active -= 1;
+      next();
+    });
+  };
+  return task => new Promise((resolve, reject) => {
+    queue.push({ task, resolve, reject });
+    next();
+  });
+}
+
+/**
+ * Extract dense columns from a CSR matrix without densifying it.
+ *
+ * CSR has no per-column index, so the `indices` array is streamed once, chunk by
+ * chunk, and every stored value whose column was requested is placed by row.
+ * Rows are recovered with a pointer that moves forward over `indptr` as the
+ * position in `indices` increases, so the whole pass is O(nnz + numRows). The
+ * `data` chunk is fetched only for chunks that contained a hit. Peak memory is a
+ * few chunks plus the output columns, independent of nnz.
+ *
+ * I/O is injected so the traversal can be tested without a store.
+ *
+ * @param {object} params
+ * @param {ArrayLike<number>} params.indptr Row pointers, number-valued, length numRows + 1.
+ * @param {number} params.numRows Number of rows (observations).
+ * @param {number} params.numCols Number of columns (features).
+ * @param {number[]} params.colIndices Requested columns, unique and within [0, numCols).
+ * @param {number} params.nnz Number of stored values (length of indices/data).
+ * @param {number} params.chunkSize Chunk length of the indices and data arrays.
+ * @param {(chunkIndex: number) => Promise<ArrayLike<number|bigint>>} params.getIndicesChunk
+ * Reads one chunk of `indices`; may be padded past nnz, as zarr chunks are.
+ * @param {(chunkIndex: number) => Promise<ArrayLike<number|bigint>>} params.getDataChunk
+ * Reads the corresponding chunk of `data`.
+ * @param {number} [params.prefetch=4] How many chunk reads to keep in flight.
+ * @returns {Promise<Float32Array[]>} One column per entry of colIndices, length numRows.
+ */
+export async function extractCsrColumns({
+  indptr, numRows, numCols, colIndices, nnz, chunkSize,
+  getIndicesChunk, getDataChunk, prefetch = 4,
+}) {
+  const out = colIndices.map(() => new Float32Array(numRows));
+  if (colIndices.length === 0 || nnz === 0) {
+    return out;
+  }
+  // Column -> output slot, so membership is a typed-array read per stored value.
+  const slotByCol = new Int32Array(numCols).fill(-1);
+  colIndices.forEach((col, slot) => {
+    slotByCol[col] = slot;
+  });
+  const numChunks = Math.ceil(nnz / chunkSize);
+  const limit = createLimiter(Math.max(1, prefetch));
+  const pending = new Map();
+  const prefetchChunk = (c) => {
+    if (c < numChunks && !pending.has(c)) {
+      pending.set(c, limit(() => getIndicesChunk(c)));
+    }
+  };
+  for (let c = 0; c < Math.min(prefetch, numChunks); c += 1) {
+    prefetchChunk(c);
+  }
+  const fills = [];
+  let row = 0;
+  for (let c = 0; c < numChunks; c += 1) {
+    prefetchChunk(c + prefetch);
+    // eslint-disable-next-line no-await-in-loop
+    const idx = await pending.get(c);
+    pending.delete(c);
+    const base = c * chunkSize;
+    // The trailing chunk is padded with the fill value (typically 0, which is
+    // also a valid column index), so only positions below nnz are stored values.
+    const validLen = Math.min(chunkSize, nnz - base);
+    const hitPos = [];
+    const hitRow = [];
+    const hitSlot = [];
+    for (let j = 0; j < validLen; j += 1) {
+      const slot = slotByCol[Number(idx[j])];
+      if (slot >= 0) {
+        const k = base + j;
+        // k only increases, so the row pointer never moves backwards.
+        while (indptr[row + 1] <= k) {
+          row += 1;
+        }
+        hitPos.push(j);
+        hitRow.push(row);
+        hitSlot.push(slot);
+      }
+    }
+    if (hitPos.length > 0) {
+      fills.push(limit(() => getDataChunk(c)).then((values) => {
+        for (let h = 0; h < hitPos.length; h += 1) {
+          out[hitSlot[h]][hitRow[h]] = Number(values[hitPos[h]]);
+        }
+      }));
+    }
+  }
+  await Promise.all(fills);
+  return out;
+}

--- a/packages/file-types/zarr/src/anndata-loaders/utils.test.js
+++ b/packages/file-types/zarr/src/anndata-loaders/utils.test.js
@@ -1,7 +1,78 @@
-import { convertBigInt64ArrayToInt32Array, IncorrectDataTypeError } from './utils.js';
+import { describe, it, expect, vi } from 'vitest';
+import {
+  convertBigInt64ArrayToInt32Array,
+  IncorrectDataTypeError,
+  bigInt64ToNumberArray,
+  getBytesPerElement,
+  extractCsrColumns,
+} from './utils.js';
 
 const toArray = typedArr => Array.from(typedArr).map(Number);
+const toBigInt = value => BigInt(value); // eslint-disable-line no-undef
 
+// Build CSR arrays from a dense row-major matrix, for testing the column scan.
+function denseToCsr(matrix) {
+  const indptr = [0];
+  const indices = [];
+  const data = [];
+  matrix.forEach((rowValues) => {
+    rowValues.forEach((value, col) => {
+      if (value !== 0) {
+        indices.push(col);
+        data.push(value);
+      }
+    });
+    indptr.push(indices.length);
+  });
+  return { indptr, indices, data, nnz: indices.length };
+}
+
+// A 20 x 15 matrix with an all-zero row (7), all-zero columns (4 and 9), and a
+// value pattern that identifies each (row, col) uniquely.
+const NUM_ROWS = 20;
+const NUM_COLS = 15;
+const DENSE = Array.from({ length: NUM_ROWS }, (_, i) => Array.from(
+  { length: NUM_COLS },
+  (__, j) => ((i + j) % 3 === 0 && i !== 7 && j !== 4 && j !== 9 ? i * NUM_COLS + j + 1 : 0),
+));
+const CSR = denseToCsr(DENSE);
+
+function makeChunkReaders(csr, chunkSize, { Indices = Int32Array, Data = Float32Array } = {}) {
+  // Chunks are padded to chunkSize with zeros, as zarr chunks are.
+  const padded = (arr, c) => {
+    const slice = arr.slice(c * chunkSize, (c + 1) * chunkSize);
+    const chunk = new Array(chunkSize).fill(0);
+    slice.forEach((v, i) => { chunk[i] = v; });
+    return chunk;
+  };
+  const asTyped = (Ctor, values) => (
+    Ctor === BigInt64Array // eslint-disable-line no-undef
+      ? Ctor.from(values.map(toBigInt))
+      : Ctor.from(values)
+  );
+  return {
+    getIndicesChunk: vi.fn(async c => asTyped(Indices, padded(csr.indices, c))),
+    getDataChunk: vi.fn(async c => asTyped(Data, padded(csr.data, c))),
+  };
+}
+
+async function extract(colIndices, chunkSize, options = {}) {
+  const { getIndicesChunk, getDataChunk } = makeChunkReaders(CSR, chunkSize, options);
+  const columns = await extractCsrColumns({
+    indptr: CSR.indptr,
+    numRows: NUM_ROWS,
+    numCols: NUM_COLS,
+    colIndices,
+    nnz: CSR.nnz,
+    chunkSize,
+    getIndicesChunk,
+    getDataChunk,
+    ...(options.prefetch ? { prefetch: options.prefetch } : {}),
+  });
+  return { columns, getIndicesChunk, getDataChunk };
+}
+
+const expectedColumn = j => DENSE.map(rowValues => rowValues[j]);
 
 describe('loaders/utils', () => {
   describe('convertBigInt64ArrayToInt32Array', () => {
@@ -16,6 +87,92 @@ describe('loaders/utils', () => {
       const array = new Int32Array([1, 2, 3, 4, 5]);
       expect(() => convertBigInt64ArrayToInt32Array(array))
         .toThrow(IncorrectDataTypeError);
+    });
+  });
+
+  describe('bigInt64ToNumberArray', () => {
+    it('keeps values above 2^31, unlike the int32 downcast', () => {
+      const big = (2n ** 33n) + 5n;
+      // eslint-disable-next-line no-undef
+      const converted = bigInt64ToNumberArray(new BigInt64Array([big, 5n, 0n]));
+      expect(converted).toBeInstanceOf(Float64Array);
+      expect(Array.from(converted)).toEqual([(2 ** 33) + 5, 5, 0]);
+    });
+
+    it('passes non-BigInt arrays through by identity', () => {
+      const arr = new Int32Array([1, 2]);
+      expect(bigInt64ToNumberArray(arr)).toBe(arr);
+    });
+  });
+
+  describe('getBytesPerElement', () => {
+    it('maps zarrita dtypes to byte widths, defaulting conservatively', () => {
+      expect(getBytesPerElement('float32')).toEqual(4);
+      expect(getBytesPerElement('int64')).toEqual(8);
+      expect(getBytesPerElement('uint8')).toEqual(1);
+      expect(getBytesPerElement('bool')).toEqual(1);
+      expect(getBytesPerElement('v2:object')).toEqual(8);
+    });
+  });
+
+  describe('extractCsrColumns', () => {
+    it('matches the dense columns across chunk sizes', async () => {
+      const cols = [1, 14, 4, 0, 7];
+      const chunkSizes = [1, 3, 8, CSR.nnz, CSR.nnz + 10];
+      // eslint-disable-next-line no-restricted-syntax
+      for (const chunkSize of chunkSizes) {
+        // eslint-disable-next-line no-await-in-loop
+        const { columns, getIndicesChunk } = await extract(cols, chunkSize);
+        expect(columns.map(toArray)).toEqual(cols.map(expectedColumn));
+        expect(getIndicesChunk).toHaveBeenCalledTimes(Math.ceil(CSR.nnz / chunkSize));
+      }
+    });
+
+    it('ignores fill-value padding in the trailing chunk', async () => {
+      // Column 0 equals the fill value, so padding read as stored values would
+      // wrongly place hits for it. Pick a chunk size that leaves a partial chunk.
+      const chunkSize = 7;
+      expect(CSR.nnz % chunkSize).not.toEqual(0);
+      const { columns } = await extract([0], chunkSize);
+      expect(toArray(columns[0])).toEqual(expectedColumn(0));
+    });
+
+    it('fetches data only for chunks that contain a requested column', async () => {
+      // Column 14 has a hit in roughly one of every three rows, so several
+      // small chunks carry no hit for it.
+      const chunkSize = 2;
+      const { columns, getIndicesChunk, getDataChunk } = await extract([14], chunkSize);
+      expect(toArray(columns[0])).toEqual(expectedColumn(14));
+      const chunksWithHits = new Set();
+      CSR.indices.forEach((col, k) => {
+        if (col === 14) {
+          chunksWithHits.add(Math.floor(k / chunkSize));
+        }
+      });
+      expect(getDataChunk).toHaveBeenCalledTimes(chunksWithHits.size);
+      expect(getDataChunk.mock.calls.length).toBeLessThan(getIndicesChunk.mock.calls.length);
+    });
+
+    it('returns zero columns without reads when nothing is requested', async () => {
+      const { columns, getIndicesChunk } = await extract([], 4);
+      expect(columns).toEqual([]);
+      expect(getIndicesChunk).not.toHaveBeenCalled();
+    });
+
+    it('is independent of the prefetch depth', async () => {
+      const cols = [2, 13];
+      const serial = await extract(cols, 5, { prefetch: 1 });
+      const parallel = await extract(cols, 5, { prefetch: 6 });
+      expect(serial.columns.map(toArray)).toEqual(parallel.columns.map(toArray));
+      expect(serial.columns.map(toArray)).toEqual(cols.map(expectedColumn));
+    });
+
+    it('accepts 64-bit integer indices and data', async () => {
+      const { columns } = await extract([1, 7], 6, {
+        Indices: BigInt64Array, // eslint-disable-line no-undef
+        Data: BigInt64Array, // eslint-disable-line no-undef
+      });
+      expect(columns.map(toArray)).toEqual([1, 7].map(expectedColumn));
     });
   });
 });

--- a/packages/utils/other-utils/src/components.ts
+++ b/packages/utils/other-utils/src/components.ts
@@ -142,7 +142,7 @@ export function formatBytes(bytes: number, decimals = 2) {
 
   const k = 1024;
   const dm = decimals < 0 ? 0 : decimals;
-  const sizes = ['Bytes', 'KB', 'MB', 'GB'];
+  const sizes = ['Bytes', 'KB', 'MB', 'GB', 'TB', 'PB'];
 
   const i = Math.floor(Math.log(bytes) / Math.log(k));
 

--- a/packages/utils/other-utils/src/index.ts
+++ b/packages/utils/other-utils/src/index.ts
@@ -42,6 +42,12 @@ export {
 } from './gating.js';
 export { default as Pool } from './Pool.js';
 export {
+  DEFAULT_MAX_ALLOCATION_BYTES,
+  getJsHeapSizeLimit,
+  getAllocationBudgetBytes,
+  exceedsAllocationBudget,
+} from './memory.js';
+export {
   aggregateFeatureArrays,
   normalizeAggregatedFeatureArray,
   filterValidExpressionArrays,

--- a/packages/utils/other-utils/src/memory.test.ts
+++ b/packages/utils/other-utils/src/memory.test.ts
@@ -1,0 +1,57 @@
+import { describe, it, expect, afterEach } from 'vitest';
+import {
+  DEFAULT_MAX_ALLOCATION_BYTES,
+  getJsHeapSizeLimit,
+  getAllocationBudgetBytes,
+  exceedsAllocationBudget,
+} from './memory.js';
+import { formatBytes } from './components.js';
+
+function setHeapLimit(value: unknown) {
+  Object.defineProperty(globalThis.performance, 'memory', {
+    value: { jsHeapSizeLimit: value },
+    configurable: true,
+  });
+}
+
+describe('allocation budget', () => {
+  afterEach(() => {
+    delete (globalThis.performance as { memory?: unknown }).memory;
+  });
+
+  it('falls back when the browser reports no heap limit', () => {
+    // Node and jsdom, like Firefox and Safari, have no performance.memory.
+    expect(getJsHeapSizeLimit()).toEqual(null);
+    expect(getAllocationBudgetBytes()).toEqual(DEFAULT_MAX_ALLOCATION_BYTES);
+    expect(exceedsAllocationBudget(DEFAULT_MAX_ALLOCATION_BYTES)).toEqual(false);
+    expect(exceedsAllocationBudget(DEFAULT_MAX_ALLOCATION_BYTES + 1)).toEqual(true);
+  });
+
+  it('uses half of the reported heap limit', () => {
+    setHeapLimit(1000);
+    expect(getJsHeapSizeLimit()).toEqual(1000);
+    expect(getAllocationBudgetBytes()).toEqual(500);
+    expect(exceedsAllocationBudget(500)).toEqual(false);
+    expect(exceedsAllocationBudget(501)).toEqual(true);
+  });
+
+  it('ignores malformed heap limits', () => {
+    setHeapLimit('4096');
+    expect(getJsHeapSizeLimit()).toEqual(null);
+    setHeapLimit(0);
+    expect(getJsHeapSizeLimit()).toEqual(null);
+  });
+
+  it('treats non-finite sizes as exceeding the budget', () => {
+    expect(exceedsAllocationBudget(Number.NaN)).toEqual(true);
+    expect(exceedsAllocationBudget(Number.POSITIVE_INFINITY)).toEqual(true);
+  });
+});
+
+describe('formatBytes', () => {
+  it('formats sizes beyond gigabytes', () => {
+    expect(formatBytes(2 ** 40)).toEqual('1 TB');
+    expect(formatBytes(465 * (2 ** 30))).toEqual('465 GB');
+    expect(formatBytes(3 * (2 ** 50))).toEqual('3 PB');
+  });
+});

--- a/packages/utils/other-utils/src/memory.ts
+++ b/packages/utils/other-utils/src/memory.ts
@@ -1,0 +1,44 @@
+/**
+ * Fallback allocation budget for browsers that do not expose a heap size limit.
+ * Matches the long-standing ceiling used by canLoadResolution in spatial-utils.
+ */
+export const DEFAULT_MAX_ALLOCATION_BYTES = (2 ** 31) - 1;
+
+type PerformanceWithMemory = {
+  memory?: { jsHeapSizeLimit?: unknown },
+};
+
+/**
+ * The JS heap size limit reported by the browser, when available.
+ * Only Chromium exposes performance.memory; Firefox, Safari, Node, and
+ * workers return null. Read via globalThis so this is safe outside the DOM.
+ * @returns The limit in bytes, or null when unknown.
+ */
+export function getJsHeapSizeLimit(): number | null {
+  const perf = (globalThis as { performance?: PerformanceWithMemory }).performance;
+  const limit = perf?.memory?.jsHeapSizeLimit;
+  if (typeof limit === 'number' && Number.isFinite(limit) && limit > 0) {
+    return limit;
+  }
+  return null;
+}
+
+/**
+ * How many bytes a single large allocation may plausibly take.
+ * Half of the reported heap limit, else DEFAULT_MAX_ALLOCATION_BYTES.
+ * @returns The budget in bytes.
+ */
+export function getAllocationBudgetBytes(): number {
+  const limit = getJsHeapSizeLimit();
+  return limit === null ? DEFAULT_MAX_ALLOCATION_BYTES : limit / 2;
+}
+
+/**
+ * Whether an allocation of the given size exceeds the budget.
+ * Non-finite sizes (overflowed products, NaN) count as exceeding it.
+ * @param bytes The estimated allocation size in bytes.
+ * @returns True when the allocation should not be attempted blindly.
+ */
+export function exceedsAllocationBudget(bytes: number): boolean {
+  return !Number.isFinite(bytes) || bytes > getAllocationBudgetBytes();
+}

--- a/packages/utils/zarr-utils/src/index.ts
+++ b/packages/utils/zarr-utils/src/index.ts
@@ -4,6 +4,7 @@ export {
 export {
   zarrOpenRoot,
   transformEntriesForZipFileStore,
+  UNCACHED_READ,
   CachedStore,
 } from './normalize.js';
 export type { QueryClientLike } from './normalize.js';

--- a/packages/utils/zarr-utils/src/normalize.test.ts
+++ b/packages/utils/zarr-utils/src/normalize.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect } from 'vitest';
 import type { AbsolutePath, RangeQuery } from 'zarrita';
-import { CachedStore, type QueryClientLike } from './normalize.js';
+import { CachedStore, UNCACHED_READ, type QueryClientLike } from './normalize.js';
 
 // A store whose responses resolve only when released, for testing coalescing.
 function makeGatedStore(withGetRange = true) {
@@ -133,5 +133,39 @@ describe('CachedStore', () => {
     // Same key, different URLs: both stores are read.
     expect(gatedA.calls.length).toEqual(1);
     expect(gatedB.calls.length).toEqual(1);
+  });
+
+  it('reads straight through when the UNCACHED_READ marker is set', async () => {
+    const seen: Array<[string, unknown]> = [];
+    const store = {
+      async get(key: AbsolutePath, opts?: RequestInit) {
+        seen.push([`get:${key}`, opts]);
+        return new TextEncoder().encode(key);
+      },
+      async getRange(key: AbsolutePath, range: RangeQuery, opts?: RequestInit) {
+        seen.push([`getRange:${key}`, opts]);
+        return new TextEncoder().encode(key);
+      },
+    };
+    const { queryClient, getFetchQueryCalls } = makeQueryClientStub();
+    const cached = new CachedStore(store, 'http://example.com/a.zarr', queryClient);
+    const opts = { [UNCACHED_READ]: true, headers: { Authorization: 'Bearer x' } };
+    await cached.get('/X/indices/0', opts);
+    await cached.get('/X/indices/0', opts);
+    await cached.getRange?.('/X/indices/0', { offset: 0, length: 4 }, opts);
+    // Every read reached the store: nothing was coalesced or retained.
+    expect(seen.map(([label]) => label)).toEqual([
+      'get:/X/indices/0', 'get:/X/indices/0', 'getRange:/X/indices/0',
+    ]);
+    expect(getFetchQueryCalls()).toEqual(0);
+    // The marker is stripped, the remaining request options are preserved, and
+    // the caller's object is not mutated.
+    expect(seen[0][1]).toEqual({ headers: { Authorization: 'Bearer x' } });
+    expect(opts[UNCACHED_READ]).toEqual(true);
+    // Reads without the marker still go through the cache.
+    await cached.get('/X/indices/1');
+    await cached.get('/X/indices/1');
+    expect(getFetchQueryCalls()).toEqual(2);
+    expect(seen.filter(([label]) => label === 'get:/X/indices/1').length).toEqual(1);
   });
 });

--- a/packages/utils/zarr-utils/src/normalize.ts
+++ b/packages/utils/zarr-utils/src/normalize.ts
@@ -39,6 +39,32 @@ type CacheFetchFn = (
 ) => Promise<Uint8Array | undefined>;
 
 /**
+ * Request-option marker that makes CachedStore read straight through to the
+ * wrapped store. Readers that stream a large array chunk by chunk (and never
+ * revisit a chunk) set it so that the react-query cache does not retain the
+ * whole array for CHUNK_GC_TIME. The marker rides on the zarrita request options
+ * object, which zarrita passes through to the store unchanged; it is stripped
+ * before the options reach the wrapped store (and therefore fetch).
+ */
+export const UNCACHED_READ = 'vitessceUncachedRead';
+
+type ReadOptions = RequestInit & { [UNCACHED_READ]?: boolean };
+
+/**
+ * Separate the UNCACHED_READ marker from the options passed to the wrapped store.
+ * @param opts Request options as received from zarrita.
+ * @returns Whether the read bypasses the cache, and the options without the marker.
+ */
+function splitReadOptions(opts?: ReadOptions): [boolean, RequestInit | undefined] {
+  if (!opts || !opts[UNCACHED_READ]) {
+    return [false, opts];
+  }
+  const rest: ReadOptions = { ...opts };
+  delete rest[UNCACHED_READ];
+  return [true, rest];
+}
+
+/**
  * Build the function through which all cached store reads flow.
  * @param queryClient A QueryClient, when available.
  * @returns With a queryClient: reads go through fetchQuery, which coalesces
@@ -85,7 +111,7 @@ export class CachedStore {
   cacheFetch: CacheFetchFn;
 
   getRange?: (
-    key: AbsolutePath, range: RangeQuery, opts?: RequestInit,
+    key: AbsolutePath, range: RangeQuery, opts?: ReadOptions,
   ) => Promise<Uint8Array | undefined>;
 
   constructor(store: Readable, cacheKeyPrefix: string, queryClient?: QueryClientLike) {
@@ -95,21 +121,33 @@ export class CachedStore {
     // getRange is part of zarrita's optional store interface and consumers
     // feature-detect it, so only define it when the wrapped store has one.
     if (typeof (store as { getRange?: unknown }).getRange === 'function') {
-      this.getRange = (key, range, opts) => this.cacheFetch(
-        ['zarrStore', this.cacheKeyPrefix, key, range],
-        () => (this.store as {
-          getRange: (
-            k: AbsolutePath, r: RangeQuery, o?: RequestInit,
-          ) => Promise<Uint8Array | undefined>,
-        }).getRange(key, range, opts),
-      );
+      const inner = this.store as {
+        getRange: (
+          k: AbsolutePath, r: RangeQuery, o?: RequestInit,
+        ) => Promise<Uint8Array | undefined>,
+      };
+      this.getRange = (key, range, opts) => {
+        const [uncached, rest] = splitReadOptions(opts);
+        if (uncached) {
+          return inner.getRange(key, range, rest);
+        }
+        return this.cacheFetch(
+          ['zarrStore', this.cacheKeyPrefix, key, range],
+          () => inner.getRange(key, range, rest),
+        );
+      };
     }
   }
 
-  get(key: AbsolutePath, opts?: RequestInit): Promise<Uint8Array | undefined> {
+  get(key: AbsolutePath, opts?: ReadOptions): Promise<Uint8Array | undefined> {
+    const [uncached, rest] = splitReadOptions(opts);
+    if (uncached) {
+      // Readable.get may resolve synchronously; normalize to a promise.
+      return Promise.resolve(this.store.get(key, rest));
+    }
     return this.cacheFetch(
       ['zarrStore', this.cacheKeyPrefix, key],
-      async () => this.store.get(key, opts),
+      async () => this.store.get(key, rest),
     );
   }
 }

--- a/packages/vit-s/src/VitS.js
+++ b/packages/vit-s/src/VitS.js
@@ -14,6 +14,7 @@ import {
 } from '@tanstack/react-query';
 import { isEqual } from 'lodash-es';
 import { buildConfigSchema, latestConfigSchema } from '@vitessce/schemas';
+import { MatrixTooLargeError } from '@vitessce/error';
 import {
   log,
   setLogLevel, setDebugMode,
@@ -248,7 +249,12 @@ export function VitS(props) {
     defaultOptions: {
       queries: {
         refetchOnWindowFocus: false,
-        retry: 2,
+        // A matrix that does not fit the browser's budget will not fit on a
+        // retry either; surface that message immediately rather than after
+        // two more attempts and their backoff.
+        retry: (failureCount, error) => (
+          failureCount < 2 && !(error instanceof MatrixTooLargeError)
+        ),
       },
     },
     // Reference: https://tkdodo.eu/blog/react-query-error-handling#the-global-callbacks

--- a/sites/docs/docs/data-file-types.mdx
+++ b/sites/docs/docs/data-file-types.mdx
@@ -361,6 +361,7 @@ To learn more, visit the [AnnData](https://anndata.readthedocs.io/en/latest/) do
 
 An observation-by-feature matrix with observations along the `obs` axis (rows) and features along the `var` axis (columns).
 Typically stored in `adata.X`, but the `"path"` option allows pointing to any array within the AnnData object.
+The matrix may be dense or sparse (`csc_matrix` or `csr_matrix`); dense and CSC matrices are preferred, because individual features can be read without scanning the whole matrix. See [sparse matrices](../data-troubleshooting/#anndata-zarr-obsfeaturematrix-with-sparse-matrices) in the data troubleshooting guide.
 
 <FileDefTabs
 fileName="my_adata.zarr"

--- a/sites/docs/docs/data-troubleshooting.md
+++ b/sites/docs/docs/data-troubleshooting.md
@@ -65,12 +65,23 @@ adata.write_zarr(out_path, chunks=(adata.shape[0], VAR_CHUNK_SIZE))
 
 ### AnnData-Zarr obsFeatureMatrix with sparse matrices
 
-Vitessce can load `obsFeatureMatrix` data (e.g., `adata.X` or `adata.layers["counts"]`) stored as either dense or sparse matrix.
+Vitessce can load `obsFeatureMatrix` data (e.g., `adata.X` or `adata.layers["counts"]`) stored as either a dense or a sparse matrix.
 
 For sparse matrices, Vitessce supports the following SciPy sparse matrix types [supported by AnnData](https://anndata.readthedocs.io/en/latest/fileformat-prose.html#sparse-arrays): CSC and CSR.
 
-__Dense and CSC sparse matrices are preferred__, as data for individual genes (a single matrix column) can be loaded efficiently (i.e., without needing to load the entire matrix) ([code](https://github.com/vitessce/vitessce/blob/a06eecfce33fc99ef0111b84db8186a9efb5d7ba/packages/file-types/zarr/src/anndata-loaders/ObsFeatureMatrixAnndataLoader.js#L108C14-L108C17)).
-Meanwhile, loading a single gene from a CSR sparse matrix currently requires Vitessce to load the entire matrix, which can  result in out-of-memory errors in the web browser (if the matrix is large).
+__Dense and CSC sparse matrices are preferred__ when features are accessed individually (the feature list, and coloring a scatterplot or spatial view by a gene): in a CSC matrix the values for one feature are one contiguous slice of `indices` and `data`, so selecting a feature reads only the chunks that slice touches.
+
+A CSR matrix has no such per-feature slice. Selecting features from a CSR matrix scans the whole `indices` array (and the `data` chunks that contain a match) in chunk-sized pieces, without ever densifying the matrix. Memory stays bounded, but every selection downloads on the order of `nnz × 8` bytes, so it is only practical for small matrices; above the browser's allocation budget (roughly 2 GB) Vitessce refuses the selection with a `MatrixTooLargeError` that names the matrix and this remedy. Convert before writing to Zarr:
+
+```python
+from scipy import sparse
+adata.X = sparse.csc_matrix(adata.X)
+adata.write_zarr("my_store.zarr")
+```
+
+For CSC matrices, smaller chunks on the sparse component arrays reduce how much is read per feature: AnnData's default chunking stores hundreds of thousands of values per chunk, so a feature with a few thousand nonzeros still downloads several megabytes. Rechunking `X/indices` and `X/data` to roughly 100,000 elements cuts that read amplification several-fold.
+
+Rendering the __full__ matrix (the heatmap and the expression histogram) requires `n_obs × n_vars × 4` bytes regardless of encoding. Vitessce logs a warning when that estimate exceeds the browser's budget and, if the allocation then fails, reports a `MatrixTooLargeError` instead of stalling. See the [next section](#my-obsfeaturematrix-is-too-large-to-render-everything) for how to load a subset.
 
 ### My obsFeatureMatrix is too large to render everything
 
@@ -91,7 +102,7 @@ Below, we provide guidance for how to pursue the former strategy (i.e., load and
 When the full expression matrix `adata.X` is large, there may be performance costs if Vitessce tries to load the full matrix for visualization, whether it be a heatmap
 or just loading genes to overlay on a spatial or scatterplot view.
 To resolve this issue:
-1. Ensure the X array is stored using the CSC sparse format or __chunk the Zarr store efficiently__ (the latter is recommended, see above ["chunking strategy" section](#anndata-zarr-obsfeaturematrix-chunking-strategy)) so that the UI remains responsive when selecting a gene to load into the client.
+1. Ensure the X array is stored using the CSC sparse format (see the ["sparse matrices" section](#anndata-zarr-obsfeaturematrix-with-sparse-matrices) above) or, if dense, __chunk the Zarr store efficiently__ (see the ["chunking strategy" section](#anndata-zarr-obsfeaturematrix-chunking-strategy)) so that the UI remains responsive when selecting a gene to load into the client.
 Every time a gene is selected (or the heatmap is loaded), the client will use Zarr to fetch all the "cell x gene" information needed for rendering - however, a poor chunking strategy
 can result in too much data be loaded (and then not used).  To remedy this, we recommend passing in the `chunk_size` argument to `write_zarr` so that the data is chunked in a manner that allows
 remote sources (like browsers) to fetch only the genes (and all cells) necessary for efficient display - to this end the chunk size is usually something like `[num_cells, small_number]`
@@ -110,14 +121,11 @@ adata = read_h5ad('path/to/my_dataset.h5ad')
 
 # Adds the `highly_variable` key to `var`
 sc.pp.highly_variable_genes(adata, n_top_genes=200)
-# If the matrix is sparse, it's best for performance to
-# use non-sparse formats + chunking to keep the UI responsive.
-# In the future, we should be able to use CSC sparse data natively
-# and get equal performance with chunking:
-# https://github.com/theislab/anndata/issues/524 
-# but for now, it is still not as good (although not unusable).
+# If the matrix is sparse, store it as CSC so that individual genes
+# can be read without scanning the whole matrix. A dense, column-chunked
+# array (see the chunking strategy section above) is the other efficient option.
 if isinstance(adata.X, sparse.spmatrix):
-    adata.X = adata.X.todense() # Or adata.X.tocsc() if you need to.
+    adata.X = adata.X.tocsc()
 adata.write_zarr(zarr_path, [adata.shape[0], VAR_CHUNK_SIZE])  # VAR_CHUNK_SIZE should be something small like 10
 ```
 


### PR DESCRIPTION
Fixes #2565

#### Background

Third and last fix from the 2,073,246-cell HuBMAP dataset (`728d02be5fada1541decd1091a4b17e3`). Its `layers/unscaled` matrix is a `csc_matrix` of shape 2,073,246 × 56,134 with 1.54 billion stored values (`indices`/`data` in 2,048 chunks of 750,257).

`ObsFeatureMatrixAnndataLoader` had three ways to fall over on a matrix like this, all ending in an indefinite spinner:

- **Unguarded densification.** Both sparse full-matrix paths read *all* of `indptr`/`indices`/`data` and then allocated `new Float32Array(shape[0] * shape[1])` — here ~12 GB of download followed by a 465 GB allocation, surfacing as a `RangeError` far from its cause (or GC death). The dense path let zarrita allocate the same product unchecked.
- **CSR selection densified the whole matrix** to read one column, while the CSC path correctly sliced `[indptr[i], indptr[i+1])`. The CSR + `initialFeatureFilterPath` branch densified everything and then allocated a *second* filtered copy.
- **Sticky failures.** Cached promises were never cleared on rejection, and react-query's `retry: 2` re-ran a deterministic failure three times.

Implementing this also surfaced latent bugs: int64 `indptr` **crashed** CSC selection (a `BigInt` reached zarrita's `slice()`; untested because the fixtures' int64 layers are dense); an unknown feature returned the **last column** on dense matrices (zarrita normalizes `-1`); both CSR paths strided the dense buffer by the `featureFilterPath`-filtered gene count while it was laid out by `shape[1]`; and `_matrixZattrs` was assigned after an `await`, so concurrent callers raced.

#### Change List

**`@vitessce/zarr` — `ObsFeatureMatrixAnndataLoader`**
- **CSR per-feature selection is a chunk-wise scan**, never a densification. `extractCsrColumns` (in `anndata-loaders/utils.js`, with injected chunk readers so it is unit-testable) streams `indices` with a bounded prefetch window, recovers rows with a pointer that moves forward over `indptr` (O(nnz + n_obs)), fetches a `data` chunk only when it contained a hit, and clamps the fill-value-padded trailing chunk (whose padding is `0`, a valid column index). Peak memory is a few chunks plus the output columns, independent of nnz.
- **Concurrent selections share one scan.** `useFeatureSelection` issues one query per gene, so requests are collected and flushed on a macrotask; scans serialize per loader, and columns requested mid-scan form the next one. No per-column result cache — react-query already retains per-feature results.
- **Budget checks before any chunk read**, from array metadata alone (`indexArr.shape[0]` is nnz): a CSR scan whose `nnz × (indexBytes + valueBytes)` exceeds the browser's allocation budget is refused with a `MatrixTooLargeError` naming the path, shape, nnz, estimate, and the remedy (`adata.X = scipy.sparse.csc_matrix(adata.X)`, with a docs link); above 256 MiB it proceeds with a one-time warning.
- **Full-matrix paths warn and attempt.** When `4 × n_obs × n_vars` (plus the sparse arrays) exceeds the budget, the loader logs a descriptive warning and still tries; the dense buffer is **allocated before downloading**, so an impossible allocation fails immediately with no transfer, and a `RangeError` is rethrown as a `MatrixTooLargeError` (matched by name as well as class — it can come from another realm). The `initialFeatureFilterPath` case reads only the filtered columns for every encoding, deleting the CSR branch that densified and copied.
- CSC: `indptr` is read once and converted to numbers (fixes the int64 crash), the `indices`/`data` slices are fetched in parallel with bounded concurrency, and int64 values convert without truncation.
- Unknown features report zeros with a warning on every encoding (CSC's existing behavior; safe for `featureSelection` scopes shared across datasets) instead of garbage (CSR) or the last column (dense).
- All memoized promises go through `_memoized`, which clears a rejected promise so a retry re-runs the work.

**`@vitessce/utils`** — `memory.ts`: `getAllocationBudgetBytes` / `exceedsAllocationBudget` / `getJsHeapSizeLimit`, the same `jsHeapSizeLimit / 2` (fallback 2³¹ − 1) rule `canLoadResolution` already uses, read via `globalThis` so it works in Node, jsdom, and workers. `formatBytes` gains TB/PB.

**`@vitessce/error`** — `MatrixTooLargeError extends DataLoaderError`, so `TitleInfo` shows `MatrixTooLargeError: …`.

**`@vitessce/zarr-utils`** — `UNCACHED_READ` request-option marker; `CachedStore.get`/`getRange` read straight through when it is set (stripping it before the wrapped store). Scan reads use it so a multi-GB pass does not pin every chunk in the react-query cache for 30 s; `gcTime` cannot be lowered per read (react-query takes the max).

**`@vitessce/vit-s`** — the global `retry` becomes a predicate that skips retries for `MatrixTooLargeError`; transient errors still retry twice.

**Docs** — the "sparse matrices" section is rewritten (CSC preferred and why; how CSR selection now behaves and where its limit is; a CSC chunking tip), the stale "requires Vitessce to load the entire matrix" text and pinned permalink are removed, the `todense()` advice becomes `tocsc()`, and `data-file-types.mdx` gets a pointer under `obsFeatureMatrix.anndata.zarr`.

**Tests** — 13 new loader tests plus 9 helper tests: CSR/CSC/dense equivalence including all-zero, repeated, and unknown features; coalescing (two concurrent calls → one `indices` read; requests during a scan → exactly one further scan); budget refusal with zero chunk reads; heap-limit stub honored without caching the refusal; warn-and-attempt equality; allocation failure → descriptive error with zero chunk reads; no caching of a failed load; multi-chunk and int64 CSR/CSC built as in-memory zarr-v3 overlays with zarrita (chunk sizes 1/4/5, int32 and int64 pointers) matching the dense fixture; `initialFeatureFilterPath` on CSR without densifying; `extractCsrColumns` boundary cases (padding clamp with column 0, hit-less chunks skip `data`, prefetch depth, BigInt inputs); `UNCACHED_READ` bypass; budget helper behavior with and without `performance.memory`.

#### Verification

- Unit tests: zarr 100/100, utils 12/12, zarr-utils 15/15, vit-s 42/42. ESLint 0 errors; `tsc --build` clean; `changeset-status` clean.
- **Live HuBMAP store, through the compiled loader (Node):** selecting one gene from the CSC matrix returns the full 2,073,246-length column (380,480 nonzeros) with **exactly 2 chunk reads** (`indices/11`, `data/11`) in 3.4 s; the full-matrix load logs one warning and fails in **0.0 s with 0 chunk reads**: `MatrixTooLargeError: Loading the full observation-by-feature matrix at "mod/RNA_processed/layers/unscaled" (shape [2073246, 56134], csc_matrix) needs about 445 GB of memory, more than this browser's ~2 GB budget. Load a subset of features with the "initialFeatureFilterPath" option …`. Before this change the same load downloaded ~12 GB first.

#### Notes for reviewers

- The message reports `445 GB` where #2565 says 465 GB — same byte count, `formatBytes` uses binary units.
- The budget is the 2 GiB fallback on Firefox/Safari and ≈2 GB on Chromium; the heatmap's `useUint8ObsFeatureMatrix` adds ~2.25× downstream, so a matrix just under budget can still fail later — documented rather than multiplied in.
- A CSR scan below the cap is allowed but heavy (up to ~2 GB per selection); mitigated by the warning, coalescing, and docs. A worker is not warranted yet: each chunk is a few ms of decode + loop with an `await` between chunks.
- Not in this PR: the sibling loaders that also allocate `n_obs × n_vars` unguarded (`ObsFeatureColumnsAnndataLoader`, `ObsFeatureMatrixCsv`); the optional 3-line reuse of the budget helper in `canLoadResolution`; a Python-generated multi-chunk fixture (the in-memory zarr-v3 overlay covers the same paths without a toolchain).

#### Checklist
 - [x] Have tested PR with one or more demo configurations — the 2M-cell HuBMAP matrix exercised through the compiled loader against the live store (above); also tested with Salcher 2022 dataset.
 - [x] Documentation added, updated, or not applicable — `data-troubleshooting.md` and `data-file-types.mdx` updated

