### PR TITLE
NickAkhmetov/Fix handling of 403 responses during config generation and add tests for .zmetadata access

### DIFF
--- a/.changeset/khaki-donuts-flash.md
+++ b/.changeset/khaki-donuts-flash.md
@@ -1,0 +1,6 @@
+---
+"@vitessce/config": patch
+"@vitessce/zarr-utils": patch
+---
+
+Treat a 403 response for `.zmetadata` as missing consolidated metadata during automatic config generation, since buckets that deny `s3:ListBucket` return AccessDenied rather than Not Found for keys that do not exist.

--- a/packages/config/src/VitessceAutoConfig.js
+++ b/packages/config/src/VitessceAutoConfig.js
@@ -339,10 +339,9 @@ class AnndataZarrAutoConfig extends AbstractAutoConfig {
       if (response.ok) {
         return this.setMetadataSummaryWithZmetadata(response);
       }
-      if (response.status === 404) {
-        return this.setMetadataSummaryWithoutZmetadata();
-      }
-      throw new Error(`Could not generate config: ${response.statusText}`);
+      // A missing .zmetadata is a 404, or a 403 when the bucket denies s3:ListBucket
+      // (S3 masks non-existence as AccessDenied). Either way, probe known keys instead.
+      return this.setMetadataSummaryWithoutZmetadata();
     }).catch((error) => {
       throw new Error(`Could not generate config for URL ${this.fileUrl}: ${error}`);
     });

--- a/packages/config/src/VitessceAutoConfig.test.js
+++ b/packages/config/src/VitessceAutoConfig.test.js
@@ -1,8 +1,12 @@
-import { describe, it, expect } from 'vitest';
+import { describe, it, expect, vi, afterEach } from 'vitest';
 import { generateConfig, getHintOptions } from './VitessceAutoConfig.js';
 import { HINT_TYPE_TO_FILE_TYPE_MAP } from './constants.js';
 
 describe('generateConfig', () => {
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
   it('generates config for OME-TIFF file correctly', async () => {
     const urls = ['somefile.ome.tif'];
     const expectedConfig = {
@@ -578,6 +582,27 @@ describe('generateConfig', () => {
 
     const config = await generateConfig(urls);
     expect(config).toEqual(expectedConfig);
+  });
+
+  it('Does the parsing when .zmetadata request is denied with 403', async () => {
+    // Buckets that grant s3:GetObject but not s3:ListBucket answer AccessDenied
+    // rather than Not Found for keys that do not exist, so a missing .zmetadata
+    // arrives as a 403. Reference: the meta-2022-azimuth dataset on data-1.vitessce.io.
+    const urls = ['http://localhost:4204/@fixtures/zarr/anndata-0.8/anndata-csr.adata.zarr'];
+    const realFetch = fetch;
+    vi.stubGlobal('fetch', async (input, init) => {
+      const response = await realFetch(input, init);
+      if (String(input).endsWith('/.zmetadata') && response.status === 404) {
+        return new Response('<Error><Code>AccessDenied</Code></Error>', { status: 403 });
+      }
+      return response;
+    });
+
+    const config = await generateConfig(urls);
+    const [file] = config.datasets[0].files;
+    expect(file.options.obsEmbedding).toEqual([{ path: 'obsm/X_umap', embeddingType: 'UMAP' }]);
+    expect(file.options.obsSets).toEqual([{ name: 'Cell Type', path: 'obs/leiden' }]);
+    expect(config.layout.map(v => v.component)).toContain('heatmap');
   });
 
   it('raises an error when URL with unsupported file format is passed', async () => {

--- a/packages/config/src/generate-config.js
+++ b/packages/config/src/generate-config.js
@@ -4,7 +4,7 @@ import { FileType } from '@vitessce/constants-internal';
 import { withConsolidatedMetadata, extendStore, FetchStore, open as zarrOpen } from 'zarrita';
 // eslint-disable-next-line import/no-unresolved
 import ZipFileStore from '@zarrita/storage/zip';
-import { transformEntriesForZipFileStore } from '@vitessce/zarr-utils';
+import { transformEntriesForZipFileStore, relaxedFetch } from '@vitessce/zarr-utils';
 import { VitessceConfig } from './VitessceConfig.js';
 // Classes for different types of objects
 import { AnnDataAutoConfig } from './generate-config-anndata.js';
@@ -88,7 +88,9 @@ function getStore(parsedUrl) {
     ? ZipFileStore.fromUrl(url, {
       transformEntries: transformEntriesForZipFileStore,
     })
-    : new FetchStore(url);
+    // relaxedFetch maps 403 to 404, since buckets that deny s3:ListBucket
+    // return AccessDenied for keys that do not exist.
+    : new FetchStore(url, { fetch: relaxedFetch });
 }
 
 /**

--- a/packages/utils/zarr-utils/src/index.ts
+++ b/packages/utils/zarr-utils/src/index.ts
@@ -5,6 +5,7 @@ export {
   applyStoreExtensions,
   zarrOpenRoot,
   transformEntriesForZipFileStore,
+  relaxedFetch,
   UNCACHED_READ,
 } from './normalize.js';
 export type { QueryClientLike } from './normalize.js';

--- a/packages/utils/zarr-utils/src/normalize.ts
+++ b/packages/utils/zarr-utils/src/normalize.ts
@@ -13,7 +13,7 @@ import { withGetRange } from './base-getrange.js';
 // custom error handling function or additional options
 // to the zarrita FetchStore so that a subclass is not required.
 // Reference: https://zarrita.dev/migration/v0.7.html
-async function relaxedFetch(...args: Parameters<typeof fetch>) {
+export async function relaxedFetch(...args: Parameters<typeof fetch>) {
   const response = await fetch(...args);
   if (response.status === 403) {
     return new Response(null, { status: 404 });


### PR DESCRIPTION

#### Background

Passing `https://data-1.vitessce.io/0.0.33/main/meta-2022-azimuth/meta_2022_azimuth.h5ad.zarr` to the config generator in the docs View Config Editor failed with:

```
Error: Could not generate config for URL https://.../meta_2022_azimuth.h5ad.zarr: Error: Could not generate config: setMetadataSummary
```


That store has no consolidated metadata, and the bucket returns **403 AccessDenied rather than
404** for keys that do not exist — the bucket policy grants `s3:GetObject` but not `s3:ListBucket`,
so S3 masks non-existence as AccessDenied. Verified by direct request:

| key | status |
|---|---|
| `/.zmetadata` | 403 (missing) |
| `/obsm/X_umap/.zarray` | 200 |
| `/obsm/X_pca/.zarray` | 403 (missing) |
| `/obs/.zattrs` | 200 |
| `/X/.zarray` | 200 |
| `/zarr.json` | 403 (missing) |

Both config generators assumed missing == 404, so both failed on this bucket:

- `VitessceAutoConfig.js` (used by the docs editor) branched on `response.ok` and exactly
  `response.status === 404`; a 403 fell through to
  `throw new Error(\`Could not generate config: ${response.statusText}\`)`. `statusText` is `""` in
  browsers over HTTP/2, so the visible tail was empty and the trailing `setMetadataSummary` came
  from the stack frame.
- `generate-config.js` (`generateConfigAlt`, used by the launcher and drag-and-drop) built a bare
  `new FetchStore(url)`. zarrita's `handle_response` returns `undefined` only for 404 and throws
  for every other non-200/206 status, so `zarrOpen(store, { kind: 'group' })` threw on the 403
  from `/zarr.json`.

The store itself is fine — the non-consolidated fallback already filters probe responses on `.ok`
and produces a usable config once it is reached.

The repo already solved this for the main data-loading path: `relaxedFetch` in
`packages/utils/zarr-utils/src/normalize.ts` maps a 403 response to a synthetic 404 before zarrita
sees it. It was module-private and unused by either generator.

#### Change List

- `packages/config/src/VitessceAutoConfig.js`: treat any non-ok `.zmetadata` response as "not
  consolidated" and fall back to probing known keys, instead of only handling 404 and throwing
  otherwise.
- `packages/utils/zarr-utils/src/normalize.ts`, `src/index.ts`: export the existing `relaxedFetch`
  helper.
- `packages/config/src/generate-config.js`: pass `relaxedFetch` to `FetchStore` in `getStore()`, so
  the newer generator tolerates the same buckets.
- `packages/config/src/VitessceAutoConfig.test.js`: regression test that stubs `fetch` to turn the
  fixture's 404 for `.zmetadata` into a 403, and asserts a config is still generated.
- Changeset (patch) for `@vitessce/config` and `@vitessce/zarr-utils`.


#### Checklist

 - [x] Have tested PR with one or more demo configurations
 - [x] Documentation added, updated, or not applicable
