### PR TITLE
NickAkhmetov/Update and optimize GitHub Actions workflows

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,14 @@
+# Keeps GitHub Actions pinned versions from silently going stale.
+# Dependabot rewrites both the commit SHA and the trailing "# vX.Y.Z" comment
+# on the pinned entries in release.yml.
+version: 2
+updates:
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: weekly
+    groups:
+      # One pull request for all action bumps instead of one per action.
+      actions:
+        patterns:
+          - '*'

--- a/.github/workflows/bundle-size.yml
+++ b/.github/workflows/bundle-size.yml
@@ -3,22 +3,38 @@ name: Bundle size
 
 on: [ pull_request ]
 
+# Supersede in-flight runs for the same pull request.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
 jobs:
   build:
 
     runs-on: ubuntu-latest
 
+    timeout-minutes: 45
+
+    permissions:
+      # Needed for the action to leave the size comparison comment.
+      contents: read
+      pull-requests: write
+
     steps:
-      - uses: actions/checkout@v4
-      - uses: pnpm/action-setup@v4
+      - uses: actions/checkout@v7
+      - uses: pnpm/action-setup@v6
         name: Install pnpm
         id: pnpm-install
         with:
           run_install: true
+          cache: true
       - id: get-options
         run: . ./scripts/set-node-options.sh --action
         shell: bash
-      - uses: preactjs/compressed-size-action@2.6.0
+      - uses: preactjs/compressed-size-action@2.10.0
         with:
           minimum-change-threshold: 1000
           compression: "none"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -13,6 +13,7 @@ jobs:
   release:
     runs-on: ubuntu-latest
     name: Deploy
+    timeout-minutes: 90
     permissions:
       # Need "write" to interact with GitHub's OIDC Token endpoint.
       id-token: write
@@ -20,22 +21,23 @@ jobs:
       contents: write
       pull-requests: write
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           # Reference: https://github.com/changesets/changesets/issues/517#issuecomment-1182094769
           ref: ${{ github.event.pull_request.head.sha }}
           fetch-depth: 0
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
           node-version: 24.15.0
           registry-url: https://registry.npmjs.org/
       # npm 11.5.1 or later is required for OIDC publishingso update to latest to be sure
       - run: npm install -g npm@latest
-      - uses: pnpm/action-setup@v4
+      - uses: pnpm/action-setup@ea17c68df8912ef543352723c149a84f56e3d413 # v6.1.0
         name: Install pnpm
         id: pnpm-install
         with:
           run_install: true
+          cache: true
       - id: get-options
         run: . ./scripts/set-node-options.sh --action
         shell: bash
@@ -46,7 +48,11 @@ jobs:
       - name: Create release pull request or Publish to NPM
         if: github.repository == 'vitessce/vitessce'
         id: changesets
-        uses: changesets/action@v1
+        uses: changesets/action@a45c4d594aa4e2c509dc14a9f2b3b67ba3780d0d # v1.9.0
+        # Pinned to v1 on purpose: changesets/action@v2 requires @changesets/cli v3
+        # and refuses to run against the v2 CLI this repo uses. Upgrading the action
+        # means bumping @changesets/cli to v3 first, plus the v2 input renames
+        # (version -> version-script, publish -> publish-script, title -> pr-title).
         with:
           title: Create release
           # this expects you to have a npm script called changeset-version that runs some logic and then calls `changeset version`.
@@ -69,7 +75,7 @@ jobs:
           echo "- [Demo]($VERSIONED_DEMO_URL)" >> RELEASE_NOTES.md
       - name: Create GitHub release if publish was successful
         if: steps.changesets.outputs.should-release == 'true'
-        uses: softprops/action-gh-release@v2
+        uses: softprops/action-gh-release@efb35369e0ad2afab669f228072c1b0d510eae64 # v3.0.3
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           tag_name: ${{ steps.get-tag.outputs.tag }}
@@ -84,7 +90,7 @@ jobs:
         run: pnpm run sync-cdn
       - name: Configure AWS credentials
         if: steps.changesets.outputs.should-release == 'true'
-        uses: aws-actions/configure-aws-credentials@v4
+        uses: aws-actions/configure-aws-credentials@cbe3b392738ccf3f987d68400dafcf4b0624a56c # v6.2.4
         with:
           role-to-assume: ${{ secrets.AWS_IAM_ROLE }}
           aws-region: us-east-1
@@ -111,5 +117,3 @@ jobs:
           aws cloudfront create-invalidation --distribution-id ${{ secrets.DEMO_CF_DISTRIBUTION_ID }} --paths "/*"
           aws cloudfront create-invalidation --distribution-id ${{ secrets.APP_CF_DISTRIBUTION_ID }} --paths "/*"
           aws cloudfront create-invalidation --distribution-id ${{ secrets.CDN_CF_DISTRIBUTION_ID }} --paths "/*"
-            
-            

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -8,34 +8,82 @@ on:
     - '**/*.md'
   pull_request:
 
+# Supersede in-flight runs for the same ref, so rapid pushes to a pull request
+# do not leave a queue of obsolete runs occupying runners.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
 jobs:
+  # Builds the workspace once and shares the output with the end-to-end jobs,
+  # which previously each repeated the same serialized `build:ci`.
+  build:
+    name: Build (shared)
+    runs-on: ubuntu-latest
+    timeout-minutes: 45
+    steps:
+      - uses: actions/checkout@v7
+      - uses: pnpm/action-setup@v6
+        name: Install pnpm
+        id: pnpm-install
+        with:
+          run_install: true
+          cache: true
+      - id: get-options
+        run: . ./scripts/set-node-options.sh --action
+        shell: bash
+      - run: pnpm run build:ci
+        env:
+          NODE_OPTIONS: ${{ steps.get-options.outputs.node-options }}
+      # The build output is ~3200 files across ~60 packages, which uploads much
+      # faster as a single entry. The tar is left uncompressed so that
+      # upload-artifact's own zip is the only compression pass.
+      - name: Pack build output
+        run: >
+          find packages examples -name node_modules -prune -o
+          \( -name dist -o -name dist-tsc \) -type d -print0 -prune
+          | tar -cf dist.tar --null -T -
+      - uses: actions/upload-artifact@v7
+        with:
+          name: build-dist
+          path: dist.tar
+          retention-days: 1
+
   test-unit:
     runs-on: ${{ matrix.os }}
-    
+
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-latest, windows-2022]
-    
+        os: [ubuntu-latest, windows-latest]
+
     name: Test on ${{ matrix.os }}
+
+    timeout-minutes: 45
 
     permissions:
       # Permissions required for the vitest-coverage-report action
       # to be able to leave a comment on the pull request
       contents: read
       pull-requests: write
-    
+
+    # Deliberately builds its own copy rather than reusing the shared artifact:
+    # this job exists to prove the build itself works on each OS.
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
         with:
           # Reference: https://github.com/changesets/changesets/issues/517#issuecomment-1182094769
           ref: ${{ github.event.pull_request.head.sha }}
           fetch-depth: 0
-      - uses: pnpm/action-setup@v4
+      - uses: pnpm/action-setup@v6
         name: Install pnpm
         id: pnpm-install
         with:
           run_install: true
+          cache: true
       - run: pnpm run changeset-status
       - id: get-options
         run: . ./scripts/set-node-options.sh --action
@@ -45,6 +93,10 @@ jobs:
           NODE_OPTIONS: ${{ steps.get-options.outputs.node-options }}
       - run: ./scripts/test.sh --action
         shell: bash
+        env:
+          # ESLint results do not vary by OS, so only lint on one matrix leg
+          # (Windows runner minutes bill at a higher rate than Linux).
+          SKIP_LINT: ${{ matrix.os == 'ubuntu-latest' && '' || '1' }}
       - run: pnpm run bundle:ci
       - run: pnpm run publint
       - name: Report coverage
@@ -54,31 +106,34 @@ jobs:
         if: ${{ matrix.os == 'ubuntu-latest' && always() }}
         uses: davelosert/vitest-coverage-report-action@v2
 
-  
   test-e2e-demo:
     runs-on: ubuntu-latest
+    timeout-minutes: 30
+    needs: build
     steps:
-      - uses: actions/checkout@v4
-      - uses: pnpm/action-setup@v4
+      - uses: actions/checkout@v7
+      - uses: pnpm/action-setup@v6
         name: Install pnpm
         id: pnpm-install
         with:
           run_install: true
+          cache: true
+      - uses: actions/download-artifact@v8
+        with:
+          name: build-dist
+      - run: tar -xf dist.tar
       - id: get-options
         run: . ./scripts/set-node-options.sh --action
         shell: bash
-      - run: |
-          pnpm run build:ci
-          cd ./sites/demo
-          pnpm run build-demo
+      - run: pnpm -C ./sites/demo run build-demo
         env:
           NODE_OPTIONS: ${{ steps.get-options.outputs.node-options }}
 
       - name: Cypress PNPM Patch
         run: cp pnpm-lock.yaml ./sites/demo/package-lock.json
-      
+
       - name: Cypress
-        uses: cypress-io/github-action@v4
+        uses: cypress-io/github-action@v7
         env:
           DEBUG: '@cypress/github-action'
         with:
@@ -89,29 +144,36 @@ jobs:
           wait-on-timeout: 240
           browser: chrome
           headed: false
-  
+
   test-e2e-html:
     runs-on: ubuntu-latest
+    timeout-minutes: 30
+    needs: build
     steps:
-      - uses: actions/checkout@v4
-      - uses: pnpm/action-setup@v4
+      - uses: actions/checkout@v7
+      - uses: pnpm/action-setup@v6
         name: Install pnpm
         id: pnpm-install
         with:
           run_install: true
+          cache: true
+      - uses: actions/download-artifact@v8
+        with:
+          name: build-dist
+      - run: tar -xf dist.tar
       - id: get-options
         run: . ./scripts/set-node-options.sh --action
         shell: bash
-      - run: pnpm run build:ci && pnpm run bundle:ci
+      - run: pnpm run bundle:ci
         env:
           NODE_OPTIONS: ${{ steps.get-options.outputs.node-options }}
       - run: ./scripts/consumer-install.sh
         shell: bash
       - name: Cypress PNPM Patch
         run: cp pnpm-lock.yaml ./sites/html/package-lock.json
-      
+
       - name: Cypress
-        uses: cypress-io/github-action@v4
+        uses: cypress-io/github-action@v7
         env:
           DEBUG: '@cypress/github-action'
         with:
@@ -125,23 +187,39 @@ jobs:
 
   test-e2e-playwright:
     # because we take the golden screenshots on macOS locally
+    # (the snapshots in auto-init-coordination/ are *-chromium-darwin.png)
     runs-on: macos-latest
+    timeout-minutes: 30
+    needs: build
     steps:
-      - uses: actions/checkout@v4
-      - uses: pnpm/action-setup@v4
+      - uses: actions/checkout@v7
+      - uses: pnpm/action-setup@v6
         name: Install pnpm
         id: pnpm-install
         with:
           run_install: true
+          cache: true
+      - uses: actions/cache@v6
+        id: playwright-cache
+        with:
+          path: ${{ runner.os == 'macOS' && '~/Library/Caches/ms-playwright' || '~/.cache/ms-playwright' }}
+          key: ${{ runner.os }}-playwright-${{ hashFiles('pnpm-lock.yaml') }}
       - name: Install Playwright Browsers
+        if: steps.playwright-cache.outputs.cache-hit != 'true'
         run: pnpm exec playwright install --with-deps
+      - name: Install Playwright system dependencies
+        # The browser binaries are cached, but the OS-level libraries they link
+        # against are not part of that cache and must be installed every run.
+        if: steps.playwright-cache.outputs.cache-hit == 'true'
+        run: pnpm exec playwright install-deps
+      - uses: actions/download-artifact@v8
+        with:
+          name: build-dist
+      - run: tar -xf dist.tar
       - id: get-options
         run: . ./scripts/set-node-options.sh --action
         shell: bash
-      - run: |
-          pnpm run build:ci
-          cd ./sites/demo
-          pnpm run build-demo
+      - run: pnpm -C ./sites/demo run build-demo
         env:
           NODE_OPTIONS: ${{ steps.get-options.outputs.node-options }}
       - name: Playwright
@@ -152,39 +230,66 @@ jobs:
   # (non-3D views, 3D spatial views, graceful degradation).
   test-e2e-playwright-react-19:
     runs-on: ubuntu-latest
+    timeout-minutes: 30
+    needs: build
     steps:
-      - uses: actions/checkout@v4
-      - uses: pnpm/action-setup@v4
+      - uses: actions/checkout@v7
+      - uses: pnpm/action-setup@v6
         name: Install pnpm
         id: pnpm-install
         with:
           run_install: true
+          cache: true
+      - uses: actions/cache@v6
+        id: playwright-cache
+        with:
+          path: ${{ runner.os == 'macOS' && '~/Library/Caches/ms-playwright' || '~/.cache/ms-playwright' }}
+          key: ${{ runner.os }}-playwright-${{ hashFiles('pnpm-lock.yaml') }}
       - name: Install Playwright Browsers
+        if: steps.playwright-cache.outputs.cache-hit != 'true'
         run: pnpm exec playwright install --with-deps
+      - name: Install Playwright system dependencies
+        if: steps.playwright-cache.outputs.cache-hit == 'true'
+        run: pnpm exec playwright install-deps
+      - uses: actions/download-artifact@v8
+        with:
+          name: build-dist
+      - run: tar -xf dist.tar
       - id: get-options
         run: . ./scripts/set-node-options.sh --action
         shell: bash
-      - run: |
-          pnpm run build:ci
-          cd ./sites/demo
-          pnpm run build-demo
+      - run: pnpm -C ./sites/demo run build-demo
         env:
           NODE_OPTIONS: ${{ steps.get-options.outputs.node-options }}
       - name: Playwright (React 19)
         run: pnpm exec playwright test react-19/
 
   test-e2e-playwright-for-create-view-cli:
-    # because we take the golden screenshots on macOS locally
-    runs-on: macos-latest
+    # Runs on Linux: the create-view specs make no screenshot comparisons, so
+    # unlike auto-init-coordination they do not need the macOS golden images.
+    runs-on: ubuntu-latest
+    timeout-minutes: 45
+    # No `needs: build` — the create-view CLI scaffolds a new package first, so
+    # this job has to build the modified workspace rather than the shared output.
     steps:
-      - uses: actions/checkout@v4
-      - uses: pnpm/action-setup@v4
+      - uses: actions/checkout@v7
+      - uses: pnpm/action-setup@v6
         name: Install pnpm
         id: pnpm-install
         with:
           run_install: true
+          cache: true
+      - uses: actions/cache@v6
+        id: playwright-cache
+        with:
+          path: ${{ runner.os == 'macOS' && '~/Library/Caches/ms-playwright' || '~/.cache/ms-playwright' }}
+          key: ${{ runner.os }}-playwright-${{ hashFiles('pnpm-lock.yaml') }}
       - name: Install Playwright Browsers
+        if: steps.playwright-cache.outputs.cache-hit != 'true'
         run: pnpm exec playwright install --with-deps
+      - name: Install Playwright system dependencies
+        if: steps.playwright-cache.outputs.cache-hit == 'true'
+        run: pnpm exec playwright install-deps
       - id: get-options
         run: . ./scripts/set-node-options.sh --action
         shell: bash

--- a/scripts/test.sh
+++ b/scripts/test.sh
@@ -4,7 +4,11 @@ set -o errexit
 die() { echo "$*" 1>&2 ; exit 1; }
 
 # linting
-pnpm run lint || die 'eslint failed; try: pnpm run lint-fix'
+# ESLint results do not vary by OS, so CI sets SKIP_LINT=1 on all but one
+# matrix leg rather than paying for the same lint run on every platform.
+if [[ -z "$SKIP_LINT" ]]; then
+  pnpm run lint || die 'eslint failed; try: pnpm run lint-fix'
+fi
 # end linting
 
 # unit tests


### PR DESCRIPTION
#### Background

The GitHub Actions workflows had drifted well behind upstream: every action in use was at least one major version old (`actions/checkout@v4` against v7, `cypress-io/github-action@v4` against v7, and so on), and nothing was watching for that, so the drift would have keptaccumulating.

Auditing the workflows to fix the versions surfaced several cost and reliability problems alongside the stale pins:

- **No dependency caching anywhere.** All nine job-runs per pull request did a cold `pnpm install` of the full monorepo. `pnpm/action-setup` only gained a `cache` input in v5, so the version drift was what blocked the fix.
- **`build:ci` ran eight times per pull request.** It is `pnpm -r --workspace-concurrency 1 build`, deliberately serialized to stay inside the memory ceiling described in `scripts/set-node-options.sh`, and six jobs rebuilt identical output from the same commit.
- **A macOS runner doing nothing that needed macOS.** `test-e2e-playwright-for-create-view-cli` ran on `macos-latest` under a comment about golden screenshots, but `sites/demo/playwright/create-view/` contains no `toHaveScreenshot` call and no snapshot directory. Only `auto-init-coordination/` has goldens, and those are `*-chromium-darwin.png`. macOS runner minutes bill at 10x Linux.
- **No `concurrency` groups.** Three quick pushes to a branch meant 24 job-runs with 21 of them obsolete and none cancelled.
- **No `timeout-minutes` on any job**, so a hung Cypress or Playwright run could hold a runner for the 360-minute default.
- **Playwright browsers re-downloaded on every run**, three times per pull request.
- **ESLint running twice per pull request**, including on the Windows leg where results cannot differ and minutes cost double.

`release.yml` is also the workflow that publishes to NPM via OIDC, and it referenced every action by mutable tag. A compromised tag on any one of them is an NPM supply-chain compromise.

#### Change List

**Action versions**

- Upgraded across all three workflows: `actions/checkout` v4 → v7, `actions/setup-node` v4 → v7, `pnpm/action-setup` v4 → v6, `cypress-io/github-action` v4 → v7, `preactjs/compressed-size-action` 2.6.0 → 2.10.0, `softprops/action-gh-release` v2 → v3, `aws-actions/configure-aws-credentials` v4 → v6.
- Added `actions/upload-artifact@v7`, `actions/download-artifact@v8`, and `actions/cache@v6`.
- **`changesets/action` deliberately stays on v1**, now pinned to v1.9.0. v2 requires `@changesets/cli` v3 and validates the CLI version at runtime, refusing to run against the v2 CLI this repo uses (2.26.1). Upgrading it requires bumping `@changesets/cli` to v3 first, plus the v2 input renames (`version` → `version-script`, `publish` → `publish-script`, `title` → `pr-title`) and setting `create-github-releases: false` so it does not duplicate the existing `softprops/action-gh-release` step. That belongs in its own pull request; the blocker is recorded in a comment above the pin.

**Caching**

- `cache: true` on every `pnpm/action-setup@v6` invocation, keyed on `pnpm-lock.yaml`.
- Playwright browser binaries cached via `actions/cache@v6` with an OS-aware path (`~/Library/Caches/ms-playwright` on macOS, `~/.cache/ms-playwright` on Linux), keyed on `pnpm-lock.yaml`. On a cache hit the job runs `playwright install-deps` rather than `install --with-deps`, because the OS-level libraries the browsers link against are not part of that cache and still have to be installed each run.

**Shared build**

- New `build` job runs `build:ci` once, tars the `dist` and `dist-tsc` trees across `packages/` and `examples/`, and uploads them as a single artifact with `retention-days: 1`. Measured locally: 107 directories, ~3200 files, 326 MB, compressing to roughly 73 MB. Packed as one entry because several thousand individual files upload far more slowly, and left uncompressed so that `upload-artifact`'s own zip is the only compression pass.
- `test-e2e-demo`, `test-e2e-html`, `test-e2e-playwright`, and `test-e2e-playwright-react-19` now declare `needs: build` and unpack that artifact instead of rebuilding.
- Two jobs intentionally still build their own copy, commented in place: `test-unit`, whose purpose is to prove the build works on each OS, and `test-e2e-playwright-for-create-view-cli`, which scaffolds a new package with the create-view CLI before building and therefore needs the modified workspace rather than the shared output.

**Cost and reliability**

- `concurrency` with `cancel-in-progress` on `test.yml` and `bundle-size.yml`. Not added to `release.yml`, where cancelling mid-publish would be harmful.
- `test-e2e-playwright-for-create-view-cli` moved from `macos-latest` to `ubuntu-latest`. The comment on `test-e2e-playwright` now records why that job is the one that genuinely needs macOS.
- `timeout-minutes` on every job (30 for the e2e jobs, 45 for builds, 90 for release).
- `windows-2022` replaced with `windows-latest`; the hard pin was holding the matrix on an image heading for deprecation.
- ESLint now runs on one matrix leg only. `scripts/test.sh` gained a `SKIP_LINT` guard, which `test.yml` sets on the Windows leg.

**Security**

- Every action in `release.yml` pinned to a full commit SHA with a trailing `# vX.Y.Z` comment, so the publishing path cannot be changed by moving a tag.
- Explicit `permissions: contents: read` at the top of `test.yml` and `bundle-size.yml`, with `pull-requests: write` granted only to the two jobs that post comments.

**Maintenance**

- Added `.github/dependabot.yml` with a weekly `github-actions` update schedule, grouped into a single pull request. Dependabot rewrites both the SHA and the version comment on the pinned entries, so this is what stops the drift from recurring.

**Notes for review**

- Node version is still unpinned in `test.yml` and `bundle-size.yml` — only `release.yml` pins 24.15.0, so CI tests on whatever the runner image ships. Left unchanged here to avoid folding a behavior change into an infrastructure pull request, but worth a follow-up.
- The checkout / pnpm-setup / cache block is now repeated across eight jobs. A composite action under `.github/actions/` would collapse it; deferred to keep this diff reviewable.

#### Checklist
 - [ ] Have tested PR with one or more demo configurations
 - [x] Documentation added, updated, or not applicable