### PR TITLE
Tkakar/fix 2579

### DIFF
--- a/.changeset/famous-lamps-talk.md
+++ b/.changeset/famous-lamps-talk.md
@@ -1,0 +1,5 @@
+---
+"docs": patch
+---
+
+Fix production build error - add webpack fallback for worker_threads

--- a/sites/docs/docusaurus.config.js
+++ b/sites/docs/docusaurus.config.js
@@ -163,6 +163,20 @@ export default {
   plugins: [
     './plugins/vitessce-plugin',
     './plugins/monaco-editor-plugin',
+    function webpackWorkerThreadsFallbackPlugin() {
+      return {
+        name: 'webpack-worker-threads-fallback',
+        configureWebpack() {
+          return {
+            resolve: {
+              fallback: {
+                worker_threads: false,
+              },
+            },
+          };
+        },
+      };
+    },
     //path.resolve(__dirname, 'plugins', 'vitessce-plugin'),
   ],
   scripts: [


### PR DESCRIPTION
unzipit (pulled in transitively via zarr-utils/zarrita) attempts to import Node's worker_threads module, which Webpack 5 no longer auto-polyfills. This has been silently breaking the docs/demo/app site build step in the release workflow since at least the zarrita upgrade in #2546 
worker_threads is only used in unzipit's Node-side code path and is safely unused in the browser; this tells webpack to treat it as unavailable rather than trying to resolve/bundle it.
Fixes #2579 
<!-- For other PRs without open issue -->
#### Background
<!-- For all the PRs -->
#### Change List
-
#### Checklist
 - [ ] Have tested PR with one or more demo configurations
 - [ ] Documentation added, updated, or not applicable
